### PR TITLE
Update CMake scripts to post-3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,50 +1,63 @@
-cmake_minimum_required(VERSION 2.8.12)
-project (ipr)
-set (ipr_VERSION_MAJOR 0)
-set (ipr_VERSION_MINOR 47)
+cmake_minimum_required(
+   VERSION 3.5 # Ubuntu 16.04 LTS
+)
 
-# Hey, we are building C++ for C++.
-enable_language(CXX)
+project(ipr
+   VERSION 0.47
+   LANGUAGES CXX
+)
 
-# Microsoft's Visual C++ still does not support alternative keywords! :-/
-# Also, set the appropriate exception handling flavor.
-if (WIN32)
-   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /FIiso646.h")
-   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc")
-endif()
+add_library(${PROJECT_NAME}
+   src/interface.cxx
+   src/impl.cxx
+   src/io.cxx
+   src/traversal.cxx
+   src/utility.cxx
+)
 
-# On UNIX systems, we do want the ability to process large files.
-if (UNIX)
-   add_definitions(-D_FILE_OFFSET_BITS=64)
-endif()
+target_include_directories(${PROJECT_NAME}
+   PUBLIC
+      ${PROJECT_SOURCE_DIR}/include
+)
 
-# We really want to use C++14 (bug fix over C++11).
-# When the booting compiler is g++ or clang, use -std= flag.
-# Approximate that with UNIX platforms for now.
-if (UNIX)
-   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -O2 -Wall")
-endif()
+set_target_properties(${PROJECT_NAME}
+   PROPERTIES
+      CXX_STANDARD 14
+      CXX_STANDARD_REQUIRED ON
+	  CXX_EXTENSIONS OFF
+)
+				
+target_compile_options(${PROJECT_NAME}
+   PRIVATE
+      $<$<CXX_COMPILER_ID:MSVC>:
+         /W4           # Highest sensible warning level
+         /permissive-  # Turn on strict language conformance
+         /EHsc         # Turn on exception handling semantics
+         /FIiso646.h   # MSVC still does not support alternative keywords! :-/
+      >
+      $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:
+         -Wall         # Turn on all warnings
+         -Wextra       # Turn on even more warnings
+         -pedantic     # Turn on strict language conformance
+      >
+      $<$<CXX_COMPILER_ID:Clang>:
+		 -Wno-overloaded-virtual  # Too many false positives
+      >
+)
 
-# Clang can sometimes be overly anal-rententive vis-a-vis good programming idioms :-(
-if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-overloaded-virtual")
-endif()
+target_compile_definitions(${PROJECT_NAME}
+   PRIVATE
+	  $<$<PLATFORM_ID:UNIX>:
+		 _FILE_OFFSET_BITS=64 # We want the ability to process large files.
+	  >
+)
 
-# Set up search paths for source header files.
-include_directories ("${PROJECT_SOURCE_DIR}/include")
-
-# The final IPR library
-add_library(ipr STATIC
-		src/interface.cxx
-		src/impl.cxx
-		src/io.cxx
-		src/traversal.cxx
-		src/utility.cxx)
-
-
-## Installation time, folks.
-install(TARGETS ipr
-	LIBRARY DESTINATION lib
-	ARCHIVE DESTINATION lib)
-install(DIRECTORY include/ipr DESTINATION include)
-
+install(
+   TARGETS ipr
+   LIBRARY DESTINATION lib
+   ARCHIVE DESTINATION lib
+)
+install(
+   DIRECTORY include/ipr
+   DESTINATION include
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,8 @@ target_compile_options(${PROJECT_NAME}
          -pedantic     # Turn on strict language conformance
       >
       $<$<CXX_COMPILER_ID:Clang>:
-		 -Wno-overloaded-virtual  # Too many false positives
+		 -Wno-overloaded-virtual                   # Too many false positives
+		 -Wno-delete-non-abstract-non-virtual-dtor # System headers plagued
       >
 )
 

--- a/src/interface.cxx
+++ b/src/interface.cxx
@@ -33,4 +33,4 @@ namespace ipr {
       // FIXME: Implement checking of "c".
       ++stats::node_usage_counts[c];
    }
-};
+}

--- a/src/io.cxx
+++ b/src/io.cxx
@@ -638,7 +638,7 @@ namespace ipr
                << xpr_cast_expr(e.storage());
          }
       };
-   };
+   }
 
    static Printer& operator<<(Printer&, xpr_cast_expr);
    
@@ -1688,7 +1688,7 @@ namespace ipr
             pp << xpr_decl(d, true);
          }
       };
-   };
+   }
 
    Printer&
    operator<<(Printer& printer, xpr_stmt x)


### PR DESCRIPTION
I took the liberty and enrolled the CMake build scripts into my "pimp your CMake" customer care program. They were updated to the brave "new" post-3.0 era. I set the minimum to 3.5 (might work under it, let me know if it's an issue, two Ubuntu LTS releases back is "old enough" for a practical stand point).

Some notes about the update:
- I tried to stick to a sleek, modern indentation style for readability
- The script is 100% declarative, as per modern guidelines
- Generator expresions are used when compiler or platform specific behavior is requested
- I turned the warning level as high up as possible and selectively turned off noisy warnings. Let me know if selective turn offs cause new warning in older versions (where the switch does not exist yet) and I'll put them behind version check genexprs.
- A few warnings still remain in the codde that are actual potential source of bugs or the result of "sloppy" API design.

One such example is `include/ipr/impl:81`
```c++
int size() const final { return Rep::size(); }
```

A size is always unsigned, if the API decides that sizes are `int`s, it would be better if it self-contained this decision and not implicitly cast on the API surface (or anywhere, for that matter). There are also a few `__int64` to `int` casts with MSVC, but only 4 in total.

Clang only has a single instance of `warning: private field 'region' is not used [-Wunused-private-field]` in `include/ipr/impl:1598`

```c++
const ipr::Region& region;
```

But that may be a false positive, I am not confident enough with the codebase to tell for sure.

GCC 7 builds cleanly.