### PR TITLE
Fix missing Rvalue_Reference in io causing crash.

### DIFF
--- a/src/io.cxx
+++ b/src/io.cxx
@@ -1436,6 +1436,9 @@ namespace ipr
       void visit(const Reference& t) override
       { pp << xpr_type_expr(t); }
 
+      void visit(const Rvalue_reference& t) override
+      { pp << xpr_type_expr(t); }
+
       void visit(const Template& t) override
       { pp << xpr_type_expr(t); }
 


### PR DESCRIPTION
Simple fix for issue #25