### PR TITLE
Fixed build error from ipr::String selecting scalar compare overload.

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -192,7 +192,8 @@ namespace ipr {
       // identifier at its creation and retain it unchanged till the
       // end of the program.)  An obvious benefit is that ordering comes
       // for free.
-      template<typename T>
+      template<typename T,
+          typename std::enable_if_t<std::is_scalar_v<T>, int> = 0>
       constexpr int compare(T lhs, T rhs)
       {
          return lhs < rhs ? -1 : (lhs > rhs ? 1 : 0);


### PR DESCRIPTION
I fail to build the IPR library with the latest MSVC compiler due to build trying to select the templated overload for ipr::String. This results in a "cannot instantiate abstract class" because the parameter is passed by value.

This PR resolves that issue but please chime in on whether it is the right fix or whether it should be needed at all.

```
1>E:\src\ipr\src\impl.cxx(875,13): error C2259: 'ipr::String': cannot instantiate abstract class
1>E:\src\ipr\include\ipr/interface(608): message : see declaration of 'ipr::String'
1>E:\src\ipr\src\impl.cxx(875,13): message : due to following members:
1>E:\src\ipr\src\impl.cxx(875,13): message : 'void ipr::Node::accept(ipr::Visitor &) const': is abstract
1>E:\src\ipr\include\ipr/interface(598): message : see declaration of 'ipr::Node::accept'
1>E:\src\ipr\src\impl.cxx(875,13): message : 'int ipr::String::size(void) const': is abstract
1>E:\src\ipr\include\ipr/interface(610): message : see declaration of 'ipr::String::size'
1>E:\src\ipr\src\impl.cxx(875,13): message : 'ipr::String::iterator ipr::String::begin(void) const': is abstract
1>E:\src\ipr\include\ipr/interface(611): message : see declaration of 'ipr::String::begin'
1>E:\src\ipr\src\impl.cxx(875,13): message : 'ipr::String::iterator ipr::String::end(void) const': is abstract
1>E:\src\ipr\include\ipr/interface(612): message : see declaration of 'ipr::String::end'
1>E:\src\ipr\src\impl.cxx(880,13): error C2259: 'ipr::String': cannot instantiate abstract class
1>E:\src\ipr\include\ipr/interface(608): message : see declaration of 'ipr::String'
1>E:\src\ipr\src\impl.cxx(880,13): message : due to following members:
1>E:\src\ipr\src\impl.cxx(880,13): message : 'void ipr::Node::accept(ipr::Visitor &) const': is abstract
1>E:\src\ipr\include\ipr/interface(598): message : see declaration of 'ipr::Node::accept'
1>E:\src\ipr\src\impl.cxx(880,13): message : 'int ipr::String::size(void) const': is abstract
1>E:\src\ipr\include\ipr/interface(610): message : see declaration of 'ipr::String::size'
1>E:\src\ipr\src\impl.cxx(880,13): message : 'ipr::String::iterator ipr::String::begin(void) const': is abstract
1>E:\src\ipr\include\ipr/interface(611): message : see declaration of 'ipr::String::begin'
1>E:\src\ipr\src\impl.cxx(880,13): message : 'ipr::String::iterator ipr::String::end(void) const': is abstract
1>E:\src\ipr\include\ipr/interface(612): message : see declaration of 'ipr::String::end'
```