### PR TITLE
Named_map pointer in impl should be const

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -752,7 +752,7 @@ namespace ipr {
       template<class D>
       struct Decl : Stmt<Node<D>> {
          basic_decl_data<D> decl_data;
-         ipr::Named_map* pat = { };
+         const ipr::Named_map* pat = { };
          val_sequence<ipr::Substitution> args;
 
          Decl() : decl_data{ nullptr } { }
@@ -793,7 +793,7 @@ namespace ipr {
          ipr::DeclSpecifiers spec;
          const ipr::Linkage* langlinkage;
          singleton_overload overload;
-         ipr::Named_map* pat;
+         const ipr::Named_map* pat;
          val_sequence<ipr::Substitution> args;
 
          unique_decl() : spec(ipr::DeclSpecifiers::None),


### PR DESCRIPTION
Pointers to ipr nodes need to be const as everything at the interface level is const&. This bug is likely a simple typo.

These appear to be the only instances of this problem that I can find.