### PR TITLE
Improvements to CI

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,27 @@
+name: Ubuntu-Docs
+
+on:
+  push:
+    paths:
+      - 'doc/**'
+    branches: [ master ]
+  pull_request:
+    paths:
+      - 'doc/**'
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install GCC, CMake
+      run: sudo apt-get install build-essential cmake texlive texlive-latex-extra
+
+    - name: Configure CMake
+      run: mkdir build && cmake -Bbuild -DBUILD_DOC=ON
+
+    - name: Build project
+      run: make -C build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,8 +2,12 @@ name: Ubuntu-Build
 
 on:
   push:
+    paths-ignore:
+      - 'doc/**'
     branches: [ master ]
   pull_request:
+    paths-ignore:
+      - 'doc/**'
     branches: [ master ]
 
 jobs:


### PR DESCRIPTION
Installing latex on ubuntu takes a bit more time, it is not included in the default job.
After this patch, when there are changes to the doc folder, a separate CI job will build the latex files as well.