### PR TITLE
Add mac builder.

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -1,0 +1,24 @@
+name: Mac-Build
+
+on:
+  push:
+    paths-ignore:
+      - 'doc/**'
+    branches: [ master ]
+  pull_request:
+    paths-ignore:
+      - 'doc/**'
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Configure CMake
+      run: mkdir build && cmake -Bbuild
+
+    - name: Build project
+      run: make -C build


### PR DESCRIPTION
 I do not know what are the requirements of this project in terms of platform support. 
This patch adds a mac builder to the CI, and it picks up Clang as a compiler.
Feel free to just close it if macs are not supported.