### PR TITLE
Doc builder only builds doc target

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -24,4 +24,4 @@ jobs:
       run: mkdir build && cmake -Bbuild -DBUILD_DOC=ON
 
     - name: Build project
-      run: make -C build
+      run: make -C build doc


### PR DESCRIPTION
The other builder will always trigger if there is a non-doc change, so this can help to avoid redundant work. 