### PR TITLE
Id_expr does not belong to Name hierarchy

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -1108,11 +1108,11 @@ namespace ipr {
       using Identifier = Unary_expr<ipr::Identifier>;
 
       struct Id_expr : Unary_expr<ipr::Id_expr> {
-         const ipr::Decl* decl;
+         const ipr::Expr* decls = nullptr;
 
          explicit Id_expr(const ipr::Name&);
          const ipr::Type& type() const final;
-         const ipr::Decl& resolution() const final;
+         Optional<ipr::Expr> resolution() const final;
       };
 
       using Not = Classic_unary_expr<ipr::Not>;

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -1190,9 +1190,14 @@ namespace ipr {
 
                                 // -- Id_expr --
    // This node represents use of a name to designate an entity.
-   // FIXME: Explain how useful this is and when it is used.
-   struct Id_expr : Unary<Category<id_expr_cat, Name>, const Name&> {
-      virtual const Decl& resolution() const = 0;
+   // In general, names are introduced by a declaration.  In a well-formed
+   // fully elaborated program, a use of name refers to exactly one declaration.
+   // However, in a partially elaborated program (e.g. a template definition)
+   // a dependent name may refer to zero, one, or many (overloaded) declarations.
+   struct Id_expr : Unary<Category<id_expr_cat, Expr>, const Name&> {
+      // The set of declarations the name refers to, at the elaboration point.
+      virtual Optional<Expr> resolution() const = 0;
+
       Arg_type name() const { return operand(); }
    };
 

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -1083,17 +1083,17 @@ namespace ipr {
       // -------------
 
       Id_expr::Id_expr(const ipr::Name& n)
-            : impl::Unary<impl::Expr<ipr::Id_expr>>(n), decl(0)
+            : impl::Unary<impl::Expr<ipr::Id_expr>>(n)
       { }
 
       const ipr::Type&
       Id_expr::type() const {
-         return util::check(decl)->type();
+         return *util::check(constraint);
       }
 
-      const ipr::Decl&
+      Optional<ipr::Expr>
       Id_expr::resolution() const {
-         return *util::check(decl);
+         return { decls };
       }
 
 
@@ -1512,7 +1512,7 @@ namespace ipr {
       expr_factory::make_id_expr(const ipr::Decl& d) {
          impl::Id_expr* x = id_exprs.make(d.name());
          x->constraint = &d.type();
-         x->decl = &d;
+         x->decls = &d;
          return x;
       }
 

--- a/src/io.cxx
+++ b/src/io.cxx
@@ -241,7 +241,7 @@ namespace ipr
 
    namespace xpr {
       struct Name : pp_base {
-         Name(Printer& p, const ipr::Decl* d = 0) : pp_base(p), decl(d) { }
+         explicit Name(Printer& p) : pp_base(p) { }
          
          void visit(const Identifier& id) override
          {
@@ -337,23 +337,19 @@ namespace ipr
                << rn.position()
                << token(')');
          }
-         
-         const ipr::Decl* decl;
       };
    }
    
    struct xpr_name {
       const Name& name;
-      const Decl* decl;
-      explicit xpr_name(const Name& n) : name(n), decl(0) { }
-      explicit xpr_name(const Name& n, const Decl& d) : name(n), decl(&d) { }
-      explicit xpr_name(const Decl& d) : name(d.name()), decl(&d) { }
+      explicit xpr_name(const Name& n) : name(n) { }
+      explicit xpr_name(const Decl& d) : name(d.name()) { }
    };
    
    static inline Printer&
    operator<<(Printer& printer, xpr_name x)
    {
-      xpr::Name pp(printer, x.decl);
+      xpr::Name pp { printer };
       x.name.accept(pp);
       return printer;
    }
@@ -370,7 +366,7 @@ namespace ipr
          Primary_expr(Printer& pp) : xpr::Name(pp) { }
          
          void visit(const Label& l) override { xpr::Name::visit(l.name()); }
-         void visit(const Id_expr& id) override { pp << xpr_name(id.name(), id.resolution()); }
+         void visit(const Id_expr& id) override { pp << xpr_name{ id.name() }; }
          void visit(const Literal&) override;
          void visit(const As_type& t) override { pp << xpr_primary_expr(t.expr()); }
          void visit(const Phantom&) override { } // nothing to print


### PR DESCRIPTION
`Id_expr` isn't listed as part of the `Name` sub-hierarchy -- it represents a name used of a name as expression, but it isn't itself a name.

Fixes issue #60 