### PR TITLE
Update the ipr Name sub-hierarchy

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -1962,7 +1962,7 @@ namespace ipr {
       struct stmt_factory : expr_factory {
          impl::Break* make_break();
          impl::Continue* make_continue();
-         impl::Empty_stmt* make_empty_stmt();
+         impl::Empty_stmt* make_empty_stmt(const ipr::Type&);
          impl::Block* make_block(const ipr::Region&, const ipr::Type&);
          impl::Ctor_body* make_ctor_body(const ipr::Expr_list&,
                                          const ipr::Block&);

--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -1107,6 +1107,7 @@ namespace ipr {
       using Typeid = Unary_expr<ipr::Typeid>;
       using Identifier = Unary_expr<ipr::Identifier>;
       using Suffix = Unary_expr<ipr::Suffix>;
+      using Guide_name = Unary_expr<ipr::Guide_name>;
 
       struct Id_expr : Unary_expr<ipr::Id_expr> {
          const ipr::Expr* decls = nullptr;
@@ -1243,6 +1244,8 @@ namespace ipr {
          Operator* make_operator(const char*);
          Operator* make_operator(const std::string&);
 
+         Guide_name* make_guide_name(const ipr::Named_map&);
+
          Address* make_address(const ipr::Expr&);
          Array_delete* make_array_delete(const ipr::Expr&);
          Complement* make_complement(const ipr::Expr&);
@@ -1341,6 +1344,7 @@ namespace ipr {
          util::rb_tree::container<impl::Suffix> suffixes;
          util::rb_tree::container<impl::Literal> lits;
          util::rb_tree::container<impl::Operator> ops;
+         util::rb_tree::container<impl::Guide_name> guide_ids;
          util::rb_tree::container<impl::Rname> rnames;
          util::rb_tree::container<impl::Template_id> template_ids;
          util::rb_tree::container<impl::Type_id> type_ids;

--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -1106,6 +1106,7 @@ namespace ipr {
       using Sizeof = Unary_expr<ipr::Sizeof>;
       using Typeid = Unary_expr<ipr::Typeid>;
       using Identifier = Unary_expr<ipr::Identifier>;
+      using Suffix = Unary_expr<ipr::Suffix>;
 
       struct Id_expr : Unary_expr<ipr::Id_expr> {
          const ipr::Expr* decls = nullptr;
@@ -1235,6 +1236,8 @@ namespace ipr {
          Identifier* make_identifier(const char*);
          Identifier* make_identifier(const std::string&);
 
+         Suffix* make_suffix(const ipr::Identifier&);
+
          // Builds an IPR object for an operator name.
          Operator* make_operator(const ipr::String&);
          Operator* make_operator(const char*);
@@ -1335,10 +1338,11 @@ namespace ipr {
          util::rb_tree::container<impl::Ctor_name> ctors;
          util::rb_tree::container<impl::Dtor_name> dtors;
          util::rb_tree::container<impl::Identifier> ids;
+         util::rb_tree::container<impl::Suffix> suffixes;
          util::rb_tree::container<impl::Literal> lits;
          util::rb_tree::container<impl::Operator> ops;
          util::rb_tree::container<impl::Rname> rnames;
-         util::rb_tree::container<Template_id> template_ids;
+         util::rb_tree::container<impl::Template_id> template_ids;
          util::rb_tree::container<impl::Type_id> type_ids;
          util::rb_tree::container<impl::Sizeof> sizeofs;
          util::rb_tree::container<impl::Typeid> xtypeids;
@@ -2035,6 +2039,8 @@ namespace ipr {
          const ipr::Identifier& get_identifier(const char*);
          const ipr::Identifier& get_identifier(const std::string&);
          const ipr::Identifier& get_identifier(const ipr::String&);
+
+         const ipr::Suffix& get_suffix(const ipr::Identifier&);
          
          const ipr::Operator& get_operator(const char*);
          const ipr::Operator& get_operator(const std::string&);

--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -1191,7 +1191,7 @@ namespace ipr {
       using Reinterpret_cast = Conversion_expr<ipr::Reinterpret_cast>;
       using Rshift = Classic_binary_expr<ipr::Rshift>;
       using Rshift_assign = Classic_binary_expr<ipr::Rshift_assign>;
-      using Scope_ref = Binary_expr<ipr::Scope_ref>;
+      using Scope_ref = Classic_binary_expr<ipr::Scope_ref>;
       using Static_cast = Conversion_expr<ipr::Static_cast>;
       using Template_id = Binary_expr<ipr::Template_id>;
 
@@ -1338,7 +1338,6 @@ namespace ipr {
          util::rb_tree::container<impl::Literal> lits;
          util::rb_tree::container<impl::Operator> ops;
          util::rb_tree::container<impl::Rname> rnames;
-         util::rb_tree::container<impl::Scope_ref> scope_refs;
          util::rb_tree::container<Template_id> template_ids;
          util::rb_tree::container<impl::Type_id> type_ids;
          util::rb_tree::container<impl::Sizeof> sizeofs;
@@ -1366,6 +1365,7 @@ namespace ipr {
          stable_farm<impl::Unary_plus> unary_pluses;
          stable_farm<impl::Expansion> expansions;
 
+         stable_farm<impl::Scope_ref> scope_refs;
          stable_farm<impl::And> ands;
          stable_farm<impl::Array_ref> array_refs;
          stable_farm<impl::Arrow> arrows;
@@ -2044,9 +2044,6 @@ namespace ipr {
          const ipr::Dtor_name& get_dtor_name(const ipr::Type&);
 
          const ipr::Conversion& get_conversion(const ipr::Type&);
-
-         const ipr::Scope_ref& get_scope_ref(const ipr::Expr&,
-                                             const ipr::Expr&);
 
          const ipr::Template_id& get_template_id(const ipr::Name&,
                                                  const ipr::Expr_list&);

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -105,6 +105,7 @@ namespace ipr {
    struct Type_id;               // C++ type-id                  const int*
    struct Ctor_name;             // constructor name                   T::T
    struct Dtor_name;             // destructor name                   T::~T
+   struct Guide_name;            // deduction guide name
    struct Rname;                 // de Bruijn (index, position),
                                  // find better name
 
@@ -789,6 +790,17 @@ namespace ipr {
    // is a type.
    struct Dtor_name : Unary<Category<dtor_name_cat, Name>, const Type&> {
       Arg_type object_type() const { return operand(); }
+   };
+                                // -- Guide_name --
+   // This interface class represents the name of a deduction guide.
+   // Deduction guides do not have names in Standard C++, and they cannot
+   // be found by name lookup.  Yet, they are entities (like templates)
+   // that generate compiler-internal instructions (their initializers)
+   // that when executed yield deduced template arguments.  As such, they
+   // fit the IPR model of a declaration being an introduction of a name
+   // in a scope, with a type and optional initializer.
+   struct Guide_name : Unary<Category<guide_name_cat, Name>, const Named_map&> {
+      Arg_type mapping_decl() const { return operand(); }
    };
 
                                 // -- Rname --
@@ -2042,6 +2054,7 @@ namespace ipr {
       virtual void visit(const Type_id&);
       virtual void visit(const Ctor_name&);
       virtual void visit(const Dtor_name&);
+      virtual void visit(const Guide_name&);
       virtual void visit(const Rname&);
 
       virtual void visit(const Type&) = 0;

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -98,6 +98,7 @@ namespace ipr {
    // -- results of name constructor constants --
    // ------------------------------------------
    struct Identifier;            // identifier                          foo
+   struct Suffix;                // Literal operator suffix       "Plato"sv
    struct Operator;              // C++ operator name             operator+
    struct Conversion;            // conversion function name   operator int
    struct Template_id;           // C++ template-id                  S<int>
@@ -731,6 +732,13 @@ namespace ipr {
    struct Identifier : Unary<Category<identifier_cat, Name>, const String&> {
       // The character sequence of this identifier
       Arg_type string() const { return operand(); }
+   };
+
+                                // -- Suffix --
+   // The suffix of a user-defined literal is essential just an identifier
+   // with a distinguished interpretation.
+   struct Suffix : Unary<Category<suffix_cat, Name>, const Identifier&> {
+      Arg_type name() const { return operand(); }
    };
 
                                 // -- Operator --
@@ -2027,6 +2035,7 @@ namespace ipr {
       
       virtual void visit(const Name&);
       virtual void visit(const Identifier&);
+      virtual void visit(const Suffix&);
       virtual void visit(const Operator&);
       virtual void visit(const Conversion&);
       virtual void visit(const Template_id&);

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -100,7 +100,6 @@ namespace ipr {
    struct Identifier;            // identifier                          foo
    struct Operator;              // C++ operator name             operator+
    struct Conversion;            // conversion function name   operator int
-   struct Scope_ref;             // qualified name                     s::m
    struct Template_id;           // C++ template-id                  S<int>
    struct Type_id;               // C++ type-id                  const int*
    struct Ctor_name;             // constructor name                   T::T
@@ -707,7 +706,6 @@ namespace ipr {
    // i.e. whose meaning depends on binding contexts (Scopes).
    // That definition accounts for the following (in the standard C++ sense)
    //    - unqualified-id                    -- Identifier
-   //    - qualified-id                      -- Scope_ref
    //    - operator-function-id              -- Operator
    //    - conversion-function-id            -- Conversion
    //    - template-id                       -- Template_id
@@ -751,13 +749,6 @@ namespace ipr {
    struct Conversion : Unary<Category<conversion_cat, Name>, const Type&> {
       // The type this conversion-function converts values to.
       Arg_type target() const { return operand(); }
-   };
-
-                                // -- Scope_ref --
-   // A qualified name of the form "scope::member".
-   struct Scope_ref : Binary<Category<scope_ref_cat, Name>> {
-      Arg1_type scope() const  { return first(); }
-      Arg2_type member() const { return second(); }
    };
 
                                 // -- Template_id --
@@ -1186,7 +1177,7 @@ namespace ipr {
 
                                 // -- Typeid --
    // typeid-expression -- "typeid (expr)", or "typeid (int)"
-   struct Typeid : Unary<Category<typeid_cat>> { };
+   struct Typeid : Unary<Category<typeid_cat>> { }; 
 
                                 // -- Id_expr --
    // This node represents use of a name to designate an entity.
@@ -1271,6 +1262,18 @@ namespace ipr {
       // necessary to make it a single indirection.
 
       const Expr& expr() const { return this->second(); }
+   };
+
+                                // -- Scope_ref --
+   // A qualified name of the form "scope::member".
+   // Although the scope resolution operator ('::') in this expression
+   // cannot be overloaded in standard C++ (yet), it is conceptually
+   // dual to the dot operator, for which overloading has been
+   // suggested multiple time with an operational model.  Consequently,
+   // a qualified name is modelled as a classic expression.
+   struct Scope_ref : Binary<Category<scope_ref_cat, Classic>> {
+      Arg1_type scope() const  { return first(); }
+      Arg2_type member() const { return second(); }
    };
 
                                 // -- Plus --
@@ -2026,7 +2029,6 @@ namespace ipr {
       virtual void visit(const Identifier&);
       virtual void visit(const Operator&);
       virtual void visit(const Conversion&);
-      virtual void visit(const Scope_ref&);
       virtual void visit(const Template_id&);
       virtual void visit(const Type_id&);
       virtual void visit(const Ctor_name&);
@@ -2079,6 +2081,7 @@ namespace ipr {
       virtual void visit(const Unary_plus&);
       virtual void visit(const Expansion&);
 
+      virtual void visit(const Scope_ref&);
       virtual void visit(const And&); 
       virtual void visit(const Array_ref&);
       virtual void visit(const Arrow&); 

--- a/include/ipr/node-category
+++ b/include/ipr/node-category
@@ -35,6 +35,7 @@ auto_cat,                               // ipr::Auto
 
 identifier_cat,                         // ipr::Identifier
 operator_cat,                           // ipr::Operator
+suffix_cat,                             // ipr::Suffix
 conversion_cat,                         // ipr::Conversion
 template_id_cat,                        // ipr::Template_id
 type_id_cat,                            // ipr::Type_id

--- a/include/ipr/node-category
+++ b/include/ipr/node-category
@@ -36,7 +36,6 @@ auto_cat,                               // ipr::Auto
 identifier_cat,                         // ipr::Identifier
 operator_cat,                           // ipr::Operator
 conversion_cat,                         // ipr::Conversion
-scope_ref_cat,                          // ipr::Scope_ref
 template_id_cat,                        // ipr::Template_id
 type_id_cat,                            // ipr::Type_id
 ctor_name_cat,                          // ipr::Ctor_name
@@ -66,6 +65,7 @@ unary_minus_cat,                        // ipr::Unary_minus
 unary_plus_cat,                         // ipr::Unary_plus;
 expansion_cat,                          // ipr::Expansion
 
+scope_ref_cat,                          // ipr::Scope_ref
 plus_cat,                               // ipr::Plus
 plus_assign_cat,                        // ipr::Plus_assign
 and_cat,                                // ipr::And

--- a/include/ipr/node-category
+++ b/include/ipr/node-category
@@ -41,6 +41,7 @@ template_id_cat,                        // ipr::Template_id
 type_id_cat,                            // ipr::Type_id
 ctor_name_cat,                          // ipr::Ctor_name
 dtor_name_cat,                          // ipr::Dtor_name
+guide_name_cat,                         // ipr::Guide_name
 rname_cat,                              // ipr::Rname
 
 phantom_cat,                            // ipr::Phantom

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -1507,6 +1507,11 @@ namespace ipr {
          return suffixes.insert(s, unary_compare());
       }
 
+      impl::Guide_name*
+      expr_factory::make_guide_name(const ipr::Named_map& m) {
+         return guide_ids.insert(m, unary_compare());
+      }
+
       impl::Id_expr*
       expr_factory::make_id_expr(const ipr::Name& n) {
          return id_exprs.make(n);

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -635,8 +635,8 @@ namespace ipr {
       }
 
       impl::Empty_stmt*
-      stmt_factory::make_empty_stmt() {
-         return empty_stmts.make(*make_phantom());
+      stmt_factory::make_empty_stmt(const ipr::Type& t) {
+         return empty_stmts.make(*make_phantom(t));
       }
 
       impl::Block*

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -1831,8 +1831,7 @@ namespace ipr {
       impl::Scope_ref*
       expr_factory::make_scope_ref(const ipr::Expr& l, const ipr::Expr& r)
       {
-         using Rep = impl::Scope_ref::Rep;
-         return scope_refs.insert(Rep{ l, r }, binary_compare());
+         return scope_refs.make(l, r);
       }
 
       impl::Rshift*
@@ -2106,14 +2105,6 @@ namespace ipr {
          if (conv->constraint == 0)
             conv->constraint = &get_decltype(*conv);
          return *conv;
-      }
-
-      const ipr::Scope_ref&
-      Lexicon::get_scope_ref(const ipr::Expr& s, const ipr::Expr& m) {
-         impl::Scope_ref* sr = expr_factory::make_scope_ref(s, m);
-         if (sr->constraint == 0)
-            sr->constraint = &get_decltype(*sr);
-         return *sr;
       }
 
       const ipr::Template_id&

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -1502,6 +1502,10 @@ namespace ipr {
          return make_identifier(get_string(s));
       }
 
+      impl::Suffix*
+      expr_factory::make_suffix(const ipr::Identifier& s) {
+         return suffixes.insert(s, unary_compare());
+      }
 
       impl::Id_expr*
       expr_factory::make_id_expr(const ipr::Name& n) {
@@ -2004,6 +2008,14 @@ namespace ipr {
          if (id->constraint == 0)
             id->constraint = &get_decltype(*id);
          return *id;
+      }
+
+      const ipr::Suffix&
+      Lexicon::get_suffix(const ipr::Identifier& id) {
+         auto s = expr_factory::make_suffix(id);
+         if (s->constraint == nullptr)
+            s->constraint = &get_decltype(*s);
+         return *s;
       }
 
       const ipr::Type& Lexicon::void_type() const {  return voidtype;  }

--- a/src/traversal.cxx
+++ b/src/traversal.cxx
@@ -148,6 +148,12 @@ ipr::Visitor::visit(const Dtor_name& n)
 }
 
 void
+ipr::Visitor::visit(const Guide_name& n)
+{
+   visit(as<Name>(n));
+}
+
+void
 ipr::Visitor::visit(const Rname& n)
 {
    visit(as<Name>(n));

--- a/src/traversal.cxx
+++ b/src/traversal.cxx
@@ -118,12 +118,6 @@ ipr::Visitor::visit(const Conversion& conv)
 }
 
 void
-ipr::Visitor::visit(const Scope_ref& n)
-{
-   visit(as<Name>(n));
-}
-
-void
 ipr::Visitor::visit(const Template_id& e)
 {
    visit(as<Name>(e));
@@ -401,6 +395,12 @@ void
 ipr::Visitor::visit(const Expansion& e)
 {
    visit(as<Classic>(e));
+}
+
+void
+ipr::Visitor::visit(const Scope_ref& n)
+{
+   visit(as<Classic>(n));
 }
 
 void

--- a/src/traversal.cxx
+++ b/src/traversal.cxx
@@ -78,7 +78,7 @@ ipr::Visitor::visit(const Linkage& l)
    visit(as<Node>(l));
 }
 
-// Because Name is a very high-leverl interface to
+// Because Name is a very high-level interface to
 // Identifier, Operator, Conversion, Instantiation and
 // Qualified and these share common very high-level
 // semantics, it is convenient to have the implementation
@@ -103,6 +103,12 @@ void
 ipr::Visitor::visit(const Identifier& id)
 {
    visit(as<Name>(id));
+}
+
+void
+ipr::Visitor::visit(const Suffix& s)
+{
+   visit(as<Name>(s));
 }
 
 void


### PR DESCRIPTION
Fix #61 
Fix #59 
Add a name for deduction guides, even if standard C++ pretends they don't have names