### PR TITLE
Move Name out of Expr hierarchy

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -216,7 +216,7 @@ namespace ipr {
          Arg_type operand() const final { return rep; }
       };
 
-      // Short for the impplementation of generic unary nodes.
+      // Shorthand for the implementation of generic unary nodes.
       template<typename T>
       using Unary_node = Unary<Node<T>>;
 
@@ -253,7 +253,7 @@ namespace ipr {
          Arg2_type second() const final { return rep.second; }
       };
 
-      // Short hand for implementation of geeric binary nodes.
+      // Short hand for implementation of generic binary nodes.
       template<typename T>
       using Binary_node = Binary<Node<T>>;
 
@@ -1074,16 +1074,22 @@ namespace ipr {
 
       using Comment = Unary_node<Comment>;
 
+      using Identifier = Unary_node<ipr::Identifier>;
+      using Suffix = Unary_node<ipr::Suffix>;
+      using Operator = Unary_node<ipr::Operator>;
+      using Conversion = Unary_node<ipr::Conversion>;
+      using Ctor_name = Unary_node<ipr::Ctor_name>;
+      using Dtor_name = Unary_node<ipr::Dtor_name>;
+      using Guide_name = Unary_node<ipr::Guide_name>;
+      using Type_id = Unary_node<ipr::Type_id>;
+
       using Phantom = Expr<ipr::Phantom>;
 
       using Address = Classic_unary_expr<ipr::Address>;
       using Array_delete = Classic_unary_expr<ipr::Array_delete>;
       using Complement = Classic_unary_expr<ipr::Complement>;
-      using Conversion = Unary_expr<ipr::Conversion>;
-      using Ctor_name = Unary_expr<ipr::Ctor_name>;
       using Delete = Classic_unary_expr<ipr::Delete>;
       using Deref = Classic_unary_expr<ipr::Deref>;
-      using Dtor_name = Unary_expr<ipr::Dtor_name>;
 
       struct Expr_list : impl::Node<ipr::Expr_list> {
          typed_sequence<ref_sequence<ipr::Expr>> seq;
@@ -1105,9 +1111,6 @@ namespace ipr {
       using Initializer_list = Classic_unary_expr<ipr::Initializer_list>;
       using Sizeof = Unary_expr<ipr::Sizeof>;
       using Typeid = Unary_expr<ipr::Typeid>;
-      using Identifier = Unary_expr<ipr::Identifier>;
-      using Suffix = Unary_expr<ipr::Suffix>;
-      using Guide_name = Unary_expr<ipr::Guide_name>;
 
       struct Id_expr : Unary_expr<ipr::Id_expr> {
          const ipr::Expr* decls = nullptr;
@@ -1119,7 +1122,6 @@ namespace ipr {
 
       using Not = Classic_unary_expr<ipr::Not>;
 
-      using Operator = Unary_expr<ipr::Operator>;
       using Paren_expr = type_from_operand<Classic<Node<ipr::Paren_expr>>>;
       
       using Pre_decrement = Classic_unary_expr<ipr::Pre_decrement>;
@@ -1127,7 +1129,6 @@ namespace ipr {
       using Post_decrement = Classic_unary_expr<ipr::Post_decrement>;
       using Post_increment = Classic_unary_expr<ipr::Post_increment>;
       using Throw = Classic_unary_expr<ipr::Throw>;
-      using Type_id = type_from_operand<Node<ipr::Type_id>>;
 
       using Unary_minus = Classic_unary_expr<ipr::Unary_minus>;
       using Unary_plus = Classic_unary_expr<ipr::Unary_plus>;
@@ -1195,7 +1196,7 @@ namespace ipr {
       using Rshift_assign = Classic_binary_expr<ipr::Rshift_assign>;
       using Scope_ref = Classic_binary_expr<ipr::Scope_ref>;
       using Static_cast = Conversion_expr<ipr::Static_cast>;
-      using Template_id = Binary_expr<ipr::Template_id>;
+      using Template_id = Binary_node<ipr::Template_id>;
 
       using Conditional = Ternary<Classic<Expr<ipr::Conditional>>>;
 
@@ -2023,7 +2024,7 @@ namespace ipr {
                : impl::Expr<T>(&t), id(n), link(l) { }
 
          const ipr::Name& name() const { return id; }
-         Arg1_type first() const { return id; }
+         Arg1_type first() const { return *this; }
          Arg2_type second() const { return link; }
 
       private:

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -714,16 +714,13 @@ namespace ipr {
    //    - type-id                           -- Type_id
    // 
    // Most names are introduced by declarations into scope.
-   // A Name is an Expression.  That obviates the needs for a
-   // special node to turn names into Expressions, for the purpose
-   // of symbolic interpretation.   
-   struct Name : Expr {
+   struct Name : Node {
       // At the moment, this class is empty because there is no
       // interesting operation that could be provided here without
       // imposing too much of implementation details.
 
    protected:
-      Name(Category_code c) : Expr(c)
+      Name(Category_code c) : Node{ c }
       { }
    };
 
@@ -2045,7 +2042,7 @@ namespace ipr {
       virtual void visit(const Expr&) = 0;
       virtual void visit(const Classic&);
       
-      virtual void visit(const Name&);
+      virtual void visit(const Name&) = 0;
       virtual void visit(const Identifier&);
       virtual void visit(const Suffix&);
       virtual void visit(const Operator&);

--- a/include/ipr/traversal
+++ b/include/ipr/traversal
@@ -39,6 +39,7 @@ namespace ipr {
    template<class F>
    struct Constant_visitor : Visitor, F {
       void visit(const Node& n) override { (*this)(n); }
+      void visit(const Name& n) override { (*this)(n); }
       void visit(const Expr& n) override { (*this)(n); }
       void visit(const Type& n) override { (*this)(n); }
       void visit(const Stmt& n) override { (*this)(n); }

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -2009,18 +2009,12 @@ namespace ipr {
 
       const ipr::Identifier&
       Lexicon::get_identifier(const ipr::String& s) {
-         impl::Identifier* id = expr_factory::make_identifier(s);
-         if (id->constraint == 0)
-            id->constraint = &get_decltype(*id);
-         return *id;
+         return *expr_factory::make_identifier(s);
       }
 
       const ipr::Suffix&
       Lexicon::get_suffix(const ipr::Identifier& id) {
-         auto s = expr_factory::make_suffix(id);
-         if (s->constraint == nullptr)
-            s->constraint = &get_decltype(*s);
-         return *s;
+         return *expr_factory::make_suffix(id);
       }
 
       const ipr::Type& Lexicon::void_type() const {  return voidtype;  }
@@ -2084,18 +2078,12 @@ namespace ipr {
 
       const ipr::Ctor_name&
       Lexicon::get_ctor_name(const ipr::Type& t) {
-         impl::Ctor_name* id = expr_factory::make_ctor_name(t);
-         if (id->constraint == 0)
-            id->constraint = &get_decltype(*id);
-         return *id;
+         return *expr_factory::make_ctor_name(t);
       }
 
       const ipr::Dtor_name&
       Lexicon::get_dtor_name(const ipr::Type& t) {
-         impl::Dtor_name* id = expr_factory::make_dtor_name(t);
-         if (id->constraint == 0)
-            id->constraint = &get_decltype(*id);
-         return *id;
+         return *expr_factory::make_dtor_name(t);
       }
 
       const ipr::Operator&
@@ -2110,26 +2098,17 @@ namespace ipr {
 
       const ipr::Operator&
       Lexicon::get_operator(const ipr::String& s) {
-         impl::Operator* op = expr_factory::make_operator(s);
-         if (op->constraint == 0)
-            op->constraint = &get_decltype(*op);
-         return *op;
+         return *expr_factory::make_operator(s);
       }
 
       const ipr::Conversion&
       Lexicon::get_conversion(const ipr::Type& t) {
-         impl::Conversion* conv = expr_factory::make_conversion(t);
-         if (conv->constraint == 0)
-            conv->constraint = &get_decltype(*conv);
-         return *conv;
+         return *expr_factory::make_conversion(t);
       }
 
       const ipr::Template_id&
       Lexicon::get_template_id(const ipr::Name& t, const ipr::Expr_list& a) {
-         impl::Template_id* tid = expr_factory::make_template_id(t, a);
-         if (tid->constraint == 0)
-            tid->constraint = &get_decltype(*tid);
-         return *tid;
+         return *expr_factory::make_template_id(t, a);
       }
 
       const ipr::Array&

--- a/src/io.cxx
+++ b/src/io.cxx
@@ -18,7 +18,6 @@ namespace ipr
    struct pp_base : Constant_visitor<Missing_overrider> {
       explicit pp_base(Printer& p) : pp(p) { }
       using Visitor::visit;
-      void visit(const Name& n) override { visit(as<Expr>(n)); }
       void visit(const Type& t) override { visit(as<Expr>(t)); }
       void visit(const Decl& d) override { visit(as<Expr>(d)); }
       
@@ -302,8 +301,8 @@ namespace ipr
          //       primary-expression < expression-seq >
          void visit(const Template_id& n) override
          {
-            pp << xpr_primary_expr(n.template_name())
-               << token("<|") << n.args() << token("|>");
+            n.template_name().accept(*this);
+            pp << token("<|") << n.args() << token("|>");
          }
          
          // -- ctor-name:

--- a/src/traversal.cxx
+++ b/src/traversal.cxx
@@ -94,12 +94,6 @@ ipr::Visitor::visit(const Classic& e)
 }
 
 void
-ipr::Visitor::visit(const Name& n)
-{
-   visit(as<Expr>(n));
-}
-
-void
 ipr::Visitor::visit(const Identifier& id)
 {
    visit(as<Name>(id));


### PR DESCRIPTION
With the push to have expressions with their own source locations, there is less benefit to having names be part of the general `Expr` hierarchy.

This is a breaking change from [Classic IPR](https://github.com/GabrielDosReis/ipr/commit/3fc82cb0a38932b82f06a2efda4087ddad61fa84).