### PR TITLE
Rename type `Template` to `Forall`

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -1071,7 +1071,7 @@ namespace ipr {
       using Reference = Unary_type<ipr::Reference>;
       using Rvalue_reference = Unary_type<ipr::Rvalue_reference>;
       using Sum = Unary_type<ipr::Sum>;
-      using Template = Binary_type<ipr::Template>;
+      using Forall = Binary_type<ipr::Forall>;
 
       using Comment = Unary_node<Comment>;
 
@@ -1612,9 +1612,9 @@ namespace ipr {
          impl::Typedecl* make_typedecl(const ipr::Name&, const ipr::Type&);
          impl::Fundecl* make_fundecl(const ipr::Name&, const ipr::Function&);
          impl::Named_map* make_primary_map(const ipr::Name&,
-                                           const ipr::Template&);
+                                           const ipr::Forall&);
          impl::Named_map* make_secondary_map(const ipr::Name&,
-                                             const ipr::Template&);
+                                             const ipr::Forall&);
       
       private:
          const ipr::Region& region;
@@ -1685,13 +1685,13 @@ namespace ipr {
          }
 
          Named_map* declare_primary_map(const ipr::Name& n,
-                                        const ipr::Template& t)
+                                        const ipr::Forall& t)
          {
             return scope.make_primary_map(n, t);
          }
 
          Named_map* declare_secondary_map(const ipr::Name& n,
-                                          const ipr::Template& t)
+                                          const ipr::Forall& t)
          {
             return scope.make_secondary_map(n, t);
          }
@@ -1766,7 +1766,7 @@ namespace ipr {
          }
          
          impl::Named_map*
-         declare_primary_map(const ipr::Name& n, const ipr::Template& t)
+         declare_primary_map(const ipr::Name& n, const ipr::Forall& t)
          {
             impl::Named_map* map = body.declare_primary_map(n, t);
             map->member_of = this;
@@ -1774,7 +1774,7 @@ namespace ipr {
          }
 
          impl::Named_map*
-         declare_secondary_map(const ipr::Name& n, const ipr::Template& t)
+         declare_secondary_map(const ipr::Name& n, const ipr::Forall& t)
          {
             impl::Named_map* map = body.declare_secondary_map(n, t);
             map->member_of = this;
@@ -1835,7 +1835,7 @@ namespace ipr {
          impl::Reference* make_reference(const ipr::Type&);
          impl::Rvalue_reference* make_rvalue_reference(const ipr::Type&);
          impl::Sum* make_sum(const ipr::Sequence<ipr::Type>&);
-         impl::Template* make_template(const ipr::Product&, const ipr::Type&);
+         impl::Forall* make_forall(const ipr::Product&, const ipr::Type&);
 
          impl::Enum* make_enum(const ipr::Region&, const ipr::Type&, Enum::Kind);
          impl::Class* make_class(const ipr::Region&, const ipr::Type&);
@@ -1854,7 +1854,7 @@ namespace ipr {
          util::rb_tree::container<impl::Reference> references;
          util::rb_tree::container<impl::Rvalue_reference> refrefs;
          util::rb_tree::container<impl::Sum> sums;
-         util::rb_tree::container<impl::Template> templates;
+         util::rb_tree::container<impl::Forall> foralls;
          stable_farm<impl::Enum> enums;
          stable_farm<impl::Class> classes;
          stable_farm<impl::Union> unions;
@@ -2131,7 +2131,7 @@ namespace ipr {
 
          const ipr::Sum& get_sum(const ref_sequence<ipr::Type>&);
 
-         const ipr::Template& get_template(const ipr::Product&,
+         const ipr::Forall& get_forall(const ipr::Product&,
                                            const ipr::Type&);
 
          impl::Mapping* make_mapping(const ipr::Region&);

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -90,7 +90,7 @@ namespace ipr {
    struct Reference;             // reference type
    struct Rvalue_reference;      // rvalue-reference type -- C++0x
    struct Sum;                   // sum type - not ISO C++ type
-   struct Template;              // type of a template - Not ISO C++ type
+   struct Forall;                // universally quantified type - Not ISO C++ type
    struct Union;                 // user-defined type - union
    struct Auto;                  // "auto" -- each occurrence is generative
 
@@ -1062,11 +1062,13 @@ namespace ipr {
       const Type& operator[](int i) const { return elements()[i]; }
    };
 
-                                // -- Template --
-   // This represents the type of a template declaration.  In the near future,
+                                // -- Forall --
+   // This represents a universally quantified type, parameterized by any compile-time sort,
+   // that is all values for the parameters must designate compile-time entities.
+   // It is useful for representing the type of a template declaration, and more.  In the near future,
    // when "concepts" are integrated, it will become a Ternary node where the
    // third operand will represent the "where-clause".
-   struct Template : Binary<Category<template_cat, Type>,
+   struct Forall : Binary<Category<forall_cat, Type>,
                             const Product&, const Type&> {
       // The constraints or types of the template-parameters.
       const Product& source() const { return first(); }
@@ -2069,7 +2071,7 @@ namespace ipr {
       virtual void visit(const Reference&);
       virtual void visit(const Rvalue_reference&);
       virtual void visit(const Sum&);
-      virtual void visit(const Template&);
+      virtual void visit(const Forall&);
       virtual void visit(const Union&);
       virtual void visit(const Auto&);
 

--- a/include/ipr/node-category
+++ b/include/ipr/node-category
@@ -29,7 +29,7 @@ qualified_cat,                          // ipr::Qualified
 reference_cat,                          // ipr::Reference
 rvalue_reference_cat,                   // ipr::Rvalue_reference
 sum_cat,                                // ipr::Sum
-template_cat,                           // ipr::Template
+forall_cat,                             // ipr::Forall
 union_cat,                              // ipr::Union
 auto_cat,                               // ipr::Auto
 

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -1031,10 +1031,10 @@ namespace ipr {
          return sums.insert(seq, unary_compare());
       }
 
-      impl::Template*
-      type_factory::make_template(const ipr::Product& s, const ipr::Type& t) {
-         using rep = impl::Template::Rep;
-         return templates.insert(rep{ s, t }, binary_compare());
+      impl::Forall*
+      type_factory::make_forall(const ipr::Product& s, const ipr::Type& t) {
+         using rep = impl::Forall::Rep;
+         return foralls.insert(rep{ s, t }, binary_compare());
       }
 
       impl::Enum*
@@ -1274,7 +1274,7 @@ namespace ipr {
       }
 
       impl::Named_map*
-      Scope::make_primary_map(const ipr::Name& n, const ipr::Template& t)
+      Scope::make_primary_map(const ipr::Name& n, const ipr::Forall& t)
       {
          impl::Overload* ovl = overloads.insert(n, node_compare());
          overload_entry* master = ovl->lookup(t);
@@ -1294,7 +1294,7 @@ namespace ipr {
       }
 
       impl::Named_map*
-      Scope::make_secondary_map(const ipr::Name& n, const ipr::Template& t)
+      Scope::make_secondary_map(const ipr::Name& n, const ipr::Forall& t)
       {
          impl::Overload* ovl = overloads.insert(n, node_compare());
          overload_entry* master = ovl->lookup(t);
@@ -2194,9 +2194,9 @@ namespace ipr {
             (types.make_sum(*type_seqs.insert(s, unary_compare())));
       }
 
-      const ipr::Template&
-      Lexicon::get_template(const ipr::Product& p, const ipr::Type& t) {
-         return *finish_type(types.make_template(p, t));
+      const ipr::Forall&
+      Lexicon::get_forall(const ipr::Product& p, const ipr::Type& t) {
+         return *finish_type(types.make_forall(p, t));
       }
 
       impl::Class*

--- a/src/io.cxx
+++ b/src/io.cxx
@@ -1090,7 +1090,7 @@ namespace ipr
          pp << xpr_initializer(map.result());
       }
 
-      void visit(const Template&) override
+      void visit(const Forall&) override
       {
          pp << token('<');
          pp << map.params();
@@ -1389,7 +1389,7 @@ namespace ipr
          pp << token('&') << token('&') << xpr_type(t.refers_to());
       }
 
-      void visit(const Template& t) override
+      void visit(const Forall& t) override
       {
          pp << token('<') << t.source().operand() << token('>')
             << token(' ')
@@ -1446,7 +1446,7 @@ namespace ipr
       void visit(const Rvalue_reference& t) final
       { pp << xpr_type_expr(t); }
 
-      void visit(const Template& t) final
+      void visit(const Forall& t) final
       { pp << xpr_type_expr(t); }
 
       void visit(const Type& t) final

--- a/src/traversal.cxx
+++ b/src/traversal.cxx
@@ -240,7 +240,7 @@ ipr::Visitor::visit(const Sum& t)
 }
 
 void
-ipr::Visitor::visit(const Template& t)
+ipr::Visitor::visit(const Forall& t)
 {
    visit(as<Type>(t));
 }


### PR DESCRIPTION
and adjust uses and definitions.

This is a breaking change, but the renaming will create less FAQ/confusion over the long term.