### PR TITLE
Owner of home scope of a type declaration

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -1562,12 +1562,12 @@ namespace ipr {
 
       struct Typedecl : impl::Decl<ipr::Typedecl> {
          const ipr::Type* init;
-         const ipr::Udt<ipr::Decl>* member_of;
+         const ipr::Expr* member_of;
          const ipr::Region* lexreg;
 
          Typedecl();
 
-         const ipr::Udt<ipr::Decl>& membership() const final;
+         const ipr::Expr& membership() const final;
          Optional<ipr::Expr> initializer() const final;
          const ipr::Region& lexical_region() const final;
       };

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -1905,7 +1905,7 @@ namespace ipr {
                                 // -- Enumerator --
    // This represents a classic enumerator.
    struct Enumerator : Category<enumerator_cat, Decl> {
-      const Type& type() const { return membership(); }
+      const Type& type() const final { return membership(); }
       virtual const Enum& membership() const = 0;
    };
 
@@ -1981,7 +1981,7 @@ namespace ipr {
 
                                 // -- Typedecl --
    struct Typedecl : Category<typedecl_cat, Decl> {
-      virtual const Type& membership() const = 0;
+      virtual const Expr& membership() const = 0;
       virtual Optional<Typedecl> definition() const = 0;
    };
 

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -470,7 +470,7 @@ namespace ipr {
          return { init };
       }
 
-      const ipr::Udt<ipr::Decl>&
+      const ipr::Expr&
       Typedecl::membership() const {
          return *util::check(member_of);
       }


### PR DESCRIPTION
A type declaration can appear at non-type scope, e.g. it can be a local class.

Fixes #70