### PR TITLE
Rename Named_map to Template

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -547,13 +547,13 @@ namespace ipr {
       };
 
       template<>
-      struct master_decl_data<ipr::Named_map>
-         : basic_decl_data<ipr::Named_map>, overload_entry {
-         using Base = basic_decl_data<ipr::Named_map>;
+      struct master_decl_data<ipr::Template>
+         : basic_decl_data<ipr::Template>, overload_entry {
+         using Base = basic_decl_data<ipr::Template>;
          // The declaration that is considered to be the definition.
-         const ipr::Named_map* def;
+         const ipr::Template* def;
          const ipr::Linkage* langlinkage;
-         const ipr::Named_map* primary;
+         const ipr::Template* primary;
          const ipr::Region* home;
 
          // The overload set that contains this master declaration.  It
@@ -755,7 +755,7 @@ namespace ipr {
       template<class D>
       struct Decl : Stmt<Node<D>> {
          basic_decl_data<D> decl_data;
-         const ipr::Named_map* pat = { };
+         const ipr::Template* pat = { };
          val_sequence<ipr::Substitution> args;
 
          Decl() : decl_data{ nullptr } { }
@@ -763,7 +763,7 @@ namespace ipr {
          const ipr::Sequence<ipr::Substitution>& substitutions() const final
          { return args; }
 
-         const ipr::Named_map& generating_map() const final
+         const ipr::Template& generating_map() const final
          { return *util::check(pat); }
 
          const ipr::Linkage& lang_linkage() const final
@@ -796,7 +796,7 @@ namespace ipr {
          ipr::DeclSpecifiers spec;
          const ipr::Linkage* langlinkage;
          singleton_overload overload;
-         const ipr::Named_map* pat;
+         const ipr::Template* pat;
          val_sequence<ipr::Substitution> args;
 
          unique_decl() : spec(ipr::DeclSpecifiers::None),
@@ -815,7 +815,7 @@ namespace ipr {
          const ipr::Sequence<ipr::Substitution>& substitutions() const final
          { return args; }
 
-         const ipr::Named_map& generating_map() const final
+         const ipr::Template& generating_map() const final
          { return *util::check(pat); }
       };
 
@@ -1256,7 +1256,7 @@ namespace ipr {
          Operator* make_operator(const char*);
          Operator* make_operator(const std::string&);
 
-         Guide_name* make_guide_name(const ipr::Named_map&);
+         Guide_name* make_guide_name(const ipr::Template&);
 
          Address* make_address(const ipr::Expr&);
          Array_delete* make_array_delete(const ipr::Expr&);
@@ -1441,24 +1441,24 @@ namespace ipr {
       };
 
       
-      struct Named_map : impl::Decl<ipr::Named_map> {
+      struct Template : impl::Decl<ipr::Template> {
          const ipr::Udt<ipr::Decl>* member_of;
          impl::Mapping* init;
          const ipr::Region* lexreg;
          impl::Expr_list args;
 
-         Named_map();
+         Template();
 
-         const ipr::Named_map& primary_named_map() const;
-         const ipr::Sequence<ipr::Decl>& specializations() const;
-         const ipr::Mapping& mapping() const;
+         const ipr::Template& primary_template() const final;
+         const ipr::Sequence<ipr::Decl>& specializations() const final;
+         const ipr::Mapping& mapping() const final;
          Optional<ipr::Expr> initializer() const final;
-         const ipr::Region& lexical_region() const;
+         const ipr::Region& lexical_region() const final;
       };
 
       template<>
-      struct traits<ipr::Named_map> {
-         using rep = impl::Named_map;
+      struct traits<ipr::Template> {
+         using rep = impl::Template;
       };
       
       template<class Interface>
@@ -1624,10 +1624,8 @@ namespace ipr {
          impl::Bitfield* make_bitfield(const ipr::Name&, const ipr::Type&);
          impl::Typedecl* make_typedecl(const ipr::Name&, const ipr::Type&);
          impl::Fundecl* make_fundecl(const ipr::Name&, const ipr::Function&);
-         impl::Named_map* make_primary_map(const ipr::Name&,
-                                           const ipr::Forall&);
-         impl::Named_map* make_secondary_map(const ipr::Name&,
-                                             const ipr::Forall&);
+         impl::Template* make_primary_template(const ipr::Name&, const ipr::Forall&);
+         impl::Template* make_secondary_template(const ipr::Name&, const ipr::Forall&);
       
       private:
          const ipr::Region& region;
@@ -1641,8 +1639,8 @@ namespace ipr {
          decl_factory<ipr::Bitfield> bitfields;
          decl_factory<ipr::Fundecl> fundecls;
          decl_factory<ipr::Typedecl> typedecls;
-         decl_factory<ipr::Named_map> primary_maps;
-         decl_factory<ipr::Named_map> secondary_maps;
+         decl_factory<ipr::Template> primary_maps;
+         decl_factory<ipr::Template> secondary_maps;
 
          template<class T> inline void add_member(T*);
       };
@@ -1697,16 +1695,14 @@ namespace ipr {
             return scope.make_fundecl(n, t);
          }
 
-         Named_map* declare_primary_map(const ipr::Name& n,
-                                        const ipr::Forall& t)
+         Template* declare_primary_template(const ipr::Name& n, const ipr::Forall& t)
          {
-            return scope.make_primary_map(n, t);
+            return scope.make_primary_template(n, t);
          }
 
-         Named_map* declare_secondary_map(const ipr::Name& n,
-                                          const ipr::Forall& t)
+         Template* declare_secondary_template(const ipr::Name& n, const ipr::Forall& t)
          {
-            return scope.make_secondary_map(n, t);
+            return scope.make_secondary_template(n, t);
          }
 
          Region(const ipr::Region*, const ipr::Type&);
@@ -1778,18 +1774,18 @@ namespace ipr {
             return fundecl;
          }
          
-         impl::Named_map*
-         declare_primary_map(const ipr::Name& n, const ipr::Forall& t)
+         impl::Template*
+         declare_primary_template(const ipr::Name& n, const ipr::Forall& t)
          {
-            impl::Named_map* map = body.declare_primary_map(n, t);
+            impl::Template* map = body.declare_primary_template(n, t);
             map->member_of = this;
             return map;
          }
 
-         impl::Named_map*
-         declare_secondary_map(const ipr::Name& n, const ipr::Forall& t)
+         impl::Template*
+         declare_secondary_template(const ipr::Name& n, const ipr::Forall& t)
          {
-            impl::Named_map* map = body.declare_secondary_map(n, t);
+            impl::Template* map = body.declare_secondary_template(n, t);
             map->member_of = this;
             return map;
          }

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -229,7 +229,7 @@ namespace ipr {
    struct Field;                 // field in union or class declaration
    struct Bitfield;              // bitfield
    struct Fundecl;               // function-declaration
-   struct Named_map;             // template-declaration
+   struct Template;              // template-declaration
    struct Parameter;             // function or template parameter
    struct Typedecl;              // declaration for a type
    struct Var;                   // variable declaration
@@ -798,7 +798,7 @@ namespace ipr {
    // that when executed yield deduced template arguments.  As such, they
    // fit the IPR model of a declaration being an introduction of a name
    // in a scope, with a type and optional initializer.
-   struct Guide_name : Unary<Category<guide_name_cat, Name>, const Named_map&> {
+   struct Guide_name : Unary<Category<guide_name_cat, Name>, const Template&> {
       Arg_type mapping_decl() const { return operand(); }
    };
 
@@ -1866,7 +1866,7 @@ namespace ipr {
 
       virtual Optional<Expr> initializer() const = 0;
 
-      virtual const Named_map& generating_map() const = 0;
+      virtual const Template& generating_map() const = 0;
       virtual const Sequence<Substitution>& substitutions() const = 0;
 
       virtual int position() const = 0;
@@ -1883,7 +1883,7 @@ namespace ipr {
       { }
    };
 
-                                // -- Named_map --
+                                // -- Template --
    // This represents a parameterized declaration.  If its
    // template-parameter list is empty, that means that it is
    // either an explicit specialization -- if result() has a
@@ -1891,15 +1891,15 @@ namespace ipr {
    // declaration  -- if result().substitutions() is empty.
    // The list of specializations of this template (either
    // partial or explicit) is given by specializations().
-   struct Named_map : Category<named_map_cat, Decl> {
-      virtual const Named_map& primary_named_map() const = 0;
+   struct Template : Category<template_cat, Decl> {
+      virtual const Template& primary_template() const = 0;
       virtual const Sequence<Decl>& specializations() const = 0;
       virtual const Mapping& mapping() const = 0;
 
       const Parameter_list& params() const { return mapping().params(); }
       const Expr& result() const { return mapping().result(); }
 
-      virtual Optional<Named_map> definition() const = 0;
+      virtual Optional<Template> definition() const = 0;
    };
 
                                 // -- Enumerator --
@@ -2196,7 +2196,7 @@ namespace ipr {
       virtual void visit(const Enumerator&);
       virtual void visit(const Field&);
       virtual void visit(const Fundecl&);
-      virtual void visit(const Named_map&);
+      virtual void visit(const Template&);
       virtual void visit(const Parameter&);
       virtual void visit(const Parameter_list&);
       virtual void visit(const Typedecl&);

--- a/include/ipr/node-category
+++ b/include/ipr/node-category
@@ -145,7 +145,7 @@ enumerator_cat,                         // ipr::Enumerator
 field_cat,                              // ipr::Field
 bitfield_cat,                           // ipr::Bitfield
 fundecl_cat,                            // ipr::Fundecl
-named_map_cat,                          // ipr::Named_map
+template_cat,                           // ipr::Template
 parameter_cat,                          // ipr::Parameter
 typedecl_cat,                           // ipr::Typedecl
 var_cat,                                // ipr::Var

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -56,11 +56,11 @@ namespace ipr {
 
       Optional<ipr::Expr_list> New::initializer() const { return { args }; }
 
-      // --------------------------------------
-      // -- master_decl_data<ipr::Named_map> --
-      // --------------------------------------
+      // -------------------------------------
+      // -- master_decl_data<ipr::Template> --
+      // -------------------------------------
 
-      master_decl_data<ipr::Named_map>::
+      master_decl_data<ipr::Template>::
       master_decl_data(impl::Overload* ovl, const ipr::Type& t)
             : Base(this), overload_entry(t),
               def(0), langlinkage(0), primary(0),home(0),
@@ -381,33 +381,33 @@ namespace ipr {
          return *util::check(lexreg);
       }
 
-      // ---------------------
-      // -- impl::Named_map --
-      // ---------------------
+      // --------------------
+      // -- impl::Template --
+      // --------------------
 
-      Named_map::Named_map() : member_of(0), init(0), lexreg(0) { }
+      Template::Template() : member_of(0), init(0), lexreg(0) { }
 
-      const ipr::Named_map&
-      Named_map::primary_named_map() const {
+      const ipr::Template&
+      Template::primary_template() const {
          return *util::check(util::check(decl_data.master_data)->primary);
       }
 
       const ipr::Sequence<ipr::Decl>&
-      Named_map::specializations() const {
+      Template::specializations() const {
          return util::check(decl_data.master_data)->specs;
       }
 
       const ipr::Mapping&
-      Named_map::mapping() const {
+      Template::mapping() const {
          return *util::check(init);
       }
 
-      Optional<ipr::Expr> Named_map::initializer() const {
+      Optional<ipr::Expr> Template::initializer() const {
          return { util::check(init)->body };
       }
 
       const ipr::Region&
-      Named_map::lexical_region() const {
+      Template::lexical_region() const {
          return *util::check(lexreg);
       }
 
@@ -1281,40 +1281,40 @@ namespace ipr {
          }
       }
 
-      impl::Named_map*
-      Scope::make_primary_map(const ipr::Name& n, const ipr::Forall& t)
+      impl::Template*
+      Scope::make_primary_template(const ipr::Name& n, const ipr::Forall& t)
       {
          impl::Overload* ovl = overloads.insert(n, node_compare());
          overload_entry* master = ovl->lookup(t);
 
          if (master == 0) {
-            impl::Named_map* decl = primary_maps.declare(ovl, t);
+            impl::Template* decl = primary_maps.declare(ovl, t);
             decl->decl_data.master_data->primary = decl;
             add_member(decl);
             return decl;
          }
          else {
-            impl::Named_map* decl = primary_maps.redeclare(master);
+            impl::Template* decl = primary_maps.redeclare(master);
             // FIXME: set the primary field.
             add_member(decl);
             return decl;
          }
       }
 
-      impl::Named_map*
-      Scope::make_secondary_map(const ipr::Name& n, const ipr::Forall& t)
+      impl::Template*
+      Scope::make_secondary_template(const ipr::Name& n, const ipr::Forall& t)
       {
          impl::Overload* ovl = overloads.insert(n, node_compare());
          overload_entry* master = ovl->lookup(t);
 
          if (master == 0) {
-            impl::Named_map* decl = secondary_maps.declare(ovl, t);
+            impl::Template* decl = secondary_maps.declare(ovl, t);
             // FXIME: record this a secondary map and set its primary.
             add_member(decl);
             return decl;
          }
          else {
-            impl::Named_map* decl = secondary_maps.redeclare(master);
+            impl::Template* decl = secondary_maps.redeclare(master);
             // FIXME: set primary info.
             add_member(decl);
             return decl;
@@ -1521,7 +1521,7 @@ namespace ipr {
       }
 
       impl::Guide_name*
-      expr_factory::make_guide_name(const ipr::Named_map& m) {
+      expr_factory::make_guide_name(const ipr::Template& m) {
          return guide_ids.insert(m, unary_compare());
       }
 

--- a/src/io.cxx
+++ b/src/io.cxx
@@ -1826,7 +1826,7 @@ namespace ipr
                   << xpr_stmt(init.get());
          }
 
-         void visit(const Named_map& m) override
+         void visit(const Template& m) override
          {
             m.name().accept(*this);
             pp << token(" : ")

--- a/src/traversal.cxx
+++ b/src/traversal.cxx
@@ -864,7 +864,7 @@ ipr::Visitor::visit(const Typedecl& d)
 }
 
 void
-ipr::Visitor::visit(const Named_map& d)
+ipr::Visitor::visit(const Template& d)
 {
    visit(as<Decl>(d));
 }


### PR DESCRIPTION
This is a breaking change from previous versions.  When you sync to this version, you need to make the following changes in your codebase:

   1. Change `Template` to `Forall`
   2.  change `Named_map` to `Template`

in that order, or chaos ensues.