### PR TITLE
Made CMake variable relative

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,6 @@ endif()
 
 # Testing
 enable_testing()
-set(DOCTEST_INCLUDE_DIR "${CMAKE_SOURCE_DIR}/3rdparty")
+set(DOCTEST_INCLUDE_DIR "${PROJECT_SOURCE_DIR}/3rdparty")
 add_subdirectory(tests)
 


### PR DESCRIPTION
Similarly to the variable used for the `ipr/include` path this variable should be relative to the project. This will allow ipr to built as part of another larger CMake project where ipr is not the CMake root.