### PR TITLE
Simplify ipr::Decl a bit

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -755,16 +755,8 @@ namespace ipr {
       template<class D>
       struct Decl : Stmt<Node<D>> {
          basic_decl_data<D> decl_data;
-         const ipr::Template* pat = { };
-         val_sequence<ipr::Substitution> args;
 
          Decl() : decl_data{ nullptr } { }
-
-         const ipr::Sequence<ipr::Substitution>& substitutions() const final
-         { return args; }
-
-         const ipr::Template& generating_map() const final
-         { return *util::check(pat); }
 
          const ipr::Linkage& lang_linkage() const final
          {
@@ -796,13 +788,10 @@ namespace ipr {
          ipr::DeclSpecifiers spec;
          const ipr::Linkage* langlinkage;
          singleton_overload overload;
-         const ipr::Template* pat;
-         val_sequence<ipr::Substitution> args;
 
          unique_decl() : spec(ipr::DeclSpecifiers::None),
                          langlinkage{ },
-                         overload(*this),
-                         pat{ }
+                         overload(*this)
          { }
 
          ipr::DeclSpecifiers specifiers() const final { return spec; }
@@ -811,12 +800,6 @@ namespace ipr {
          {
             return *util::check(langlinkage);
          }
-
-         const ipr::Sequence<ipr::Substitution>& substitutions() const final
-         { return args; }
-
-         const ipr::Template& generating_map() const final
-         { return *util::check(pat); }
       };
 
       struct Parameter : unique_decl<ipr::Parameter> {

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -1830,9 +1830,9 @@ namespace ipr {
    }
 
                                 // -- Decl --
-   // Only declaration-statements are statements.  But we find it simpler
-   // just to take the general rule that a declaration is a statement.
-   // However it should be observed that declarations like
+   // Only declaration-statements are statements from Standard C++ perspective.
+   // However, we find it simpler just to take the general rule that a declaration
+   //  is a statement. Furthermore, it should be observed that declarations like
    //   (a) function-definition
    //   (b) template-declaration
    //   (c) explicit-instantiation
@@ -1865,9 +1865,6 @@ namespace ipr {
       virtual const Region& lexical_region() const = 0;
 
       virtual Optional<Expr> initializer() const = 0;
-
-      virtual const Template& generating_map() const = 0;
-      virtual const Sequence<Substitution>& substitutions() const = 0;
 
       virtual int position() const = 0;
 


### PR DESCRIPTION
At some point in the design of the IPR, we decided that just about any expression should be subject to parameterization -- not just declarations, but also types (which later gave rise to template aliases, that CWG unwisely renamed to alias templates) and classic expressions.  A corollary of that is that every declaration was potentially the result of an instantiation.

This patch starts a series where we take a slightly different approach to implementing that idea by representing request for specialization as distinct expression nodes.  First we remove the remnant of the previous implementation tactic.