### PR TITLE
[WIP] Add static_assert node.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode/
+.vs/
 build/

--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -788,6 +788,21 @@ namespace ipr {
             return langlinkage.get();
          }
          const ipr::Sequence<ipr::Decl>& decl_set() const final { return overload.seq; }
+         int position() const { return 0; }
+      };
+
+      // Some declarations like Static_assert and Asm does not introduce
+      // any names and cannot be overloaded.
+      template<class Interface>
+      struct barren_decl : unique_decl<Interface> {
+         const ipr::Type* t;
+         const ipr::Name* n;
+
+         barren_decl(const ipr::Type* type, const ipr::Name* name) :
+            t(type), n(name) {};
+
+         const ipr::Name &name() const override { return *util::check(n); }
+         const ipr::Type &type() const override { return *util::check(t); } 
       };
 
       struct Parameter final : unique_decl<ipr::Parameter> {
@@ -1503,6 +1518,25 @@ namespace ipr {
          using rep = impl::Typedecl;
       };
 
+      struct Static_assert : barren_decl<ipr::Static_assert> {
+         const ipr::Expr* a_expr;
+         Optional<ipr::Literal> mes;
+         const ipr::Region* lexreg;
+
+         Static_assert(const ipr::Type*, const ipr::Name*);
+
+         const ipr::Expr& assert_expr() const final;
+         Optional<ipr::Expr> initializer() const final;
+         Optional<ipr::Literal> message() const final;
+         const ipr::Region& lexical_region() const final;
+         const ipr::Region& home_region() const final;
+      };
+
+      template<>
+      struct traits<ipr::Static_assert> {
+         using rep = impl::Static_assert;
+      };
+
       // For a non-defining function declaration, the parameters - if any is named
       // or has a default argument - are stored with that particular declaration.
       // A function definition is one that specifies the initializer (Mapping) which
@@ -1549,6 +1583,7 @@ namespace ipr {
          impl::Field* make_field(const ipr::Name&, const ipr::Type&);
          impl::Bitfield* make_bitfield(const ipr::Name&, const ipr::Type&);
          impl::Typedecl* make_typedecl(const ipr::Name&, const ipr::Type&);
+         impl::Static_assert* make_static_assert(Lexicon&, const ipr::Expr&, Optional<ipr::Literal> message);
          impl::Fundecl* make_fundecl(const ipr::Name&, const ipr::Function&);
          impl::Template* make_primary_template(const ipr::Name&, const ipr::Forall&);
          impl::Template* make_secondary_template(const ipr::Name&, const ipr::Forall&);
@@ -1565,6 +1600,7 @@ namespace ipr {
          decl_factory<ipr::Bitfield> bitfields;
          decl_factory<ipr::Fundecl> fundecls;
          decl_factory<ipr::Typedecl> typedecls;
+         stable_farm<impl::Static_assert> static_asserts;
          decl_factory<ipr::Template> primary_maps;
          decl_factory<ipr::Template> secondary_maps;
 
@@ -1614,6 +1650,13 @@ namespace ipr {
          Typedecl* declare_type(const ipr::Name& n, const ipr::Type& t)
          {
             return scope.make_typedecl(n, t);
+         }
+
+         Static_assert* declare_static_assert(Lexicon& l, const ipr::Expr& e,
+                                              Optional<ipr::Literal> m) {
+            Static_assert* stat_assert = scope.make_static_assert(l, e, m);
+            stat_assert->lexreg = this;
+            return stat_assert;
          }
 
          Fundecl* declare_fun(const ipr::Name& n, const ipr::Function& t)
@@ -1690,6 +1733,12 @@ namespace ipr {
             impl::Typedecl* typedecl = body.declare_type(n, t);
             typedecl->member_of = this;
             return typedecl;
+         }
+
+         impl::Static_assert* declare_static_assert(Lexicon& l,
+                                                    const ipr::Expr& e,
+                                                    Optional<ipr::Literal> m) {
+            return body.declare_static_assert(l, e, m);
          }
          
          impl::Fundecl*
@@ -2028,6 +2077,7 @@ namespace ipr {
          const ipr::Type& union_type() const final;
          const ipr::Type& enum_type() const final;
          const ipr::Type& namespace_type() const final;
+         const ipr::Type& static_assert_type() const final;
 
          const ipr::Array& get_array(const ipr::Type&, const ipr::Expr&);
 
@@ -2102,6 +2152,7 @@ namespace ipr {
          const impl::Builtin<ipr::As_type> uniontype;
          const impl::Builtin<ipr::As_type> enumtype;
          const impl::Builtin<ipr::As_type> namespacetype;
+         const impl::Builtin<ipr::As_type> staticasserttype;
          const impl::Builtin<ipr::As_type> voidtype;
          const impl::Builtin<ipr::As_type> booltype;
          const impl::Builtin<ipr::As_type> chartype;

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -235,6 +235,7 @@ namespace ipr {
    struct Typedecl;              // declaration for a type
    struct Var;                   // variable declaration
    struct Using_directive;       // using-directive
+   struct Static_assert;         // static_assert-declaration
 
    // ------------------------
    // -- distinguished node --
@@ -1971,6 +1972,12 @@ namespace ipr {
       virtual Optional<Typedecl> definition() const = 0;
    };
 
+                                // -- Static_assert --
+   struct Static_assert : Category<static_assert_cat, Decl> {
+      virtual const Expr& assert_expr() const = 0;
+      virtual Optional<Literal> message() const = 0;
+   };
+
                                 // -- Translation_unit --
    struct Translation_unit {
       struct Visitor;
@@ -2023,6 +2030,7 @@ namespace ipr {
       virtual const Type& union_type() const = 0;
       virtual const Type& enum_type() const = 0;
       virtual const Type& namespace_type() const = 0;
+      virtual const Type& static_assert_type() const = 0;
 
       virtual const Linkage& cxx_linkage() const = 0;
       virtual const Linkage& c_linkage() const = 0;
@@ -2188,6 +2196,7 @@ namespace ipr {
       virtual void visit(const Typedecl&);
       virtual void visit(const Var&);
       virtual void visit(const Asm&);
+      virtual void visit(const Static_assert&);
 
       virtual void visit(const Global_scope&);
       virtual void visit(const Empty_stmt&);

--- a/include/ipr/node-category
+++ b/include/ipr/node-category
@@ -149,7 +149,8 @@ template_cat,                           // ipr::Template
 parameter_cat,                          // ipr::Parameter
 typedecl_cat,                           // ipr::Typedecl
 var_cat,                                // ipr::Var
-using_directive,                        // ipr::Using_directive
+using_directive_cat,                    // ipr::Using_directive
+static_assert_cat,                      // ipr::Static_assert
 
 unit_cat,                               // ipr::Unit
 

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -495,6 +495,36 @@ namespace ipr {
          return *util::check(lexreg);
       }
 
+      // --------------------
+      // -- impl::Static_assert --
+      // --------------------
+
+      Static_assert::Static_assert(const ipr::Type* t, const ipr::Name* n) :
+         barren_decl(t, n), a_expr(0), mes(), lexreg(0)
+      { }
+      
+      const ipr::Expr& Static_assert::assert_expr() const {
+         return *util::check(a_expr);
+      }
+
+      Optional<ipr::Expr> Static_assert::initializer() const {
+         return a_expr;
+      }
+      
+      Optional<ipr::Literal> Static_assert::message() const {
+         return mes;
+      }
+
+      const ipr::Region&
+      Static_assert::lexical_region() const {
+         return *util::check(lexreg);
+      }
+
+      const ipr::Region&
+      Static_assert::home_region() const {
+         return *util::check(lexreg);
+      }
+
       // -----------------
       // -- impl::Block --
       // -----------------
@@ -1247,6 +1277,20 @@ namespace ipr {
             decl = typedecls.redeclare(master);
          add_member(decl);      // remember we saw a declaration.
          return decl;
+      }
+
+      impl::Static_assert*
+      Scope::make_static_assert(Lexicon& lexicon,
+                                const ipr::Expr& e,
+                                Optional<ipr::Literal> message)
+      {
+         impl::Static_assert* stat_assert =
+            static_asserts.make(&lexicon.static_assert_type(),
+                                &lexicon.get_identifier("static_assert"));
+         stat_assert->a_expr = &e;
+         stat_assert->mes = message;
+         
+         return stat_assert;
       }
 
       impl::Fundecl*
@@ -2042,6 +2086,7 @@ namespace ipr {
               uniontype(get_identifier("union"), cxx_linkage(), anytype),
               enumtype(get_identifier("enum"), cxx_linkage(), anytype),
               namespacetype(get_identifier("namespace"), cxx_linkage(), anytype),
+              staticasserttype(get_identifier("static_assert"), cxx_linkage(), anytype),
 
               voidtype(get_identifier("void"), cxx_linkage(), anytype),
               booltype(get_identifier("bool"), cxx_linkage(), anytype),
@@ -2071,6 +2116,7 @@ namespace ipr {
          record_builtin_type(uniontype);
          record_builtin_type(enumtype);
          record_builtin_type(namespacetype);
+         record_builtin_type(staticasserttype);
 
          record_builtin_type(voidtype);
 
@@ -2183,6 +2229,8 @@ namespace ipr {
       const ipr::Type& Lexicon::enum_type() const { return enumtype; }
 
       const ipr::Type& Lexicon::namespace_type() const { return namespacetype; }
+
+      const ipr::Type& Lexicon::static_assert_type() const { return staticasserttype; }
 
       template<class T>
       T* Lexicon::finish_type(T* t) {

--- a/src/traversal.cxx
+++ b/src/traversal.cxx
@@ -864,6 +864,12 @@ ipr::Visitor::visit(const Typedecl& d)
 }
 
 void
+ipr::Visitor::visit(const Static_assert& d)
+{
+   visit(as<Decl>(d));
+}
+
+void
 ipr::Visitor::visit(const Template& d)
 {
    visit(as<Decl>(d));


### PR DESCRIPTION
Static assert syntax: https://eel.is/c++draft/dcl.pre
Static assert elaboration: https://eel.is/c++draft/dcl.pre#6
It can be a class member (without declaring a member): https://eel.is/c++draft/class.mem (https://eel.is/c++draft/class.mem#general-2.4)
It can also be in unions: https://eel.is/c++draft/class.union.anon#1

Cppreference: https://en.cppreference.com/w/cpp/language/static_assert
Clang AST node: https://clang.llvm.org/doxygen/classclang_1_1StaticAssertDecl.html

Note that, since `static_assert` is a declaration, I had to overwrite the `initializer` getter. Strictly speaking, `static_assert` does not have an initializer. For now, I just return the assert expression. Should I return `None` instead?

Also, we did not agree yet what sort of testing do we want, so I did not add tests to this PR yet. But in case you already have something in mind, let me know and I will extend this PR.