### PR TITLE
Remove Node::node_id

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -8,8 +8,6 @@
 #ifndef IPR_IMPL_INCLUDED
 #define IPR_IMPL_INCLUDED
 
-#include <ipr/interface>
-#include <ipr/utility>
 #include <memory>
 #include <list>
 #include <vector>
@@ -17,6 +15,9 @@
 #include <map>
 #include <forward_list>
 #include <variant>
+#include <functional>
+#include <ipr/interface>
+#include <ipr/utility>
 
 // -----------------
 // -- Methodology --
@@ -187,23 +188,17 @@ namespace ipr {
          void accept(ipr::Visitor& v) const final { v.visit(*this); }
       };
 
-      // In various situations, we need to store nodes in ordered
-      // containers.  We could of course use the addresses of Nodes as
-      // keys.  However, for simplicity and persistence reasons, we chose
-      // to used an integer identifier. (Each node  acquires such an
-      // identifier at its creation and retain it unchanged till the
-      // end of the program.)  An obvious benefit is that ordering comes
-      // for free.
       template<typename T,
           typename std::enable_if_t<std::is_scalar_v<T>, int> = 0>
       constexpr int compare(T lhs, T rhs)
       {
-         return lhs < rhs ? -1 : (lhs > rhs ? 1 : 0);
+         constexpr std::less<> lt { };
+         return lt(lhs, rhs) ? -1 : (lt(rhs, lhs) ? 1 : 0);
       }
 
       constexpr int compare(const ipr::Node& lhs, const ipr::Node& rhs)
       {
-         return compare(lhs.node_id, rhs.node_id);
+         return compare(&lhs, &rhs);
       }
 
       // Helper class
@@ -952,7 +947,7 @@ namespace ipr {
          for (int i = 0; i < s; ++i) {
             const typename homogeneous_sequence<Member>::rep&
                decl = decls.seq.get(i);
-            if (decl.name().node_id == n.node_id)
+            if (&decl.name() == &n)
                return decl.overload;
          }
 

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -262,12 +262,6 @@ namespace ipr {
 #include <ipr/node-category>
    };
 
-   // Routines to report statistics about a run of a program.
-   namespace stats {
-      int all_nodes_count();    // count of all nodes 
-      int node_count(Category_code); // count of nodes of a given category
-   }
-
                                 // -- Various Location Types --
    // C++ constructs span locations.  There are at least four flavours of
    // locations:
@@ -311,7 +305,7 @@ namespace ipr {
    template<Category_code Cat, class T = Expr>
    struct Category : T {
    protected:
-      Category() : T(Cat) { }
+      constexpr Category() : T{ Cat } { }
    };
 
                                 // -- Sequence<> --
@@ -587,12 +581,6 @@ namespace ipr {
       // This class does not have a declared virtual destructor
       // because we don't plan to have Nodes manage resources, and
       // therefore no deletion through pointers to this base class.
-
-      const int node_id;        // unique node-identifier in a translation
-                                // unit.  An integer data member is prefered
-                                // over the address of the actual node
-                                // for simplicity and persistency reasons.
-
       
       const Category_code category; // the category the complete node object
                                 // belongs to.  In a sufficiently expressive
@@ -606,7 +594,7 @@ namespace ipr {
 
    protected:
       // It is an error to create a complete object of this type.
-      Node(Category_code);      // Used by derived classes.
+      constexpr Node(Category_code c) : category{ c } { }
    };
 
                                 // -- String --
@@ -673,8 +661,7 @@ namespace ipr {
       virtual const Type& type() const = 0;
 
    protected:
-      Expr(Category_code c) : Node(c)
-      { }
+      constexpr Expr(Category_code c) : Node{ c } { }
    };
 
                                 // -- Classic --
@@ -704,8 +691,7 @@ namespace ipr {
       virtual Optional<Expr> implementation() const = 0;
 
    protected:
-      Classic(Category_code c) : Expr(c)
-      { }
+      constexpr Classic(Category_code c) : Expr{ c } { }
    };
 
                                 // -- Name --
@@ -727,8 +713,7 @@ namespace ipr {
       // imposing too much of implementation details.
 
    protected:
-      Name(Category_code c) : Node{ c }
-      { }
+      constexpr Name(Category_code c) : Node{ c } { }
    };
 
                                 // -- Identifier --
@@ -875,8 +860,7 @@ namespace ipr {
       virtual const Name& name() const = 0;
 
    protected:
-      Type(Category_code c) : Expr(c)
-      { }
+      constexpr Type(Category_code c) : Expr{ c } { }
    };
 
    // cv-qualifiers are actually type operators.  Much of these operators
@@ -1096,8 +1080,7 @@ namespace ipr {
 
    protected:
       // It is an error to create a node of this type.
-      Udt(Category_code c) : Type(c) // Used by derived classes.
-      { }
+      constexpr Udt(Category_code c) : Type{ c } { }
    };
 
                                 // -- Namespace --
@@ -1619,8 +1602,7 @@ namespace ipr {
       virtual const Sequence<Attribute>& attributes() const = 0;
 
    protected:
-      Stmt(Category_code c) : Expr(c)
-      { }
+      constexpr Stmt(Category_code c) : Expr{ c } { }
    };
 
                                 // -- Expr_stmt --
@@ -1881,8 +1863,7 @@ namespace ipr {
       virtual const Sequence<Decl>& decl_set() const = 0;
 
    protected:
-      Decl(Category_code c) : Stmt(c)
-      { }
+      constexpr Decl(Category_code c) : Stmt{ c } { }
    };
 
                                 // -- Template --

--- a/include/ipr/io
+++ b/include/ipr/io
@@ -24,7 +24,7 @@ namespace ipr
    /// is used by XPR parser to relink uses of names to appropriate declarations.
    /// The key of the map is the node_id of the name used, while the value
    /// is the information about corresponding declaration.
-   struct disambiguation_map_type : std::map<int, std::vector<const ipr::Decl*>>
+   struct disambiguation_map_type : std::map<const ipr::Name*, std::vector<const ipr::Decl*>>
    {
       using declarations = std::vector<const ipr::Decl*>;
 
@@ -32,7 +32,7 @@ namespace ipr
       /// or allocates a disambiguation id for them.
       int get_disambiguation(const ipr::Name& name, const ipr::Decl& declaration)
       {
-         declarations& decls = (*this)[name.node_id];
+         declarations& decls = (*this)[&name];
          declarations::const_iterator p = std::find(decls.begin(), decls.end(), &declaration);
 
          if (p == decls.end())

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -844,7 +844,7 @@ namespace ipr {
       inline bool
       operator==(const ipr::Node& lhs, const ipr::Node& rhs)
       {
-         return lhs.node_id == rhs.node_id;
+         return &lhs == &rhs;
       }
 
       struct binary_compare {

--- a/src/interface.cxx
+++ b/src/interface.cxx
@@ -7,30 +7,4 @@
 #include "ipr/interface"
 
 namespace ipr {
-
-   namespace stats {
-      static int node_total_count = 0;
-      static int node_usage_counts[last_code_cat];
-
-      int
-      all_nodes_count()
-      {
-         return node_total_count;
-      }
-
-      int
-      node_count(Category_code c)
-      {
-         // FIXME: check that "c" is in bounds.
-         return node_usage_counts[c];
-      }
-      
-   }
-
-   Node::Node(Category_code c)
-         : node_id(stats::node_total_count++), category(c)
-   {
-      // FIXME: Implement checking of "c".
-      ++stats::node_usage_counts[c];
-   }
 }


### PR DESCRIPTION
The field `Node::node_id` was introduced as a way to aid with persistent storage identification of IPR nodes.  However, with the move towards multiple on-disk projections of IPR nodes and the out-of-date XPR projection, that member is no longer as useful as it used to be.  Furthermore it is not really needed for reproducible IPR node construction.