### PR TITLE
Add accessor for empty String

### DIFF
--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -311,7 +311,7 @@ namespace ipr {
    template<Category_code Cat, class T = Expr>
    struct Category : T {
    protected:
-      Category() : T(Cat) { }
+      constexpr Category() : T(Cat) { }
    };
 
                                 // -- Sequence<> --
@@ -610,13 +610,13 @@ namespace ipr {
    };
 
                                 // -- String --
-   // Strings in IPR are immutable, and therefore unified.  The constitute
-   // the basic building block of many nodes.
+   // Strings in IPR are immutable, and therefore unified.
    struct String : Category<string_cat, Node> {
       using iterator = const char*;
       virtual int size() const = 0;
       virtual iterator begin() const = 0;
       virtual iterator end() const  = 0;
+      static const String& empty_string();            // dedicated node for an empty string
    };
 
                                 // -- Comment --

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -16,6 +16,19 @@
 #include <cstring>
 #include <string>
 namespace ipr {
+   const String& String::empty_string()
+   {
+      struct Empty_string final : impl::Node<String> {
+         int size() const { return 0; }
+         iterator begin() const { return ""; }
+         iterator end() const { return begin(); }
+      };
+
+      constexpr Empty_string empty { };
+      return empty;
+   }
+
+
    namespace impl {
 
       Token::Token(const ipr::String& s, const Source_location& l,


### PR DESCRIPTION
Add a convenience for constructing an empty `String` node.  It is useful for creating declarations that would normally have an `Identifier` name, but may be left missing such as in an unnamed parameter declaration.