### PR TITLE
Commonalize unique_decl::decl_set overrider

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -795,9 +795,10 @@ namespace ipr {
          {
             return *util::check(langlinkage);
          }
+         const ipr::Sequence<ipr::Decl>& decl_set() const final { return overload.seq; }
       };
 
-      struct Parameter : unique_decl<ipr::Parameter> {
+      struct Parameter final : unique_decl<ipr::Parameter> {
          const ipr::Name& id;
          const impl::Rname& abstract_name;
          const ipr::Parameter_list* where;
@@ -809,14 +810,13 @@ namespace ipr {
          const ipr::Type& type() const;
          const ipr::Region& home_region() const;
          const ipr::Region& lexical_region() const;
-         const ipr::Sequence<ipr::Decl>& decl_set() const;
          int position() const;
          Optional<ipr::Expr>initializer() const final;
          // FIXME: This should go away.
          const Parameter_list& membership() const;
       };
 
-      struct Base_type : unique_decl<ipr::Base_type> {
+      struct Base_type final : unique_decl<ipr::Base_type> {
          const ipr::Type& base;
          const ipr::Region& where;
          const int scope_pos;
@@ -827,10 +827,9 @@ namespace ipr {
          const ipr::Region& home_region() const;
          int position() const;
          Optional<ipr::Expr> initializer() const final;
-         const ipr::Sequence<ipr::Decl>& decl_set() const;
       };
 
-      struct Enumerator : unique_decl<ipr::Enumerator> {
+      struct Enumerator final : unique_decl<ipr::Enumerator> {
          const ipr::Name& id;
          const ipr::Enum& constraint;
          const int scope_pos;
@@ -841,7 +840,6 @@ namespace ipr {
          const ipr::Name& name() const;
          const ipr::Region& lexical_region() const;
          const ipr::Region& home_region() const;
-         const ipr::Sequence<ipr::Decl>& decl_set() const;
          int position() const;
          Optional<ipr::Expr> initializer() const final;
          // FIXME: this should go away.

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -24,7 +24,7 @@ namespace ipr {
          iterator end() const { return begin(); }
       };
 
-      constexpr Empty_string empty { };
+      static constexpr Empty_string empty { };
       return empty;
    }
 
@@ -284,11 +284,6 @@ namespace ipr {
          throw std::domain_error("impl::Base_type::initializer");
       }
 
-      const ipr::Sequence<ipr::Decl>&
-      Base_type::decl_set() const {
-         return overload.seq;
-      }
-
       // ----------------------
       // -- impl::Enumerator --
       // ----------------------
@@ -315,11 +310,6 @@ namespace ipr {
       const ipr::Enum&
       Enumerator::membership() const {
          return constraint;
-      }
-
-      const ipr::Sequence<ipr::Decl>&
-      Enumerator::decl_set() const {
-         return overload.seq;
       }
 
       int
@@ -456,11 +446,6 @@ namespace ipr {
       const ipr::Parameter_list&
       Parameter::membership() const {
          return *util::check(where);
-      }
-
-      const ipr::Sequence<ipr::Decl>&
-      Parameter::decl_set() const {
-         return overload.seq;
       }
 
       int


### PR DESCRIPTION
All classes deriving from `unique_decl` have the same functional overrider for `decl_set()` -- by the very semantics of `unique_decl`.  This patch consolidates those overriders at one place.  It also fixes a thinko from last commit.