### PR TITLE
Consolidate factory functions for New

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -1137,11 +1137,11 @@ namespace ipr {
       using Conditional = Ternary<Classic<Expr<ipr::Conditional>>>;
 
       struct New : Classic<Expr<ipr::New>> {
-         const ipr::Expr_list* where;
+         Optional<ipr::Expr_list> where;
          const ipr::Type& what;
-         const ipr::Expr_list* args;
+         Optional<ipr::Expr_list> args;
 
-         New(const ipr::Expr_list*, const ipr::Type&, const ipr::Expr_list*);
+         New(Optional<ipr::Expr_list>, const ipr::Type&, Optional<ipr::Expr_list>);
          Optional<ipr::Expr_list> placement() const final;
          const ipr::Type& allocated_type() const final;
          Optional<ipr::Expr_list> initializer() const final;
@@ -1260,10 +1260,8 @@ namespace ipr {
                                        const ipr::Expr_list&);
          Static_cast* make_static_cast(const ipr::Type&, const ipr::Expr&);
          Binary_fold* make_binary_fold(Category_code, const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
-         New* make_new(const ipr::Type&, Optional<ipr::Type> = {});
-         New* make_new(const ipr::Type&, const ipr::Expr_list&, Optional<ipr::Type> = {});
-         New* make_new(const ipr::Expr_list&, const ipr::Type&,
-                       const ipr::Expr_list&, Optional<ipr::Type> = {});
+         New* make_new(const ipr::Type& allocated, Optional<ipr::Expr_list> init = {},
+                       Optional<Expr_list> placement = {}, Optional<ipr::Type> result = {});
          Conditional* make_conditional(const ipr::Expr&, const ipr::Expr&,
                                        const ipr::Expr&, Optional<ipr::Type> = {});
 

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -58,16 +58,16 @@ namespace ipr {
       };
 
       // -- impl::New --
-      New::New(const ipr::Expr_list* where, const ipr::Type& what,
-               const ipr::Expr_list* args)
+      New::New(Optional<ipr::Expr_list> where, const ipr::Type& what,
+               Optional<ipr::Expr_list> args)
             : where{ where }, what{ what }, args{ args }
       { }
 
-      Optional<ipr::Expr_list> New::placement() const { return { where }; }
+      Optional<ipr::Expr_list> New::placement() const { return where; }
 
       const ipr::Type& New::allocated_type() const { return what; }
 
-      Optional<ipr::Expr_list> New::initializer() const { return { args }; }
+      Optional<ipr::Expr_list> New::initializer() const { return args; }
 
       // -------------------------------------
       // -- master_decl_data<ipr::Template> --
@@ -1989,23 +1989,9 @@ namespace ipr {
       }
 
       impl::New*
-      expr_factory::make_new(const ipr::Type& t, Optional<ipr::Type> result) {
-         impl::New* new_expr = news.make(nullptr, t, nullptr);
-         new_expr->constraint = result;
-         return new_expr;
-      }
-
-      impl::New*
-      expr_factory::make_new(const ipr::Type& t, const ipr::Expr_list& i, Optional<ipr::Type> result) {
-         impl::New* new_expr = news.make(nullptr, t, &i);
-         new_expr->constraint = result;
-         return new_expr;
-      }
-
-      impl::New*
-      expr_factory::make_new(const ipr::Expr_list& p, const ipr::Type& t,
-                             const ipr::Expr_list& i, Optional<ipr::Type> result) {
-         impl::New* new_expr = news.make(&p, t, &i);
+      expr_factory::make_new(const ipr::Type& allocated, Optional<ipr::Expr_list> init,
+                       Optional<Expr_list> placement, Optional<ipr::Type> result) {
+         impl::New* new_expr = news.make(placement, allocated, init);
          new_expr->constraint = result;
          return new_expr;
       }


### PR DESCRIPTION
Currently, we have 3 factory functions for new, but they do not cover one use case: having placement arguments but not having initializers. We have 2 options, either add a 4th factory, or consolidate factory functions to have one of them. I went with latter as I believe it makes creating New nodes easier (we do not need to have 4 code paths). Let me know if other solution is preferred.