### PR TITLE
Make Bitfield::membership return type more strict

### DIFF
--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -1962,7 +1962,7 @@ namespace ipr {
    // A bit-field data member.
    struct Bitfield : Category<bitfield_cat, Decl> {
       virtual const Expr& precision() const = 0;
-      virtual const Type& membership() const = 0;
+      virtual const Udt<Decl>& membership() const = 0;
    };
 
                                 // -- Typedecl --


### PR DESCRIPTION
I made `ipr::Bitfield::membership` return the same type that is implied by `impl::Bitfield::membership`. As far as I understand, since we only have one implementation for each interface node, there is no reason to for these two return types to diverge on the interface level (unless we want the implementation nodes to point to the other implementation nodes instead of the interface nodes). Please correct me if I am wrong.