### PR TITLE
Added conversion nodes and demonstrative tests.

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -1017,6 +1017,7 @@ namespace ipr {
       using Array_delete = Classic_unary_expr<ipr::Array_delete>;
       using Complement = Classic_unary_expr<ipr::Complement>;
       using Delete = Classic_unary_expr<ipr::Delete>;
+      using Demote = Unary_expr<ipr::Demote>;
       using Deref = Classic_unary_expr<ipr::Deref>;
 
       struct Expr_list : impl::Node<ipr::Expr_list> {
@@ -1049,6 +1050,7 @@ namespace ipr {
          Optional<ipr::Expr> resolution() const final;
       };
 
+      using Materialize = Classic_unary_expr<ipr::Materialize>;
       using Not = Classic_unary_expr<ipr::Not>;
 
       using Paren_expr = type_from_operand<Classic<Node<ipr::Paren_expr>>>;
@@ -1057,6 +1059,8 @@ namespace ipr {
       using Pre_increment = Classic_unary_expr<ipr::Pre_increment>;
       using Post_decrement = Classic_unary_expr<ipr::Post_decrement>;
       using Post_increment = Classic_unary_expr<ipr::Post_increment>;
+      using Promote = Unary_expr<ipr::Promote>;
+      using Read = Unary_expr<ipr::Read>;
       using Throw = Classic_unary_expr<ipr::Throw>;
 
       using Unary_minus = Classic_unary_expr<ipr::Unary_minus>;
@@ -1126,12 +1130,24 @@ namespace ipr {
       using Scope_ref = Classic_binary_expr<ipr::Scope_ref>;
       using Static_cast = Conversion_expr<ipr::Static_cast>;
       using Template_id = Binary_node<ipr::Template_id>;
+      using Qualification = Binary_expr<ipr::Qualification>;
 
       struct Binary_fold : Classic_binary_expr<ipr::Binary_fold> {
          Category_code fold_op;
 
          Binary_fold(Category_code, const ipr::Expr&, const ipr::Expr&);
          Category_code operation() const final;
+      };
+
+      struct Coerce : Expr<ipr::Coerce> {
+         const ipr::Type& target_type;
+         const ipr::Expr& expression;
+         const ipr::Expr* impl;
+
+         Coerce(const ipr::Type&, const ipr::Expr&);
+         const ipr::Type& target() const final;
+         const ipr::Expr& expr() const final;
+         Optional<ipr::Expr> implementation() const final;
       };
 
       using Conditional = Ternary<Classic<Expr<ipr::Conditional>>>;
@@ -1191,6 +1207,7 @@ namespace ipr {
          Conversion* make_conversion(const ipr::Type&);
          Ctor_name* make_ctor_name(const ipr::Type&);
          Delete* make_delete(const ipr::Expr&);
+         Demote* make_demote(const ipr::Expr&, Optional<ipr::Type> = {});
          Deref* make_deref(const ipr::Expr&, Optional<ipr::Type> = {});
          Dtor_name* make_dtor_name(const ipr::Type&);
          Expr_list* make_expr_list();
@@ -1200,12 +1217,15 @@ namespace ipr {
          impl::Id_expr* make_id_expr(const ipr::Name&, Optional<ipr::Type> = {});
          Id_expr* make_id_expr(const ipr::Decl&);
          Label* make_label(const ipr::Identifier&, Optional<ipr::Type> = {});
+         Materialize* make_materialize(const ipr::Expr&, Optional<ipr::Type> = {});
          Not* make_not(const ipr::Expr&, Optional<ipr::Type> = {});
          Paren_expr* make_paren_expr(const ipr::Expr&);
          Post_increment* make_post_increment(const ipr::Expr&, Optional<ipr::Type> = {});
          Post_decrement* make_post_decrement(const ipr::Expr&, Optional<ipr::Type> = {});
          Pre_increment* make_pre_increment(const ipr::Expr&, Optional<ipr::Type> = {});
          Pre_decrement* make_pre_decrement(const ipr::Expr&, Optional<ipr::Type> = {});
+         Promote* make_promote(const ipr::Expr&, Optional<ipr::Type> = {});
+         Read* make_read(const ipr::Expr&, Optional<ipr::Type> = {});
          Throw* make_throw(const ipr::Expr&, Optional<ipr::Type> = {});
          Type_id* make_type_id(const ipr::Type&);
          Unary_minus* make_unary_minus(const ipr::Expr&, Optional<ipr::Type> = {});
@@ -1225,6 +1245,7 @@ namespace ipr {
          Bitxor_assign* make_bitxor_assign(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
          Cast* make_cast(const ipr::Type&, const ipr::Expr&);
          Call* make_call(const ipr::Expr&, const ipr::Expr_list&, Optional<ipr::Type> = {});
+         Coerce* make_coerce(const ipr::Type&, const ipr::Expr&, Optional<ipr::Type> = {});
          Comma* make_comma(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
          Const_cast* make_const_cast(const ipr::Type&, const ipr::Expr&);
          Datum* make_datum(const ipr::Type&, const ipr::Expr_list&);
@@ -1259,6 +1280,7 @@ namespace ipr {
          Template_id* make_template_id(const ipr::Name&,
                                        const ipr::Expr_list&);
          Static_cast* make_static_cast(const ipr::Type&, const ipr::Expr&);
+         Qualification* make_qualification(const ipr::Type&, const ipr::Expr&, Optional<ipr::Type> = {});
          Binary_fold* make_binary_fold(Category_code, const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
          New* make_new(const ipr::Type&, Optional<ipr::Type> = {});
          New* make_new(const ipr::Type&, const ipr::Expr_list&, Optional<ipr::Type> = {});
@@ -1300,17 +1322,20 @@ namespace ipr {
          stable_farm<impl::Array_delete> array_deletes;
          stable_farm<impl::Complement> complements;
          stable_farm<impl::Delete> deletes;
+         stable_farm<impl::Demote> demotes;
          stable_farm<impl::Deref> derefs;
          stable_farm<impl::Expr_list> xlists;
          stable_farm<impl::Id_expr> id_exprs;
          stable_farm<impl::Initializer_list> init_lists;
          stable_farm<impl::Label> labels;
          stable_farm<impl::Not> nots;
+         stable_farm<impl::Paren_expr> parens;
          stable_farm<impl::Pre_increment> pre_increments;
          stable_farm<impl::Pre_decrement> pre_decrements;
          stable_farm<impl::Post_increment> post_increments;
          stable_farm<impl::Post_decrement> post_decrements;
-         stable_farm<impl::Paren_expr> parens;
+         stable_farm<impl::Promote> promotes;
+         stable_farm<impl::Read> reads;
          stable_farm<impl::Throw> throws;
          stable_farm<impl::Unary_minus> unary_minuses;
          stable_farm<impl::Unary_plus> unary_pluses;
@@ -1360,9 +1385,11 @@ namespace ipr {
          stable_farm<impl::Rshift> rshifts;
          stable_farm<impl::Rshift_assign> rshift_assigns;
          stable_farm<impl::Static_cast> scasts;
+         stable_farm<impl::Qualification> qualifications;
          stable_farm<impl::Binary_fold> folds;
          
          stable_farm<impl::New> news;
+         stable_farm<impl::Coerce> coerces;
          stable_farm<impl::Conditional> conds;
          stable_farm<impl::Mapping> mappings;
 

--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -1050,7 +1050,7 @@ namespace ipr {
          Optional<ipr::Expr> resolution() const final;
       };
 
-      using Materialize = Classic_unary_expr<ipr::Materialize>;
+      using Materialize = Unary_expr<ipr::Materialize>;
       using Not = Classic_unary_expr<ipr::Not>;
 
       using Paren_expr = type_from_operand<Classic<Node<ipr::Paren_expr>>>;

--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -1235,7 +1235,7 @@ namespace ipr {
          Bitxor_assign* make_bitxor_assign(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
          Cast* make_cast(const ipr::Type&, const ipr::Expr&);
          Call* make_call(const ipr::Expr&, const ipr::Expr_list&, Optional<ipr::Type> = {});
-         Coerce* make_coerce(const ipr::Type&, const ipr::Expr&, Optional<ipr::Type> = {});
+         Coerce* make_coerce(const ipr::Expr&, const ipr::Type&, const ipr::Type&);
          Comma* make_comma(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
          Const_cast* make_const_cast(const ipr::Type&, const ipr::Expr&);
          Datum* make_datum(const ipr::Type&, const ipr::Expr_list&);

--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -1081,6 +1081,7 @@ namespace ipr {
       using Bitxor_assign = Classic_binary_expr<ipr::Bitxor_assign>;
       using Call = Classic_binary_expr<ipr::Call>;
       using Cast = Conversion_expr<ipr::Cast>;
+      using Coerce = Classic_binary_expr<ipr::Coerce>;
       using Comma = Classic_binary_expr<ipr::Comma>;
       using Const_cast = Conversion_expr<ipr::Const_cast>;
       using Datum = Conversion_expr<ipr::Datum>;
@@ -1137,17 +1138,6 @@ namespace ipr {
 
          Binary_fold(Category_code, const ipr::Expr&, const ipr::Expr&);
          Category_code operation() const final;
-      };
-
-      struct Coerce : Expr<ipr::Coerce> {
-         const ipr::Type& target_type;
-         const ipr::Expr& expression;
-         const ipr::Expr* impl;
-
-         Coerce(const ipr::Type&, const ipr::Expr&);
-         const ipr::Type& target() const final;
-         const ipr::Expr& expr() const final;
-         Optional<ipr::Expr> implementation() const final;
       };
 
       using Conditional = Ternary<Classic<Expr<ipr::Conditional>>>;
@@ -1207,7 +1197,7 @@ namespace ipr {
          Conversion* make_conversion(const ipr::Type&);
          Ctor_name* make_ctor_name(const ipr::Type&);
          Delete* make_delete(const ipr::Expr&);
-         Demote* make_demote(const ipr::Expr&, Optional<ipr::Type> = {});
+         Demote* make_demote(const ipr::Expr&, const ipr::Type&);
          Deref* make_deref(const ipr::Expr&, Optional<ipr::Type> = {});
          Dtor_name* make_dtor_name(const ipr::Type&);
          Expr_list* make_expr_list();
@@ -1217,15 +1207,15 @@ namespace ipr {
          impl::Id_expr* make_id_expr(const ipr::Name&, Optional<ipr::Type> = {});
          Id_expr* make_id_expr(const ipr::Decl&);
          Label* make_label(const ipr::Identifier&, Optional<ipr::Type> = {});
-         Materialize* make_materialize(const ipr::Expr&, Optional<ipr::Type> = {});
+         Materialize* make_materialize(const ipr::Expr&, const ipr::Type&);
          Not* make_not(const ipr::Expr&, Optional<ipr::Type> = {});
          Paren_expr* make_paren_expr(const ipr::Expr&);
          Post_increment* make_post_increment(const ipr::Expr&, Optional<ipr::Type> = {});
          Post_decrement* make_post_decrement(const ipr::Expr&, Optional<ipr::Type> = {});
          Pre_increment* make_pre_increment(const ipr::Expr&, Optional<ipr::Type> = {});
          Pre_decrement* make_pre_decrement(const ipr::Expr&, Optional<ipr::Type> = {});
-         Promote* make_promote(const ipr::Expr&, Optional<ipr::Type> = {});
-         Read* make_read(const ipr::Expr&, Optional<ipr::Type> = {});
+         Promote* make_promote(const ipr::Expr&, const ipr::Type&);
+         Read* make_read(const ipr::Expr&, const ipr::Type&);
          Throw* make_throw(const ipr::Expr&, Optional<ipr::Type> = {});
          Type_id* make_type_id(const ipr::Type&);
          Unary_minus* make_unary_minus(const ipr::Expr&, Optional<ipr::Type> = {});
@@ -1280,7 +1270,7 @@ namespace ipr {
          Template_id* make_template_id(const ipr::Name&,
                                        const ipr::Expr_list&);
          Static_cast* make_static_cast(const ipr::Type&, const ipr::Expr&);
-         Qualification* make_qualification(const ipr::Type&, const ipr::Expr&, Optional<ipr::Type> = {});
+         Qualification* make_qualification(const ipr::Expr&, ipr::Type_qualifier, const ipr::Type&);
          Binary_fold* make_binary_fold(Category_code, const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
          New* make_new(const ipr::Type&, Optional<ipr::Type> = {});
          New* make_new(const ipr::Type&, const ipr::Expr_list&, Optional<ipr::Type> = {});
@@ -1328,6 +1318,7 @@ namespace ipr {
          stable_farm<impl::Id_expr> id_exprs;
          stable_farm<impl::Initializer_list> init_lists;
          stable_farm<impl::Label> labels;
+         stable_farm<impl::Materialize> materializes;
          stable_farm<impl::Not> nots;
          stable_farm<impl::Paren_expr> parens;
          stable_farm<impl::Pre_increment> pre_increments;

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -1393,9 +1393,9 @@ namespace ipr {
    // A generalized type conversion either built-in to the language or
    // programmatically defined by either constructors or conversion
    // functions.
-   struct Coerce : Binary<Category<conditional_cat, Classic>, const Type&> {
-      Arg1_type target() const { return first(); }
-      Arg2_type expr() const { return second(); }
+   struct Coerce : Binary<Category<conditional_cat, Classic>, const Expr&, const Type&> {
+      Arg1_type expr() const { return first(); }
+      Arg2_type target() const { return second(); }
    };
 
                                 // -- Comma --

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -124,6 +124,7 @@ namespace ipr {
    struct Array_delete;          // array delete-expression     delete[] p
    struct Complement;            // bitwise complement                  ~m
    struct Delete;                // delete-expression             delete p
+   struct Demote;                // integral or floating-point conversion
    struct Deref;                 // dereference expression              *p
    struct Expr_list;             // expression list        
    struct Sizeof;                // sizeof expression: sizeof *p or sizeof(int)
@@ -131,12 +132,15 @@ namespace ipr {
    struct Id_expr;               // an identifier used in an expression
    struct Label;                 // a label - target of a goto-statement
                                  //         or entry of a switch-statement
+   struct Materialize;           // temporary materialization        T().m
    struct Not;                   // logical negation                 !cond
    struct Paren_expr;            // parenthesized expression           (a)
    struct Post_decrement;        // post-increment                     p++
    struct Post_increment;        // post-decrement                     p--
    struct Pre_decrement;         // pre-increment                      ++p
    struct Pre_increment;         // pre-decrement                      --p
+   struct Promote;               // integral or floating-point promotion
+   struct Read;                  // lvalue to rvalue conversion      = var
    struct Throw;                 // throw expression           throw Bad()
    struct Unary_minus;           // unary minus                         -a
    struct Unary_plus;            // unary plus                          +a
@@ -190,6 +194,7 @@ namespace ipr {
    struct Rshift;                // right shift                    a >> b
    struct Rshift_assign;         // in-place right shift           a >>= b
    struct Static_cast;           // static-cast            static_cast<T>(v)
+   struct Qualification;         // implicit cv-qualification
    struct Binary_fold;           // Primary expression of the form (a op ... op b)
 
    struct Mapping;               // function
@@ -198,6 +203,7 @@ namespace ipr {
    // -- result of trinary expression constructor constants --
    // --------------------------------------------------------
    struct New;                   // new-expression              new (p) T(v)
+   struct Coerce;                // implicit conversions not promotion or demotion
    struct Conditional;           // conditional                   p ? a : b
 
    // -----------------------------------------------
@@ -806,7 +812,7 @@ namespace ipr {
    struct Rname : Ternary<Category<rname_cat, Name>, const Type&, int, int> {
       // Although the type() of an Rname is its first operand, we don't define
       // that function here, for it would involve a two indirections to
-      // to give the result.  Consequently we define it in the implemenation
+      // to give the result.  Consequently we define it in the implementation
       // part.
       // pmp: swapped level and position to return 2nd and 3rd
       Arg2_type level() const { return second(); }
@@ -1167,6 +1173,10 @@ namespace ipr {
       const Expr& storage() const { return operand(); }
    };
 
+                                   // -- Demote --
+   // Integral or floating point conversion -- "(float)2.2"
+   struct Demote : Unary<Category<demote_cat>> { };
+
                                 // -- Deref --
    // Dereference-expression -- "*expr"
    struct Deref : Unary<Category<deref_cat, Classic>> { };
@@ -1219,6 +1229,10 @@ namespace ipr {
       Arg_type name() const { return operand(); }
    };
 
+                                // -- Materialize --
+   // Temporary materialization -- "T().m"
+   struct Materialize : Unary<Category<materialize_cat>> { };
+
                                 // -- Not --
    // logical-not-expression -- "!expr"
    struct Not : Unary<Category<not_cat, Classic>> { };
@@ -1238,6 +1252,14 @@ namespace ipr {
                                 // -- Pre_increment --
    // pre-increment-expression -- "++expr".
    struct Pre_increment : Unary<Category<pre_increment_cat, Classic>> { };
+
+                                // -- Promote --
+   // Integral or floating point promotion -- "(int)'2'"
+   struct Promote : Unary<Category<promote_cat>> { };
+
+                                // -- Read --
+   // Lvalue-to-rvalue conversion -- "= var"
+   struct Read : Unary<Category<read_cat>> { };
 
                                 // -- Throw --
    // A node that represents a C++ expression of the form `throw ex'.
@@ -1526,6 +1548,13 @@ namespace ipr {
    // An expression of the form "static_cast<type>(expr)".
    struct Static_cast : Cast_expr<static_cast_cat> { };
 
+                                   // -- Qualification --
+   // Implicit conversions that add cv-qualifiers
+   struct Qualification : Binary<Category<qualified_cat>, const Type&> {
+      Arg1_type target() const { return first(); }
+      Arg2_type expr() const { return second(); }
+   };
+
                                 // -- New --
    // This node represents a new-expression:
    //    ::_opt new new-placement_opt new-type-id new-initializer_opt
@@ -1534,6 +1563,14 @@ namespace ipr {
       virtual Optional<Expr_list> placement() const = 0;
       virtual const Type& allocated_type() const = 0;
       virtual Optional<Expr_list> initializer() const = 0;
+   };
+
+                                   // -- Coerce --
+   // Implicit conversions that are not promotions or demotions
+   struct Coerce : Category<conditional_cat> {
+      virtual const Type& target() const = 0;
+      virtual const Expr& expr() const = 0;
+      virtual Optional<Expr> implementation() const = 0;
    };
 
                                 // -- Conditional --
@@ -2094,6 +2131,7 @@ namespace ipr {
       virtual void visit(const Array_delete&); 
       virtual void visit(const Complement&); 
       virtual void visit(const Delete&); 
+      virtual void visit(const Demote&);
       virtual void visit(const Deref&);
       virtual void visit(const Paren_expr&);
       virtual void visit(const Sizeof&);
@@ -2102,10 +2140,13 @@ namespace ipr {
       virtual void visit(const Id_expr&);
       virtual void visit(const Label&);
       virtual void visit(const Not&); 
+      virtual void visit(const Materialize&);
       virtual void visit(const Post_decrement&);
       virtual void visit(const Post_increment&); 
       virtual void visit(const Pre_decrement&); 
       virtual void visit(const Pre_increment&); 
+      virtual void visit(const Promote&);
+      virtual void visit(const Read&);
       virtual void visit(const Throw&);
       virtual void visit(const Unary_minus&); 
       virtual void visit(const Unary_plus&);
@@ -2125,6 +2166,7 @@ namespace ipr {
       virtual void visit(const Bitxor_assign&);
       virtual void visit(const Cast&); 
       virtual void visit(const Call&); 
+      virtual void visit(const Coerce&);
       virtual void visit(const Comma&);
       virtual void visit(const Const_cast&); 
       virtual void visit(const Datum&); 
@@ -2157,6 +2199,7 @@ namespace ipr {
       virtual void visit(const Rshift_assign&);
       virtual void visit(const Static_cast&);
       virtual void visit(const Binary_fold&);
+      virtual void visit(const Qualification&);
 
       virtual void visit(const Conditional&);
       virtual void visit(const New&);

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -124,7 +124,8 @@ namespace ipr {
    struct Array_delete;          // array delete-expression     delete[] p
    struct Complement;            // bitwise complement                  ~m
    struct Delete;                // delete-expression             delete p
-   struct Demote;                // integral or floating-point conversion
+   struct Demote;                // inverse of an integral or floating-point
+                                 // promotion
    struct Deref;                 // dereference expression              *p
    struct Expr_list;             // expression list        
    struct Sizeof;                // sizeof expression: sizeof *p or sizeof(int)
@@ -132,7 +133,7 @@ namespace ipr {
    struct Id_expr;               // an identifier used in an expression
    struct Label;                 // a label - target of a goto-statement
                                  //         or entry of a switch-statement
-   struct Materialize;           // temporary materialization        T().m
+   struct Materialize;           // temporary materialization
    struct Not;                   // logical negation                 !cond
    struct Paren_expr;            // parenthesized expression           (a)
    struct Post_decrement;        // post-increment                     p++
@@ -140,7 +141,7 @@ namespace ipr {
    struct Pre_decrement;         // pre-increment                      ++p
    struct Pre_increment;         // pre-decrement                      --p
    struct Promote;               // integral or floating-point promotion
-   struct Read;                  // lvalue to rvalue conversion      = var
+   struct Read;                  // lvalue to rvalue conversion
    struct Throw;                 // throw expression           throw Bad()
    struct Unary_minus;           // unary minus                         -a
    struct Unary_plus;            // unary plus                          +a
@@ -164,6 +165,7 @@ namespace ipr {
    struct Bitxor_assign;         // in-place bitwise exclusive or  a ^= b
    struct Call;                  // function call                  f(u, v)
    struct Cast;                  // C-style class                  (T) e
+   struct Coerce;                // generalized type conversion
    struct Comma;                 // comma-operator                 a, b
    struct Const_cast;            // const-cast             const_cast<T&>(v)
    struct Datum;                 // object construction             T(v)
@@ -194,7 +196,7 @@ namespace ipr {
    struct Rshift;                // right shift                    a >> b
    struct Rshift_assign;         // in-place right shift           a >>= b
    struct Static_cast;           // static-cast            static_cast<T>(v)
-   struct Qualification;         // implicit cv-qualification
+   struct Qualification;         // cv-qualification conversion
    struct Binary_fold;           // Primary expression of the form (a op ... op b)
 
    struct Mapping;               // function
@@ -203,7 +205,6 @@ namespace ipr {
    // -- result of trinary expression constructor constants --
    // --------------------------------------------------------
    struct New;                   // new-expression              new (p) T(v)
-   struct Coerce;                // implicit conversions not promotion or demotion
    struct Conditional;           // conditional                   p ? a : b
 
    // -----------------------------------------------
@@ -1174,7 +1175,7 @@ namespace ipr {
    };
 
                                    // -- Demote --
-   // Integral or floating point conversion -- "(float)2.2"
+   // Integral or floating point conversion
    struct Demote : Unary<Category<demote_cat>> { };
 
                                 // -- Deref --
@@ -1230,7 +1231,7 @@ namespace ipr {
    };
 
                                 // -- Materialize --
-   // Temporary materialization -- "T().m"
+   // Temporary materialization
    struct Materialize : Unary<Category<materialize_cat>> { };
 
                                 // -- Not --
@@ -1386,6 +1387,15 @@ namespace ipr {
                          const Expr&, const Expr_list&> {
       Arg1_type function() const  { return first(); }
       Arg2_type args() const { return second(); }
+   };
+
+                                // -- Coerce --
+   // A generalized type conversion either built-in to the language or
+   // programmatically defined by either constructors or conversion
+   // functions.
+   struct Coerce : Binary<Category<conditional_cat, Classic>, const Type&> {
+      Arg1_type target() const { return first(); }
+      Arg2_type expr() const { return second(); }
    };
 
                                 // -- Comma --
@@ -1549,10 +1559,10 @@ namespace ipr {
    struct Static_cast : Cast_expr<static_cast_cat> { };
 
                                    // -- Qualification --
-   // Implicit conversions that add cv-qualifiers
-   struct Qualification : Binary<Category<qualified_cat>, const Type&> {
-      Arg1_type target() const { return first(); }
-      Arg2_type expr() const { return second(); }
+   // A conversion that add cv-qualifiers
+   struct Qualification : Binary<Category<qualified_cat>, const Expr&, Type_qualifier> {
+      Arg1_type expr() const { return first(); }
+      Arg2_type qualifier() const { return second(); }
    };
 
                                 // -- New --
@@ -1563,14 +1573,6 @@ namespace ipr {
       virtual Optional<Expr_list> placement() const = 0;
       virtual const Type& allocated_type() const = 0;
       virtual Optional<Expr_list> initializer() const = 0;
-   };
-
-                                   // -- Coerce --
-   // Implicit conversions that are not promotions or demotions
-   struct Coerce : Category<conditional_cat> {
-      virtual const Type& target() const = 0;
-      virtual const Expr& expr() const = 0;
-      virtual Optional<Expr> implementation() const = 0;
    };
 
                                 // -- Conditional --

--- a/include/ipr/node-category
+++ b/include/ipr/node-category
@@ -51,18 +51,22 @@ address_cat,                            // ipr::Address
 array_delete_cat,                       // ipr::Array_delete
 complement_cat,                         // ipr::Complement
 delete_cat,                             // ipr::Delete
+demote_cat,                             // ipr::Demote
 deref_cat,                              // ipr::Deref
 expr_list_cat,                          // ipr::Expr_list
 sizeof_cat,                             // ipr::Sizeof
 typeid_cat,                             // ipr::Typeid
 id_expr_cat,                            // ipr::Id_expr
 label_cat,                              // ipr::Label
+materialize_cat,                        // ipr::Materialize
 not_cat,                                // ipr::Not
 paren_expr_cat,                         // ipr::Paren_expr
 post_decrement_cat,                     // ipr::Post_decrement
 post_increment_cat,                     // ipr::Post_increment
 pre_decrement_cat,                      // ipr::Pre_decrement
 pre_increment_cat,                      // ipr::Pre_increment
+promote_cat,                            // ipr::Promote
+read_cat,                               // ipr::Read
 throw_cat,                              // ipr::Throw
 unary_minus_cat,                        // ipr::Unary_minus
 unary_plus_cat,                         // ipr::Unary_plus;
@@ -116,8 +120,10 @@ static_cast_cat,                        // ipr::Static_cast
 minus_cat,                              // ipr::Minus
 minus_assign_cat,                       // ipr::Minus_assign
 binary_fold_cat,                        // ipr::Binary_fold
+qualification_cat,                      // ipr::Qualification
 
 new_cat,                                // ipr::New
+coerce_cat,                             // ipr::Coerce
 conditional_cat,                        // ipr::Conditional
 scope_cat,                              // ipr::Scope
 

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -57,6 +57,16 @@ namespace ipr {
          }
       };
 
+      Coerce::Coerce(const ipr::Type& type, const ipr::Expr& expr)
+            : target_type{ type }, expression{ expr }
+      { }
+
+      const ipr::Type& Coerce::target() const { return target_type; }
+
+      const ipr::Expr& Coerce::expr() const { return expression; }
+
+      Optional<ipr::Expr> Coerce::implementation() const { return { impl }; }
+
       // -- impl::New --
       New::New(const ipr::Expr_list* where, const ipr::Type& what,
                const ipr::Expr_list* args)
@@ -1479,6 +1489,13 @@ namespace ipr {
          return deletes.make(e);
       }
 
+      impl::Demote*
+      expr_factory::make_demote(const ipr::Expr& e, Optional<ipr::Type> result) {
+         impl::Demote* demote_expr = demotes.make(e);
+         demote_expr->constraint = result;
+         return demote_expr;
+      }
+
       impl::Deref*
       expr_factory::make_deref(const ipr::Expr& e, Optional<ipr::Type> result) {
          impl::Deref* deref = derefs.make(e);
@@ -1603,6 +1620,20 @@ namespace ipr {
          Pre_decrement* dec = pre_decrements.make(e);
          dec->constraint = result;
          return dec;
+      }
+
+      impl::Promote*
+      expr_factory::make_promote(const ipr::Expr& e, Optional<ipr::Type> result) {
+         impl::Promote* promote_expr = promotes.make(e);
+         promote_expr->constraint = result;
+         return promote_expr;
+      }
+
+      impl::Read*
+      expr_factory::make_read(const ipr::Expr& e, Optional<ipr::Type> result) {
+         impl::Read* read_expr = reads.make(e);
+         read_expr->constraint = result;
+         return read_expr;
       }
 
       impl::Throw*
@@ -1980,6 +2011,13 @@ namespace ipr {
          return scasts.make(t, e);
       }
 
+      impl::Qualification*
+      expr_factory::make_qualification(const ipr::Type& t, const ipr::Expr& e, Optional<ipr::Type> result) {
+         impl::Qualification* qualification = qualifications.make(t, e);
+         qualification->constraint = result;
+         return qualification;
+      }
+
       impl::Binary_fold*
       expr_factory::make_binary_fold(Category_code op, const ipr::Expr& l, const ipr::Expr& r, Optional<ipr::Type> result)
       {
@@ -2008,6 +2046,13 @@ namespace ipr {
          impl::New* new_expr = news.make(&p, t, &i);
          new_expr->constraint = result;
          return new_expr;
+      }
+
+      impl::Coerce*
+      expr_factory::make_coerce(const ipr::Type& t, const ipr::Expr& e, Optional<ipr::Type> result) {
+         impl::Coerce* coerce_expr = coerces.make(t, e);
+         coerce_expr->constraint = result;
+         return coerce_expr;
       }
 
       impl::Conditional*

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -57,16 +57,6 @@ namespace ipr {
          }
       };
 
-      Coerce::Coerce(const ipr::Type& type, const ipr::Expr& expr)
-            : target_type{ type }, expression{ expr }
-      { }
-
-      const ipr::Type& Coerce::target() const { return target_type; }
-
-      const ipr::Expr& Coerce::expr() const { return expression; }
-
-      Optional<ipr::Expr> Coerce::implementation() const { return { impl }; }
-
       // -- impl::New --
       New::New(const ipr::Expr_list* where, const ipr::Type& what,
                const ipr::Expr_list* args)
@@ -1490,9 +1480,9 @@ namespace ipr {
       }
 
       impl::Demote*
-      expr_factory::make_demote(const ipr::Expr& e, Optional<ipr::Type> result) {
+      expr_factory::make_demote(const ipr::Expr& e, const ipr::Type& result) {
          impl::Demote* demote_expr = demotes.make(e);
-         demote_expr->constraint = result;
+         demote_expr->constraint = &result;
          return demote_expr;
       }
 
@@ -1567,6 +1557,13 @@ namespace ipr {
          return label;
       }
 
+      Materialize*
+      expr_factory::make_materialize(const ipr::Expr& e, const ipr::Type& result) {
+         impl::Materialize* materialize = materializes.make(e);
+         materialize->constraint = &result;
+         return materialize;
+      }
+
       impl::Not*
       expr_factory::make_not(const ipr::Expr& e, Optional<ipr::Type> result) {
          impl::Not* not_expr = nots.make(e);
@@ -1623,16 +1620,16 @@ namespace ipr {
       }
 
       impl::Promote*
-      expr_factory::make_promote(const ipr::Expr& e, Optional<ipr::Type> result) {
+      expr_factory::make_promote(const ipr::Expr& e, const ipr::Type& result) {
          impl::Promote* promote_expr = promotes.make(e);
-         promote_expr->constraint = result;
+         promote_expr->constraint = &result;
          return promote_expr;
       }
 
       impl::Read*
-      expr_factory::make_read(const ipr::Expr& e, Optional<ipr::Type> result) {
+      expr_factory::make_read(const ipr::Expr& e, const ipr::Type& result) {
          impl::Read* read_expr = reads.make(e);
-         read_expr->constraint = result;
+         read_expr->constraint = &result;
          return read_expr;
       }
 
@@ -1769,6 +1766,13 @@ namespace ipr {
          impl::Call* call = calls.make(l, r);
          call->constraint = result;
          return call;
+      }
+
+      impl::Coerce*
+      expr_factory::make_coerce(const ipr::Type& t, const ipr::Expr& e, Optional<ipr::Type> result) {
+         impl::Coerce* coerce_expr = coerces.make(t, e);
+         coerce_expr->constraint = result;
+         return coerce_expr;
       }
 
       impl::Comma*
@@ -2012,9 +2016,9 @@ namespace ipr {
       }
 
       impl::Qualification*
-      expr_factory::make_qualification(const ipr::Type& t, const ipr::Expr& e, Optional<ipr::Type> result) {
-         impl::Qualification* qualification = qualifications.make(t, e);
-         qualification->constraint = result;
+      expr_factory::make_qualification(const ipr::Expr& e, ipr::Type_qualifier q, const ipr::Type& result) {
+         impl::Qualification* qualification = qualifications.make(e, q);
+         qualification->constraint = &result;
          return qualification;
       }
 
@@ -2046,13 +2050,6 @@ namespace ipr {
          impl::New* new_expr = news.make(&p, t, &i);
          new_expr->constraint = result;
          return new_expr;
-      }
-
-      impl::Coerce*
-      expr_factory::make_coerce(const ipr::Type& t, const ipr::Expr& e, Optional<ipr::Type> result) {
-         impl::Coerce* coerce_expr = coerces.make(t, e);
-         coerce_expr->constraint = result;
-         return coerce_expr;
       }
 
       impl::Conditional*

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -1769,9 +1769,9 @@ namespace ipr {
       }
 
       impl::Coerce*
-      expr_factory::make_coerce(const ipr::Type& t, const ipr::Expr& e, Optional<ipr::Type> result) {
-         impl::Coerce* coerce_expr = coerces.make(t, e);
-         coerce_expr->constraint = result;
+      expr_factory::make_coerce(const ipr::Expr& e, const ipr::Type& t, const ipr::Type& result) {
+         impl::Coerce* coerce_expr = coerces.make(e, t);
+         coerce_expr->constraint = &result;
          return coerce_expr;
       }
 

--- a/src/traversal.cxx
+++ b/src/traversal.cxx
@@ -319,6 +319,12 @@ ipr::Visitor::visit(const Delete& e)
 }
 
 void
+ipr::Visitor::visit(const Demote& e)
+{
+   visit(as<Expr>(e));
+}
+
+void
 ipr::Visitor::visit(const Deref& e)
 {
    visit(as<Classic>(e));
@@ -361,6 +367,12 @@ ipr::Visitor::visit(const Unary_minus& e)
 }
 
 void
+ipr::Visitor::visit(const Materialize& e)
+{
+   visit(as<Expr>(e));
+}
+
+void
 ipr::Visitor::visit(const Not& e)
 {
    visit(as<Classic>(e));
@@ -388,6 +400,18 @@ void
 ipr::Visitor::visit(const Pre_increment& e)
 {
    visit(as<Classic>(e));
+}
+
+void
+ipr::Visitor::visit(const Promote& e)
+{
+   visit(as<Expr>(e));
+}
+
+void
+ipr::Visitor::visit(const Read& e)
+{
+   visit(as<Expr>(e));
 }
 
 void
@@ -667,6 +691,12 @@ ipr::Visitor::visit(const Static_cast& e)
 }
 
 void
+ipr::Visitor::visit(const Qualification& e)
+{
+   visit(as<Expr>(e));
+}
+
+void
 ipr::Visitor::visit(const Minus& e)
 {
    visit(as<Classic>(e));
@@ -681,6 +711,12 @@ ipr::Visitor::visit(const Minus_assign& e)
 void ipr::Visitor::visit(const Binary_fold& e)
 {
    visit(as<Classic>(e));
+}
+
+void
+ipr::Visitor::visit(const Coerce& e)
+{
+   visit(as<Expr>(e));
 }
 
 void

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(TEST_BINARY unittests)
 
 add_executable(${TEST_BINARY}
+   conversions.cpp
    simple.cpp
 )
 

--- a/tests/unit-tests/conversions.cpp
+++ b/tests/unit-tests/conversions.cpp
@@ -36,9 +36,9 @@ TEST_CASE("C++ Standard Conversions") {
     Type_qualifier::Const, lexicon.get_pointer(lexicon.int_type()));
   auto& ptr = *unit.global_region()->declare_var(*lexicon.make_identifier("ptr"), ptr_type);
   ptr.init = lexicon.make_coerce(
-    ptr_type,
     *lexicon.make_literal(lexicon.int_type(), "0"),
-    &ptr_type
+    ptr_type,
+    ptr_type
   );
 
   INFO("if (ptr) double(6);");
@@ -46,17 +46,17 @@ TEST_CASE("C++ Standard Conversions") {
   // Lvalue-to-Rvalue              (Read)
   // Integral-Floating Conversion  (Coercion)
   const auto& condition = *lexicon.make_coerce(
-    lexicon.bool_type(),
     *lexicon.make_read(
       *lexicon.make_id_expr(ptr),
       lexicon.get_pointer(lexicon.int_type()) // != ptr.type() (see 7.2.2/2)
     ),
-    &lexicon.bool_type()
+    lexicon.bool_type(),
+    lexicon.bool_type()
   );
   const auto& then_expr = *lexicon.make_coerce(
-      lexicon.double_type(),
       *lexicon.make_literal(lexicon.int_type(), "6"),
-      &lexicon.double_type()
+      lexicon.double_type(),
+      lexicon.double_type()
   );
   lexicon.make_if_then(condition, *lexicon.make_expr_stmt(then_expr));
 }

--- a/tests/unit-tests/conversions.cpp
+++ b/tests/unit-tests/conversions.cpp
@@ -8,30 +8,30 @@ TEST_CASE("C++ Standard Conversions") {
   impl::Module module{lexicon};
   impl::Interface_unit unit{lexicon, module};
 
-  // static_cast<long long>(4);
-  //    Integral Promotion            (Promote)
+  INFO("static_cast<long long>(4);");
+  // Integral Promotion            (Promotion)
   lexicon.make_promote(
     *lexicon.make_literal(lexicon.int_type(), "4"),
-    &lexicon.long_long_type()
+    lexicon.long_long_type()
   );
 
-  // (float)2.2;
-  //    Floating-Point Conversion     (Demote)
+  INFO("(float)2.2;");
+  // Floating-Point Conversion     (Demotion)
   lexicon.make_demote(
     *lexicon.make_literal(lexicon.double_type(), "2.2"),
-    &lexicon.float_type()
+    lexicon.float_type()
   );
 
-  // (volatile int)7;
-  //    CV-Qualifcation               (Qualification)
+  INFO("(volatile int)7;");
+  // CV-Qualifcation               (Qualification)
   lexicon.make_qualification(
-    lexicon.get_qualified(Type_qualifier::Volatile, lexicon.int_type()),
     *lexicon.make_literal(lexicon.double_type(), "2.2"),
-    &lexicon.int_type() // Type of the expr can differ from target type (see 7.2.2/2)
+    Type_qualifier::Volatile,
+    lexicon.int_type() // Type of the expr can differ from target type (see 7.2.2/2)
   );
 
-  // int* const ptr = 0;
-  //    Pointer Conversion            (Coersion)
+  INFO("int* const ptr = 0;");
+  // Pointer Conversion            (Coercion)
   const auto& ptr_type = lexicon.get_qualified(
     Type_qualifier::Const, lexicon.get_pointer(lexicon.int_type()));
   auto& ptr = *unit.global_region()->declare_var(*lexicon.make_identifier("ptr"), ptr_type);
@@ -41,21 +41,21 @@ TEST_CASE("C++ Standard Conversions") {
     &ptr_type
   );
 
-  // if (ptr) double(6);
-  //    Boolean Conversion            (Coersion)
-  //    Lvalue-to-Rvalue              (Read)
-  //    Integral-Floating Conversion  (Coersion)
+  INFO("if (ptr) double(6);");
+  // Boolean Conversion            (Coercion)
+  // Lvalue-to-Rvalue              (Read)
+  // Integral-Floating Conversion  (Coercion)
   const auto& condition = *lexicon.make_coerce(
     lexicon.bool_type(),
     *lexicon.make_read(
       *lexicon.make_id_expr(ptr),
-      &lexicon.get_pointer(lexicon.int_type()) // != ptr.type() (see 7.2.2/2)
+      lexicon.get_pointer(lexicon.int_type()) // != ptr.type() (see 7.2.2/2)
     ),
     &lexicon.bool_type()
   );
   const auto& then_expr = *lexicon.make_coerce(
       lexicon.double_type(),
-      *lexicon.make_literal(lexicon.int_type(), "4"),
+      *lexicon.make_literal(lexicon.int_type(), "6"),
       &lexicon.double_type()
   );
   lexicon.make_if_then(condition, *lexicon.make_expr_stmt(then_expr));

--- a/tests/unit-tests/conversions.cpp
+++ b/tests/unit-tests/conversions.cpp
@@ -1,0 +1,62 @@
+#include "doctest/doctest.h"
+
+#include <ipr/impl>
+
+TEST_CASE("C++ Standard Conversions") {
+  using namespace ipr;
+  impl::Lexicon lexicon{};
+  impl::Module module{lexicon};
+  impl::Interface_unit unit{lexicon, module};
+
+  // static_cast<long long>(4);
+  //    Integral Promotion            (Promote)
+  lexicon.make_promote(
+    *lexicon.make_literal(lexicon.int_type(), "4"),
+    &lexicon.long_long_type()
+  );
+
+  // (float)2.2;
+  //    Floating-Point Conversion     (Demote)
+  lexicon.make_demote(
+    *lexicon.make_literal(lexicon.double_type(), "2.2"),
+    &lexicon.float_type()
+  );
+
+  // (volatile int)7;
+  //    CV-Qualifcation               (Qualification)
+  lexicon.make_qualification(
+    lexicon.get_qualified(Type_qualifier::Volatile, lexicon.int_type()),
+    *lexicon.make_literal(lexicon.double_type(), "2.2"),
+    &lexicon.int_type() // Type of the expr can differ from target type (see 7.2.2/2)
+  );
+
+  // int* const ptr = 0;
+  //    Pointer Conversion            (Coersion)
+  const auto& ptr_type = lexicon.get_qualified(
+    Type_qualifier::Const, lexicon.get_pointer(lexicon.int_type()));
+  auto& ptr = *unit.global_region()->declare_var(*lexicon.make_identifier("ptr"), ptr_type);
+  ptr.init = lexicon.make_coerce(
+    ptr_type,
+    *lexicon.make_literal(lexicon.int_type(), "0"),
+    &ptr_type
+  );
+
+  // if (ptr) double(6);
+  //    Boolean Conversion            (Coersion)
+  //    Lvalue-to-Rvalue              (Read)
+  //    Integral-Floating Conversion  (Coersion)
+  const auto& condition = *lexicon.make_coerce(
+    lexicon.bool_type(),
+    *lexicon.make_read(
+      *lexicon.make_id_expr(ptr),
+      &lexicon.get_pointer(lexicon.int_type()) // != ptr.type() (see 7.2.2/2)
+    ),
+    &lexicon.bool_type()
+  );
+  const auto& then_expr = *lexicon.make_coerce(
+      lexicon.double_type(),
+      *lexicon.make_literal(lexicon.int_type(), "4"),
+      &lexicon.double_type()
+  );
+  lexicon.make_if_then(condition, *lexicon.make_expr_stmt(then_expr));
+}


### PR DESCRIPTION
Address some of the implicit C++ conversions #36.

This includes tests that help demonstrate how the IPR represents C++ source code and how to construct the nodes. This feels like a very effective way of providing documentation through practical examples.