### PR TITLE
add three type builtins: Function, Variable and Nullptr

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -1898,7 +1898,7 @@ namespace ipr {
       };
 
 
-      // A Break node can record the selction- of iteration-statement it
+      // A Break node can record the selection- of iteration-statement it
       // transfers control out of.
 
       struct Break : Stmt<Expr<ipr::Break>> {
@@ -2017,6 +2017,7 @@ namespace ipr {
          const ipr::Literal& get_literal(const ipr::Type&, const ipr::String&);
          
          const ipr::Type& void_type() const final;
+         const ipr::Type& nullptr_type() const final;
          const ipr::Type& bool_type() const final;
 
          const ipr::Type& char_type() const final;
@@ -2050,6 +2051,8 @@ namespace ipr {
          const ipr::Type& union_type() const final;
          const ipr::Type& enum_type() const final;
          const ipr::Type& namespace_type() const final;
+         const ipr::Type& function_type() const final;
+         const ipr::Type& variable_type() const final;
 
          const ipr::Array& get_array(const ipr::Type&, const ipr::Expr&);
 
@@ -2125,6 +2128,7 @@ namespace ipr {
          const impl::Builtin<ipr::As_type> enumtype;
          const impl::Builtin<ipr::As_type> namespacetype;
          const impl::Builtin<ipr::As_type> voidtype;
+         const impl::Builtin<ipr::As_type> nullptrtype;
          const impl::Builtin<ipr::As_type> booltype;
          const impl::Builtin<ipr::As_type> chartype;
          const impl::Builtin<ipr::As_type> schartype;
@@ -2145,6 +2149,8 @@ namespace ipr {
          const impl::Builtin<ipr::As_type> doubletype;
          const impl::Builtin<ipr::As_type> longdoubletype;
          const impl::Builtin<ipr::As_type> ellipsistype;
+         const impl::Builtin<ipr::As_type> functiontype;
+         const impl::Builtin<ipr::As_type> variabletype;
 
          template<class T> T* finish_type(T*);
       };

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -2042,6 +2042,7 @@ namespace ipr {
    struct Lexicon {
       virtual const Type& void_type() const = 0;
       virtual const Type& bool_type() const = 0;
+      virtual const Type& nullptr_type() const = 0;
       virtual const Type& char_type() const = 0;
       virtual const Type& schar_type() const = 0;
       virtual const Type& uchar_type() const = 0;
@@ -2066,6 +2067,8 @@ namespace ipr {
       virtual const Type& union_type() const = 0;
       virtual const Type& enum_type() const = 0;
       virtual const Type& namespace_type() const = 0;
+      virtual const Type& function_type() const = 0;
+      virtual const Type& variable_type() const = 0;
 
       virtual const Linkage& cxx_linkage() const = 0;
       virtual const Linkage& c_linkage() const = 0;

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -2083,7 +2083,7 @@ namespace ipr {
               namespacetype(get_identifier("namespace"), cxx_linkage(), anytype),
 
               voidtype(get_identifier("void"), cxx_linkage(), anytype),
-              nullptrtype(get_identifier("decltype(nullptr)"), cxx_linkage(), anytype),
+              nullptrtype(get_identifier("@nullptr_t"), cxx_linkage(), anytype),
               booltype(get_identifier("bool"), cxx_linkage(), anytype),
               chartype(get_identifier("char"), cxx_linkage(), anytype),
               schartype(get_identifier("signed char"), cxx_linkage(), anytype),
@@ -2108,8 +2108,8 @@ namespace ipr {
               longdoubletype(get_identifier("long double"),
                              cxx_linkage(), anytype),
               ellipsistype(get_identifier("..."), cxx_linkage(), anytype),
-              functiontype(get_identifier("(function)"), cxx_linkage(), anytype),
-              variabletype(get_identifier("(variable)"), cxx_linkage(), anytype)
+              functiontype(get_identifier("@function"), cxx_linkage(), anytype),
+              variabletype(get_identifier("@variable"), cxx_linkage(), anytype)
       {
          record_builtin_type(anytype);
          record_builtin_type(classtype);

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -2083,6 +2083,7 @@ namespace ipr {
               namespacetype(get_identifier("namespace"), cxx_linkage(), anytype),
 
               voidtype(get_identifier("void"), cxx_linkage(), anytype),
+              nullptrtype(get_identifier("decltype(nullptr)"), cxx_linkage(), anytype),
               booltype(get_identifier("bool"), cxx_linkage(), anytype),
               chartype(get_identifier("char"), cxx_linkage(), anytype),
               schartype(get_identifier("signed char"), cxx_linkage(), anytype),
@@ -2106,7 +2107,9 @@ namespace ipr {
               doubletype(get_identifier("double"), cxx_linkage(), anytype),
               longdoubletype(get_identifier("long double"),
                              cxx_linkage(), anytype),
-              ellipsistype(get_identifier("..."), cxx_linkage(), anytype)
+              ellipsistype(get_identifier("..."), cxx_linkage(), anytype),
+              functiontype(get_identifier("(function)"), cxx_linkage(), anytype),
+              variabletype(get_identifier("(variable)"), cxx_linkage(), anytype)
       {
          record_builtin_type(anytype);
          record_builtin_type(classtype);
@@ -2115,6 +2118,7 @@ namespace ipr {
          record_builtin_type(namespacetype);
 
          record_builtin_type(voidtype);
+         record_builtin_type(nullptrtype);
 
          record_builtin_type(booltype);
 
@@ -2143,6 +2147,8 @@ namespace ipr {
          record_builtin_type(longdoubletype);
 
          record_builtin_type(ellipsistype);
+         record_builtin_type(functiontype);
+         record_builtin_type(variabletype);
       }
 
       Lexicon::~Lexicon() { }
@@ -2183,6 +2189,8 @@ namespace ipr {
       }
 
       const ipr::Type& Lexicon::void_type() const {  return voidtype;  }
+
+      const ipr::Type& Lexicon::nullptr_type() const { return nullptrtype; }
 
       const ipr::Type& Lexicon::bool_type() const { return booltype; }
 
@@ -2235,6 +2243,10 @@ namespace ipr {
       const ipr::Type& Lexicon::enum_type() const { return enumtype; }
 
       const ipr::Type& Lexicon::namespace_type() const { return namespacetype; }
+
+      const ipr::Type& Lexicon::function_type() const { return functiontype; }
+
+      const ipr::Type& Lexicon::variable_type() const { return variabletype; }
 
       template<class T>
       T* Lexicon::finish_type(T* t) {

--- a/tests/unit-tests/simple.cpp
+++ b/tests/unit-tests/simple.cpp
@@ -4,6 +4,7 @@
 #include <ipr/impl>
 #include <ipr/io>
 #include <sstream>
+#include <iostream>
 
 TEST_CASE("global constant variable can be printed") {
   using namespace ipr;
@@ -24,3 +25,13 @@ TEST_CASE("global constant variable can be printed") {
   CHECK(!ss.str().empty());
 }
 
+TEST_CASE("test builtins") {
+  using namespace ipr;
+  impl::Lexicon lexicon{};
+  std::stringstream ss;
+  Printer pp{ss};
+  pp << lexicon.nullptr_type()
+     << lexicon.variable_type()
+     << lexicon.function_type();
+  CHECK(ss.str() == "decltype(nullptr) (variable) (function)");
+}

--- a/tests/unit-tests/simple.cpp
+++ b/tests/unit-tests/simple.cpp
@@ -4,7 +4,6 @@
 #include <ipr/impl>
 #include <ipr/io>
 #include <sstream>
-#include <iostream>
 
 TEST_CASE("global constant variable can be printed") {
   using namespace ipr;

--- a/tests/unit-tests/simple.cpp
+++ b/tests/unit-tests/simple.cpp
@@ -33,5 +33,5 @@ TEST_CASE("test builtins") {
   pp << lexicon.nullptr_type()
      << lexicon.variable_type()
      << lexicon.function_type();
-  CHECK(ss.str() == "decltype(nullptr) (variable) (function)");
+  CHECK(ss.str() == "@nullptr_t @variable @function");
 }


### PR DESCRIPTION
These seems to be universal enough for C++ and thus merit inclusion into the lexicon.
Their string representations are:
```
nullptr_type() => "@nullptr_t"
function_type() => "@function"
variable_type() => "@variable"
```
@ character is used to disambiguate from a similarly named identifier. Currently, we are using "@" in io.cxx to disambiguate a comma operator from a separator comma. I thought we could use it in this case as well

