### PR TITLE
Merge ipr::If_then and ipr::If_then_else

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -1826,8 +1826,7 @@ namespace ipr {
       using Empty_stmt = type_from_operand<Stmt<Node<ipr::Empty_stmt>>>;
       using Goto = type_from_operand<Stmt<Node<ipr::Goto>>>;
       using Handler = type_from_second<Stmt<Node<ipr::Handler>>>;
-      using If_then = type_from_second<Stmt<Node<ipr::If_then>>>;
-      using If_then_else = Ternary<Stmt<Expr<ipr::If_then_else>>>;
+      using If = Ternary<Stmt<Expr<ipr::If>>>;
       using Labeled_stmt = type_from_second<Stmt<Node<ipr::Labeled_stmt>>>;
       using Return = type_from_operand<Stmt<Node<ipr::Return>>>;
       using Switch = type_from_second<Stmt<Node<ipr::Switch>>>;
@@ -1932,15 +1931,13 @@ namespace ipr {
          impl::Goto* make_goto(const ipr::Expr&);
          impl::Return* make_return(const ipr::Expr&);
          impl::Do* make_do(const ipr::Stmt&, const ipr::Expr&);
-         impl::If_then* make_if_then(const ipr::Expr&, const ipr::Stmt&);
+         impl::If* make_if(const ipr::Expr&, const ipr::Stmt&);
+         impl::If* make_if(const ipr::Expr&, const ipr::Stmt&, const ipr::Stmt&);
          impl::Switch* make_switch(const ipr::Expr&, const ipr::Stmt&);
          impl::Handler* make_handler(const ipr::Decl&, const ipr::Block&);
          impl::Labeled_stmt* make_labeled_stmt(const ipr::Expr&,
                                                const ipr::Stmt&);
          impl::While* make_while(const ipr::Expr&, const ipr::Stmt&);
-         impl::If_then_else* make_if_then_else(const ipr::Expr&,
-                                               const ipr::Stmt&,
-                                               const ipr::Stmt&);
          impl::For* make_for();
          impl::For_in* make_for_in();
 
@@ -1954,12 +1951,11 @@ namespace ipr {
          stable_farm<impl::Return> returns;
          stable_farm<impl::Ctor_body> ctor_bodies;
          stable_farm<impl::Do> dos;
-         stable_farm<impl::If_then> ifs;
+         stable_farm<impl::If> ifs;
          stable_farm<impl::Handler> handlers;
          stable_farm<impl::Labeled_stmt> labeled_stmts;
          stable_farm<impl::Switch> switches;
          stable_farm<impl::While> whiles;
-         stable_farm<impl::If_then_else> ifelses;
          stable_farm<impl::For> fors;
          stable_farm<impl::For_in> for_ins;
       };

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -221,8 +221,7 @@ namespace ipr {
    struct For_in;                // structured for-statement
    struct Goto;                  // goto-statement
    struct Handler;               // exception handler statement
-   struct If_then;               // if-statement
-   struct If_then_else;          // if-else-statement
+   struct If;                    // if-statement
    struct Labeled_stmt;          // labeled-statement
    struct Return;                // return-statement
    struct Switch;                // switch-statement
@@ -1576,10 +1575,9 @@ namespace ipr {
    };
 
                                 // -- Conditional --
-   // This represents the C++ ternary operator ?:.  In principle,
-   // it is redundant with both If_then_else and Switch nodes
-   // from semantics point of view.  However, if we want to preserve
-   // the syntax, then it is necessary to have it.
+   // This represents the C++ ternary operator ?:.  In principle, it is redundant
+   //  with both If and Switch nodes from semantics point of view.  However, 
+   // it is necessary for representing templated code
    struct Conditional : Ternary<Category<Category_code::Conditional, Classic>> {
       Arg1_type condition() const { return first(); }
       Arg2_type then_expr() const { return second(); }
@@ -1688,21 +1686,13 @@ namespace ipr {
       Arg2_type block() const { return second(); }
    };
 
-                                // -- If_then
-   // A classic if-statement without the "else" part.
-   struct If_then : Binary<Category<Category_code::If_then, Stmt>,
-                           const Expr&, const Stmt&> {
+                                // -- If
+   // A classic if-statement.
+   struct If : Ternary<Category<Category_code::If, Stmt>,
+                       const Expr&, const Stmt&, Optional<Stmt>> {
       Arg1_type condition() const { return first(); }
-      Arg2_type then_stmt() const { return second(); }
-   };
-
-                                // -- If_then_else --
-   // A classic full is-statement.
-   struct If_then_else : Ternary<Category<Category_code::If_then_else, Stmt>,
-                                 const Expr&, const Stmt&, const Stmt&> {
-      Arg1_type condition() const { return first(); }
-      Arg2_type then_stmt() const { return second(); }
-      Arg3_type else_stmt() const { return third(); }
+      Arg2_type consequence() const { return second(); }
+      Arg3_type alternative() const { return third(); }
    };
 
                                 // -- Switch --
@@ -2211,8 +2201,7 @@ namespace ipr {
       virtual void visit(const Labeled_stmt&);
       virtual void visit(const Block&);
       virtual void visit(const Ctor_body&);
-      virtual void visit(const If_then&);
-      virtual void visit(const If_then_else&);
+      virtual void visit(const If&);
       virtual void visit(const Switch&);
       virtual void visit(const While&);
       virtual void visit(const Do&);

--- a/include/ipr/node-category
+++ b/include/ipr/node-category
@@ -142,8 +142,7 @@ For,                                // ipr::For
 For_in,                             // ipr::For_in
 Goto,                               // ipr::Goto
 Handler,                            // ipr::Handler
-If_then,                            // ipr::If_then
-If_then_else,                       // ipr::If_then_else
+If,                                 // ipr::If
 Labeled_stmt,                       // ipr::Labeled_stmt
 Return,                             // ipr::Return
 Switch,                             // ipr::Switch

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -660,9 +660,14 @@ namespace ipr {
          return dos.make(c, s);
       }
 
-      impl::If_then*
-      stmt_factory::make_if_then(const ipr::Expr& c, const ipr::Stmt& s) {
-         return ifs.make(c, s);
+      impl::If*
+      stmt_factory::make_if(const ipr::Expr& c, const ipr::Stmt& s) {
+         return ifs.make(c, s, nullptr);
+      }
+
+      impl::If*
+      stmt_factory::make_if(const ipr::Expr& c, const ipr::Stmt& t, const ipr::Stmt& f) {
+         return ifs.make(c, t, &f);
       }
 
       impl::Switch*
@@ -684,12 +689,6 @@ namespace ipr {
       impl::While*
       stmt_factory::make_while(const ipr::Expr& c, const ipr::Stmt& s) {
          return whiles.make(c, s);
-      }
-
-      impl::If_then_else*
-      stmt_factory::make_if_then_else(const ipr::Expr& c, const ipr::Stmt& t,
-                                      const ipr::Stmt& f) {
-         return ifelses.make(c, t, f);
       }
 
       impl::For*

--- a/src/io.cxx
+++ b/src/io.cxx
@@ -1575,31 +1575,20 @@ namespace ipr
             pp << needs_newline() << xpr_stmt(b.block());
          }
 
-         void visit(const If_then& s) override
+         void visit(const If& s) override
          {
             pp << xpr_identifier("if")
                << token(' ')
                << token('(') << xpr_expr(s.condition()) << token(')')
                << newline_and_indent(3)
-               << xpr_stmt(s.then_stmt(),false)
-               << newline_and_indent(-3)
-               << xpr_identifier("else")
-               << newline_and_indent(3)
-               << indentation(-3) << needs_newline();
-         }
-
-         void visit(const If_then_else& s) override
-         {
-            pp << xpr_identifier("if")
-               << token(' ')
-               << token('(') << xpr_expr(s.condition()) << token(')')
-               << newline_and_indent(3)
-               << xpr_stmt(s.then_stmt())
-               << newline_and_indent(-3)
-               << xpr_identifier("else")
-               << newline_and_indent(3)
-               << xpr_stmt(s.else_stmt())
-               << indentation(-3) << needs_newline();
+               << xpr_stmt(s.consequence());
+            if (auto alt = s.alternative()) {
+               pp << newline_and_indent(-3)
+                  << xpr_identifier("else")
+                  << newline_and_indent(3)
+                  << xpr_stmt(alt.get());
+            }
+            pp << indentation(-3) << needs_newline();
          }
 
          void visit(const Return& s) override

--- a/src/traversal.cxx
+++ b/src/traversal.cxx
@@ -764,13 +764,7 @@ ipr::Visitor::visit(const Expr_stmt& s)
 }
 
 void
-ipr::Visitor::visit(const If_then& s)
-{
-   visit(as<Stmt>(s));
-}
-
-void
-ipr::Visitor::visit(const If_then_else& s)
+ipr::Visitor::visit(const If& s)
 {
    visit(as<Stmt>(s));
 }

--- a/tests/unit-tests/conversions.cpp
+++ b/tests/unit-tests/conversions.cpp
@@ -58,5 +58,5 @@ TEST_CASE("C++ Standard Conversions") {
       lexicon.double_type(),
       lexicon.double_type()
   );
-  lexicon.make_if_then(condition, *lexicon.make_expr_stmt(then_expr));
+  lexicon.make_if(condition, *lexicon.make_expr_stmt(then_expr));
 }


### PR DESCRIPTION
The IPR library did not originally have a class to directly represent optionality.  That meant that in order to ensure non-forgetful and safe consumption of optional data, some notions were unfortunately duplicated in the class hierarchy.  That is the case for `ipr::If_then` and `ipr::If_then_else`.  This patch merge those classes into a single `ipr::If`, taking advantage of the availability of `ipr::Optional`.  I took the opportunity to rename accessor names - to ensure consumption sites are appropriately updated.

This is a source breaking change.