### PR TITLE
Merge ipr::Paren_expr and ipr::Initializer_list

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -1053,7 +1053,12 @@ namespace ipr {
       using Materialize = Unary_expr<ipr::Materialize>;
       using Not = Classic_unary_expr<ipr::Not>;
 
-      using Paren_expr = type_from_operand<Classic<Node<ipr::Paren_expr>>>;
+      struct Enclosure : impl::Unary_expr<ipr::Enclosure> {
+         Enclosure(ipr::Delimiter, const ipr::Expr&);
+         Delimiter delimiters() const final { return delim; }
+      private:
+         Delimiter delim;
+      };
 
       using Pre_decrement = Classic_unary_expr<ipr::Pre_decrement>;
       using Pre_increment = Classic_unary_expr<ipr::Pre_increment>;
@@ -1209,7 +1214,7 @@ namespace ipr {
          Label* make_label(const ipr::Identifier&, Optional<ipr::Type> = {});
          Materialize* make_materialize(const ipr::Expr&, const ipr::Type&);
          Not* make_not(const ipr::Expr&, Optional<ipr::Type> = {});
-         Paren_expr* make_paren_expr(const ipr::Expr&);
+         Enclosure* make_enclosure(ipr::Delimiter, const ipr::Expr&, Optional<ipr::Type> = { });
          Post_increment* make_post_increment(const ipr::Expr&, Optional<ipr::Type> = {});
          Post_decrement* make_post_decrement(const ipr::Expr&, Optional<ipr::Type> = {});
          Pre_increment* make_pre_increment(const ipr::Expr&, Optional<ipr::Type> = {});
@@ -1318,7 +1323,7 @@ namespace ipr {
          stable_farm<impl::Label> labels;
          stable_farm<impl::Materialize> materializes;
          stable_farm<impl::Not> nots;
-         stable_farm<impl::Paren_expr> parens;
+         stable_farm<impl::Enclosure> enclosures;
          stable_farm<impl::Pre_increment> pre_increments;
          stable_farm<impl::Pre_decrement> pre_decrements;
          stable_farm<impl::Post_increment> post_increments;

--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -1037,7 +1037,6 @@ namespace ipr {
 		 // <<<< Yuriy Solodkyy: 2007/02/02
       };
 
-      using Initializer_list = Classic_unary_expr<ipr::Initializer_list>;
       using Sizeof = Unary_expr<ipr::Sizeof>;
       using Typeid = Unary_expr<ipr::Typeid>;
       using Label = Unary_expr<ipr::Label>;
@@ -1208,7 +1207,6 @@ namespace ipr {
          Expr_list* make_expr_list();
          Sizeof* make_sizeof(const ipr::Expr&);
          Typeid* make_typeid(const ipr::Expr&);
-         Initializer_list* make_initializer_list(const ipr::Expr_list&, Optional<ipr::Type> = {});
          impl::Id_expr* make_id_expr(const ipr::Name&, Optional<ipr::Type> = {});
          Id_expr* make_id_expr(const ipr::Decl&);
          Label* make_label(const ipr::Identifier&, Optional<ipr::Type> = {});
@@ -1319,7 +1317,6 @@ namespace ipr {
          stable_farm<impl::Deref> derefs;
          stable_farm<impl::Expr_list> xlists;
          stable_farm<impl::Id_expr> id_exprs;
-         stable_farm<impl::Initializer_list> init_lists;
          stable_farm<impl::Label> labels;
          stable_farm<impl::Materialize> materializes;
          stable_farm<impl::Not> nots;

--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -1241,7 +1241,7 @@ namespace ipr {
          Coerce* make_coerce(const ipr::Expr&, const ipr::Type&, const ipr::Type&);
          Comma* make_comma(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
          Const_cast* make_const_cast(const ipr::Type&, const ipr::Expr&);
-         Datum* make_datum(const ipr::Type&, const ipr::Expr_list&);
+         Datum* make_datum(const ipr::Type&, const ipr::Enclosure&);
          Div* make_div(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
          Div_assign* make_div_assign(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
          Dot* make_dot(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -188,7 +188,6 @@ namespace ipr {
    struct Equal;                 // equality comparison            a == b
    struct Greater;               // greater comparison             a > b
    struct Greater_equal;         // greater-or-equal comparison    a >= b
-   struct Initializer_list;      // brace-enclosed expression list { a, b }
    struct Less;                  // less comparison                a < b
    struct Less_equal;            // less-equal comparison          a <= b
    struct Literal;               // literal expressions            3.14
@@ -1163,16 +1162,6 @@ namespace ipr {
    // was omitted, hence the name.
    struct Eclipsis : Category<Category_code::Eclipsis, Expr> { };
 
-                                // -- Initializer_list --
-   // Representation of brace-enclosed sequence of expressions.
-   // If this expression invokes a user-defined constructor to
-   // constructor the resulting value, then its resolution points
-   // to that constructor.
-   struct Initializer_list : Unary<Category<Category_code::Initializer_list, Classic>,
-                                   const Expr_list&> {
-      const Expr_list& expr_list() const { return operand(); }
-   };
-
                                 // -- Address --
    // Address-of expression -- "&expr"
    struct Address : Unary<Category<Category_code::Address, Classic>> { };
@@ -2145,7 +2134,6 @@ namespace ipr {
       virtual void visit(const Scope&);
       virtual void visit(const Phantom&);
       virtual void visit(const Eclipsis&);
-      virtual void visit(const Initializer_list&);
 
       virtual void visit(const Address&);
       virtual void visit(const Array_delete&);

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -1422,7 +1422,7 @@ namespace ipr {
    // call -- although syntactically it looks like so.  "T" will
    // be the `type()' of this expression.
    struct Datum : Binary<Category<Category_code::Datum, Classic>,
-                          const Type&, const Expr_list&> {
+                          const Type&, const Enclosure&> {
       // See comments for the various cast operators regarding type().
 
       Arg2_type args() const { return second(); }

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -146,7 +146,7 @@ namespace ipr {
                                  //         or entry of a switch-statement
    struct Materialize;           // temporary materialization
    struct Not;                   // logical negation                 !cond
-   struct Paren_expr;            // parenthesized expression           (a)
+   struct Enclosure;             // expression in enclosed in paired delimiters, e.g. (a) or {x, y, y}
    struct Post_decrement;        // post-increment                     p++
    struct Post_increment;        // post-decrement                     p--
    struct Pre_decrement;         // pre-increment                      ++p
@@ -442,6 +442,15 @@ namespace ipr {
    inline const T&
    Sequence<T>::operator[](int p) const
    { return get(p); }
+
+                                 // -- Delimiter --
+   // Enclosure delimiter of expressions
+   enum class Delimiter {
+      Paren,                     // "()"
+      Brace,                     // "{}"
+      Bracket,                   // "[]"
+      Angle,                     // "<>"
+   };
 
                                 // -- Optional<> --
    // Occasionally, a node has an optional property (e.g. a variable
@@ -1192,12 +1201,14 @@ namespace ipr {
    // Dereference-expression -- "*expr"
    struct Deref : Unary<Category<Category_code::Deref, Classic>> { };
 
-                                // -- Paren_expr --
-   // Parenthesized-expressions -- "(expr)".  This might seem purely
+                                // -- Enclosure --
+   // Expresion enclosed in matching pair of delimiters.  This might seem purely
    // syntactical but it also has semantic implications, like when an
-   // argument-dependent lookup should be done or not, or on the accuracy
+   // argument-dependent lookup should be done or not, or order of evaluation,the accuracy
    // of an expression evaluation.
-   struct Paren_expr : Unary<Category<Category_code::Paren_expr, Classic>> {
+   // Note: an empty brace-init translates to a brace enclosure of a Phantom node.
+   struct Enclosure : Unary<Category<Category_code::Enclosure>> {
+      virtual Delimiter delimiters() const = 0;
       const Expr& expr() const { return operand(); }
    };
 
@@ -2142,7 +2153,7 @@ namespace ipr {
       virtual void visit(const Delete&);
       virtual void visit(const Demote&);
       virtual void visit(const Deref&);
-      virtual void visit(const Paren_expr&);
+      virtual void visit(const Enclosure&);
       virtual void visit(const Sizeof&);
       virtual void visit(const Expr_stmt&);
       virtual void visit(const Typeid&);

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -443,8 +443,9 @@ namespace ipr {
    { return get(p); }
 
                                  // -- Delimiter --
-   // Enclosure delimiter of expressions
+   // Enclosure delimiters of expressions
    enum class Delimiter {
+      Nothing,                   // no delimiter
       Paren,                     // "()"
       Brace,                     // "{}"
       Bracket,                   // "[]"

--- a/include/ipr/node-category
+++ b/include/ipr/node-category
@@ -105,7 +105,6 @@ Dynamic_cast,                       // ipr::Dynamic_cast
 Equal,                              // ipr::Equal
 Greater,                            // ipr::Greater
 Greater_equal,                      // ipr::Greater_equal
-Initializer_list,                   // ipr::Initializer_list
 Less,                               // ipr::Less
 Less_equal,                         // ipr::Less_equal
 Literal,                            // ipr::Literal

--- a/include/ipr/node-category
+++ b/include/ipr/node-category
@@ -65,7 +65,7 @@ Id_expr,                            // ipr::Id_expr
 Label,                              // ipr::Label
 Materialize,                        // ipr::Materialize
 Not,                                // ipr::Not
-Paren_expr,                         // ipr::Paren_expr
+Enclosure,                          // ipr::Enclosure
 Post_decrement,                     // ipr::Post_decrement
 Post_increment,                     // ipr::Post_increment
 Pre_decrement,                      // ipr::Pre_decrement

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -1789,7 +1789,7 @@ namespace ipr {
       }
 
       impl::Datum*
-      expr_factory::make_datum(const ipr::Type& t, const ipr::Expr_list& e) {
+      expr_factory::make_datum(const ipr::Type& t, const ipr::Enclosure& e) {
          return data.make(t, e);
       }
 

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -1549,13 +1549,6 @@ namespace ipr {
          return x;
       }
 
-      impl::Initializer_list*
-      expr_factory::make_initializer_list(const ipr::Expr_list& e, Optional<ipr::Type> result) {
-         impl::Initializer_list* init = init_lists.make(e);
-         init->constraint = result;
-         return init;
-      }
-
       impl::Label*
       expr_factory::make_label(const ipr::Identifier& n, Optional<ipr::Type> result) {
          impl::Label* label = labels.make(n);

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -1085,6 +1085,13 @@ namespace ipr {
          return decls;
       }
 
+      // ---------------
+      // -- Enclosure --
+      // ---------------
+      Enclosure::Enclosure(ipr::Delimiter d, const ipr::Expr& e)
+         : impl::Unary_expr<ipr::Enclosure>{ e }, delim{ d}
+      { }
+
       // -----------------
       // -- Binary_fold --
       // -----------------
@@ -1585,9 +1592,11 @@ namespace ipr {
          return make_operator(get_string(s));
       }
 
-      impl::Paren_expr*
-      expr_factory::make_paren_expr(const ipr::Expr& e) {
-         return parens.make(e);
+      impl::Enclosure*
+      expr_factory::make_enclosure(ipr::Delimiter d, const ipr::Expr& e, Optional<ipr::Type> t) {
+         auto x = enclosures.make(d, e);
+         x->constraint = t;
+         return x;
       }
 
       impl::Post_increment*

--- a/src/io.cxx
+++ b/src/io.cxx
@@ -391,10 +391,6 @@ namespace ipr
             const auto delimiters = syntax[static_cast<int>(e.delimiters())];
             pp << token(delimiters[0]) << xpr_expr(e.expr()) << token(delimiters[1]);
          }
-         void visit(const Initializer_list& e) final
-         {
-            pp << token('{') << e.expr_list() << token('}');
-         }
          void visit(const Expr& e) override
          {
             pp << token('(') << xpr_expr(e) << token(')');

--- a/src/io.cxx
+++ b/src/io.cxx
@@ -522,7 +522,7 @@ namespace ipr
          void visit(const Datum& e) override
          {
             pp << xpr_type(e.type())
-               << token('(') << e.args() << token(')');
+               << xpr_primary_expr(e.args());
          }
 
          //        postfix-expression --

--- a/src/io.cxx
+++ b/src/io.cxx
@@ -387,7 +387,7 @@ namespace ipr
          void visit(const Phantom&) final { } // nothing to print
          void visit(const Enclosure& e) final
          {
-            static constexpr const char* syntax[] = { "()", "{}", "[]", "<>" };
+            static constexpr const char* syntax[] = { "\0\0", "()", "{}", "[]", "<>" };
             const auto delimiters = syntax[static_cast<int>(e.delimiters())];
             pp << token(delimiters[0]) << xpr_expr(e.expr()) << token(delimiters[1]);
          }

--- a/src/io.cxx
+++ b/src/io.cxx
@@ -385,9 +385,11 @@ namespace ipr
                pp << xpr_primary_expr(t.expr());
          }
          void visit(const Phantom&) final { } // nothing to print
-         void visit(const Paren_expr& e) final
+         void visit(const Enclosure& e) final
          {
-            pp << token('(') << xpr_expr(e.expr()) << token(')');
+            static constexpr const char* syntax[] = { "()", "{}", "[]", "<>" };
+            const auto delimiters = syntax[static_cast<int>(e.delimiters())];
+            pp << token(delimiters[0]) << xpr_expr(e.expr()) << token(delimiters[1]);
          }
          void visit(const Initializer_list& e) final
          {

--- a/src/traversal.cxx
+++ b/src/traversal.cxx
@@ -289,12 +289,6 @@ void ipr::Visitor::visit(const Eclipsis& e)
 }
 
 void
-ipr::Visitor::visit(const Initializer_list& e)
-{
-   visit(as<Expr>(e));
-}
-
-void
 ipr::Visitor::visit(const Address& e)
 {
    visit(as<Classic>(e));

--- a/src/traversal.cxx
+++ b/src/traversal.cxx
@@ -331,9 +331,9 @@ ipr::Visitor::visit(const Deref& e)
 }
 
 void
-ipr::Visitor::visit(const Paren_expr& e)
+ipr::Visitor::visit(const Enclosure& e)
 {
-   visit(as<Classic>(e));
+   visit(as<Expr>(e));
 }
 
 void


### PR DESCRIPTION
This patch merges the existing node classes `ipr::Paren_expr` and `ipr::Initializer_list` in the single notion of `ipr::Enclosure`.  It partially addresses the issues reported in #19 