### PR TITLE
Rename ipr::Datum to ipr::Construction

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -1070,6 +1070,7 @@ namespace ipr {
       using Unary_minus = Classic_unary_expr<ipr::Unary_minus>;
       using Unary_plus = Classic_unary_expr<ipr::Unary_plus>;
       using Expansion = Classic_unary_expr<ipr::Expansion>;
+      using Construction = Classic_unary_expr<ipr::Construction>;
 
       using And = Classic_binary_expr<ipr::And>;
       using Annotation = Binary_node<ipr::Annotation>;
@@ -1088,7 +1089,6 @@ namespace ipr {
       using Coerce = Classic_binary_expr<ipr::Coerce>;
       using Comma = Classic_binary_expr<ipr::Comma>;
       using Const_cast = Conversion_expr<ipr::Const_cast>;
-      using Datum = Conversion_expr<ipr::Datum>;
       using Div = Classic_binary_expr<ipr::Div>;
       using Div_assign = Classic_binary_expr<ipr::Div_assign>;
       using Dot = Classic_binary_expr<ipr::Dot>;
@@ -1144,18 +1144,14 @@ namespace ipr {
          Category_code operation() const final;
       };
 
-      using Conditional = Ternary<Classic<Expr<ipr::Conditional>>>;
+      struct New : impl::Classic_binary_expr<ipr::New> {
+         bool global = false;
 
-      struct New : Classic<Expr<ipr::New>> {
-         Optional<ipr::Expr_list> where;
-         const ipr::Type& what;
-         Optional<ipr::Expr_list> args;
-
-         New(Optional<ipr::Expr_list>, const ipr::Type&, Optional<ipr::Expr_list>);
-         Optional<ipr::Expr_list> placement() const final;
-         const ipr::Type& allocated_type() const final;
-         Optional<ipr::Expr_list> initializer() const final;
+         New(Optional<ipr::Expr_list>, const ipr::Construction&);
+         bool global_requested() const final;
       };
+
+      using Conditional = Ternary<Classic<Expr<ipr::Conditional>>>;
 
       struct expr_factory {
          // Returns an IPR node for unified string literals.
@@ -1224,6 +1220,7 @@ namespace ipr {
          Unary_minus* make_unary_minus(const ipr::Expr&, Optional<ipr::Type> = {});
          Unary_plus* make_unary_plus(const ipr::Expr&, Optional<ipr::Type> = {});
          Expansion* make_expansion(const ipr::Expr&, Optional<ipr::Type> = {});
+         Construction* make_construction(const ipr::Type&, const ipr::Enclosure&);
 
          And* make_and(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
          Array_ref* make_array_ref(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
@@ -1241,7 +1238,6 @@ namespace ipr {
          Coerce* make_coerce(const ipr::Expr&, const ipr::Type&, const ipr::Type&);
          Comma* make_comma(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
          Const_cast* make_const_cast(const ipr::Type&, const ipr::Expr&);
-         Datum* make_datum(const ipr::Type&, const ipr::Enclosure&);
          Div* make_div(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
          Div_assign* make_div_assign(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
          Dot* make_dot(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
@@ -1275,8 +1271,7 @@ namespace ipr {
          Static_cast* make_static_cast(const ipr::Type&, const ipr::Expr&);
          Qualification* make_qualification(const ipr::Expr&, ipr::Type_qualifier, const ipr::Type&);
          Binary_fold* make_binary_fold(Category_code, const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
-         New* make_new(const ipr::Type& allocated, Optional<ipr::Expr_list> init = {},
-                       Optional<Expr_list> placement = {}, Optional<ipr::Type> result = {});
+         New* make_new(Optional<ipr::Expr_list>, const ipr::Construction&, Optional<ipr::Type> = {});
          Conditional* make_conditional(const ipr::Expr&, const ipr::Expr&,
                                        const ipr::Expr&, Optional<ipr::Type> = {});
 
@@ -1331,6 +1326,7 @@ namespace ipr {
          stable_farm<impl::Unary_minus> unary_minuses;
          stable_farm<impl::Unary_plus> unary_pluses;
          stable_farm<impl::Expansion> expansions;
+         stable_farm<impl::Construction> constructions;
 
          stable_farm<impl::Scope_ref> scope_refs;
          stable_farm<impl::And> ands;
@@ -1348,7 +1344,6 @@ namespace ipr {
          stable_farm<impl::Call> calls;
          stable_farm<impl::Comma> commas;
          stable_farm<impl::Const_cast> ccasts;
-         stable_farm<impl::Datum> data;
          stable_farm<impl::Div> divs;
          stable_farm<impl::Div_assign> div_assigns;
          stable_farm<impl::Dot> dots;

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -179,7 +179,7 @@ namespace ipr {
    struct Coerce;                // generalized type conversion -- implicit conversion
    struct Comma;                 // comma-operator                 a, b
    struct Const_cast;            // const-cast             const_cast<T&>(v)
-   struct Datum;                 // object construction             T(v)
+   struct Construction;          // object construction            T(v)
    struct Div;                   // division                       a / b
    struct Div_assign;            // in-place division              a /= b
    struct Dot;                   // direct member selection        x.m
@@ -1269,6 +1269,19 @@ namespace ipr {
    // Integral or floating point promotion -- "(int)'2'"
    struct Promote : Unary<Category<Category_code::Promote>> { };
 
+                                // -- Construction --
+   // An expression of the form "T(e1, e2, .. en)" or "T{e1, e2, .. en}"
+   // where "T" is a type and "ei"s are expressions.  This is not a function
+   // call -- although syntactically it looks like so.  "T" will
+   // be the `type()' of this expression.
+   // The contructor selected for the construction operation is indicated
+   // by implementation, which is inherited from Classic.
+   struct Construction : Unary<Category<Category_code::Construction, Classic>,
+                               const Enclosure&> {
+      // The sequence of arguments used for this construction
+      Arg_type arguments() const { return operand(); }
+   };
+
                                 // -- Read --
    // Lvalue-to-rvalue conversion -- "= var"
    struct Read : Unary<Category<Category_code::Read>> { };
@@ -1416,18 +1429,6 @@ namespace ipr {
                                 // -- Const_cast --
    // const_cast-expression -- "const_cast<type>(expr)".
    struct Const_cast : Cast_expr<Category_code::Const_cast> { };
-
-                                // -- Datum --
-   // An expression of the form "T(e1, e2, .. en)" where "T"
-   // is a type and "ei"s are expressions.  This is not a function
-   // call -- although syntactically it looks like so.  "T" will
-   // be the `type()' of this expression.
-   struct Datum : Binary<Category<Category_code::Datum, Classic>,
-                          const Type&, const Enclosure&> {
-      // See comments for the various cast operators regarding type().
-
-      Arg2_type args() const { return second(); }
-   };
 
                                 // -- Div --
    // Division-expression -- "a / b"
@@ -1580,10 +1581,18 @@ namespace ipr {
    // This node represents a new-expression:
    //    ::_opt new new-placement_opt new-type-id new-initializer_opt
    //    ::_opt new new-placement_opt ( type-id ) new-initializer_opt
-   struct New : Category<Category_code::New, Classic> {
-      virtual Optional<Expr_list> placement() const = 0;
-      virtual const Type& allocated_type() const = 0;
-      virtual Optional<Expr_list> initializer() const = 0;
+   // Semantically, this has a binary structure where the first operand
+   // is the placement-list, and the second operand is a construction expression
+   // that indicates the new-type-id or the type-id coupled with the new-initializer if any.
+   // When the new-initializer is missing, the Enclosure of the Contruction has no delimiter
+   // and the arguments of the Enclosure is a Phantom node.
+   // The allocator function is indicated by the implementation().
+   struct New : Binary<Category<Category_code::New, Classic>,
+                       Optional<Expr_list>, const Construction&> {
+      // This predicate holds if the new-expression explicitly requested a global allocator.
+      virtual bool global_requested() const = 0;
+      Optional<Expr_list> placement() const { return first(); }
+      const Construction& initializer() const { return second(); }
    };
 
                                 // -- Conditional --
@@ -2178,7 +2187,7 @@ namespace ipr {
       virtual void visit(const Coerce&);
       virtual void visit(const Comma&);
       virtual void visit(const Const_cast&);
-      virtual void visit(const Datum&);
+      virtual void visit(const Construction&);
       virtual void visit(const Div&);
       virtual void visit(const Div_assign&);
       virtual void visit(const Dot&);

--- a/include/ipr/node-category
+++ b/include/ipr/node-category
@@ -96,7 +96,7 @@ Cast,                               // ipr::Cast
 Coerce,                             // ipr::Coerce
 Comma,                              // ipr::Comma
 Const_cast,                         // ipr::Const_cast
-Datum,                              // ipr::Datum
+Construction,                       // ipr::Construction
 Div,                                // ipr::Div
 Div_assign,                         // ipr::Div_assign
 Dot,                                // ipr::Dot

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -58,16 +58,11 @@ namespace ipr {
       };
 
       // -- impl::New --
-      New::New(Optional<ipr::Expr_list> where, const ipr::Type& what,
-               Optional<ipr::Expr_list> args)
-            : where{ where }, what{ what }, args{ args }
+      New::New(Optional<ipr::Expr_list> where, const ipr::Construction& expr)
+            : Classic_binary_expr<ipr::New>{ where, expr }
       { }
 
-      Optional<ipr::Expr_list> New::placement() const { return where; }
-
-      const ipr::Type& New::allocated_type() const { return what; }
-
-      Optional<ipr::Expr_list> New::initializer() const { return args; }
+      bool New::global_requested() const { return global; }
 
       // -------------------------------------
       // -- master_decl_data<ipr::Template> --
@@ -1677,6 +1672,13 @@ namespace ipr {
          return expansion;
       }
 
+      impl::Construction*
+      expr_factory::make_construction(const ipr::Type& t, const ipr::Enclosure& e) {
+         auto x = constructions.make(e);
+         x->constraint = &t;
+         return x;
+      }
+
       impl::And*
       expr_factory::make_and(const ipr::Expr& l, const ipr::Expr& r, Optional<ipr::Type> result) {
          impl::And* and_expr = ands.make(l, r);
@@ -1786,11 +1788,6 @@ namespace ipr {
       impl::Const_cast*
       expr_factory::make_const_cast(const ipr::Type& t, const ipr::Expr& e) {
          return ccasts.make(t, e);
-      }
-
-      impl::Datum*
-      expr_factory::make_datum(const ipr::Type& t, const ipr::Enclosure& e) {
-         return data.make(t, e);
       }
 
       impl::Div*
@@ -2032,9 +2029,8 @@ namespace ipr {
       }
 
       impl::New*
-      expr_factory::make_new(const ipr::Type& allocated, Optional<ipr::Expr_list> init,
-                       Optional<Expr_list> placement, Optional<ipr::Type> result) {
-         impl::New* new_expr = news.make(placement, allocated, init);
+      expr_factory::make_new(Optional<ipr::Expr_list> placement, const ipr::Construction& expr, Optional<ipr::Type> result) {
+         impl::New* new_expr = news.make(placement, expr);
          new_expr->constraint = result;
          return new_expr;
       }

--- a/src/io.cxx
+++ b/src/io.cxx
@@ -519,10 +519,10 @@ namespace ipr
                << token('(') << e.args() << token(')');
          }
 
-         void visit(const Datum& e) override
+         void visit(const Construction& e) override
          {
             pp << xpr_type(e.type())
-               << xpr_primary_expr(e.args());
+               << xpr_primary_expr(e.arguments());
          }
 
          //        postfix-expression --
@@ -624,14 +624,10 @@ namespace ipr
          void visit(const New& e) override
          {
             pp << xpr_identifier("new") << token(' ');
-
             if (auto p = e.placement())
                pp << token('(') << p.get() << token(") ");
-
-            pp << xpr_type(e.allocated_type());
-
-            if (auto init = e.initializer())
-               pp << token(" (") << init.get() << token(')');
+            // Note: The following does not exactly conform to the ISO C++ grammar (because of ambiguity).
+            pp << xpr_expr(e.initializer());
          }
 
          void visit(const Delete& e) override

--- a/src/traversal.cxx
+++ b/src/traversal.cxx
@@ -643,7 +643,7 @@ ipr::Visitor::visit(const Not_equal& e)
 }
 
 void
-ipr::Visitor::visit(const Datum& e)
+ipr::Visitor::visit(const Construction& e)
 {
    visit(as<Classic>(e));
 }


### PR DESCRIPTION
With the C++17 reclassification of value categories to [guarantee copy elision in certain circumstances](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/p0135r0.html) the meaning of `T(x, y)` (modeled by `ipr::Datum`) changed, that expression no longer really constructs a data or an rvalue.  Rather it is only a description of an object construction (note: the object itself isn't constructed).  A separate operation -- temporary materialization -- is to perform that action of actually constructing the object.  This patch incorporate that semantic refinement in the IPR.  

The class `ipr::Datum` is renamed to `ipr::Construction` to encapsulate the notion of object construction description.  It is now a unary structure since the `type()` is also the type of the object being constructed.  The `operand()` is the argument list appropriately enclosed (represented by an `ipr::Enclosure` node).

Furthermore, this change allows more similarity with `ipr::New` class, since now `T(x, y)` no longer means what it used to mean in pre-C++17.

This is a source breaking change.  Previous uses of `ipr::Datum` needs to be replaced with an `ipr::Materialize` node that takes a `ipr::Construction` node.

Fix #19 