### PR TITLE
Fix off by one index error

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -463,7 +463,7 @@ namespace ipr {
          int size() const final { return 1; }
          const T& get(int i) const final
          {
-            if (i == 1)
+            if (i == 0)
                return datum;
             throw std::domain_error("singleton_declset::get");
          }


### PR DESCRIPTION
The implementation of `singleton_declset::get` has an off-by-one error in its implementation.  Fixed.