### PR TITLE
Change return type of size()

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -78,10 +78,11 @@ namespace ipr {
          using Rep = std::deque<const void*>;
          using pointer = const T*;
          using Iterator = typename Seq::Iterator;
+         using Index = typename Seq::Index;
 
          explicit ref_sequence(std::size_t n = 0) : Rep(n) { }
 
-         int size() const final { return Rep::size(); }
+         Index size() const final { return Rep::size(); }
 
          using Seq::operator[];
          using Seq::begin;
@@ -92,7 +93,7 @@ namespace ipr {
          using Rep::push_back;
          using Rep::push_front;
 
-         const T& get(int p) const final { return *pointer(this->at(p)); }
+         const T& get(Index p) const final { return *pointer(this->at(p)); }
       };
 
                                 // -- impl::val_sequence --
@@ -104,6 +105,7 @@ namespace ipr {
          using Seq = ipr::Sequence<typename T::Interface>;
          using Impl = stable_farm<T>;
          using Iterator = typename Seq::Iterator;
+         using Index = typename Seq::Index;
 
          using Seq::operator[];
          using Seq::begin;
@@ -111,7 +113,7 @@ namespace ipr {
 
          val_sequence() : mark(this->before_begin()) { }
 
-         int size() const final
+         Index size() const final
          {
             return std::distance(Impl::begin(), Impl::end());
          }
@@ -123,7 +125,7 @@ namespace ipr {
             return &*mark;
          }
 
-         const T& get(int p) const final
+         const T& get(Index p) const final
          {
             if (p < 0 || p >= size())
                throw std::domain_error("val_sequence::get");
@@ -348,9 +350,9 @@ namespace ipr {
       struct String : impl::Node<ipr::String> {
          explicit String(const util::string&);
 
-         int size() const;
-         const char* begin() const;
-         const char* end() const;
+         Index size() const final;
+         const char* begin() const final;
+         const char* end() const final;
 
       private:
          const util::string& text;
@@ -422,7 +424,7 @@ namespace ipr {
       struct scope_datum : link<scope_datum> {
          // The position of this Decl in its scope.  It shall be set
          // at the actual declaration creation by the creating scope.
-         int scope_pos = -1;
+         std::size_t scope_pos = { };
 
          // The specifiers for this declaration.  S
          ipr::DeclSpecifiers spec = { };
@@ -440,8 +442,8 @@ namespace ipr {
       // The chain of declarations in a scope.
 
       struct decl_sequence : ipr::Sequence<ipr::Decl> {
-         int size() const final;
-         const ipr::Decl& get(int) const final;
+         Index size() const final;
+         const ipr::Decl& get(Index) const final;
          // Inserts a declaration in this sequence.
          void insert(scope_datum*);
 
@@ -457,12 +459,13 @@ namespace ipr {
 
       template<class T>
       struct singleton_declset : ipr::Sequence<ipr::Decl> {
+         using Index = typename Sequence<ipr::Decl>::Index;
          const T& datum;
 
          explicit singleton_declset(const T& t) : datum(t) { }
 
-         int size() const final { return 1; }
-         const T& get(int i) const final
+         Index size() const final { return 1; }
+         const T& get(Index i) const final
          {
             if (i == 0)
                return datum;
@@ -578,8 +581,8 @@ namespace ipr {
          explicit Overload(const ipr::Name&);
 
          const ipr::Sequence<ipr::Decl>& operator[](const ipr::Type&) const final;
-         int size() const final;
-         const ipr::Decl& get(int) const final;
+         Index size() const final;
+         const ipr::Decl& get(Index) const final;
          overload_entry* lookup(const ipr::Type&) const;
 
          template<class T>
@@ -600,8 +603,8 @@ namespace ipr {
          explicit singleton_overload(const ipr::Decl&);
 
          const ipr::Type& type() const final;
-         int size() const final;
-         const ipr::Decl& get(int) const final;
+         Index size() const final;
+         const ipr::Decl& get(Index) const final;
          const ipr::Sequence<ipr::Decl>& operator[](const ipr::Type&) const final;
       };
 
@@ -614,8 +617,8 @@ namespace ipr {
 
       struct empty_overload : impl::Node<ipr::Overload> {
          const ipr::Type& type() const final;
-         int size() const final;
-         const ipr::Decl& get(int) const final;
+         Index size() const final;
+         const ipr::Decl& get(Index) const final;
          const ipr::Sequence<ipr::Decl>& operator[](const ipr::Type&) const final;
       };
 
@@ -670,6 +673,7 @@ namespace ipr {
       template<class Seq>
       struct typed_sequence : impl::Type<ipr::Product>,
                               ipr::Sequence<ipr::Type> {
+         using Index = typename Sequence<ipr::Type>::Index;
          Seq seq;
 
          typed_sequence() { }
@@ -679,8 +683,8 @@ namespace ipr {
          {
             return *this;
          }
-         int size() const final { return seq.size(); }
-         const ipr::Type& get(int i) const final
+         Index size() const final { return seq.size(); }
+         const ipr::Type& get(Index i) const final
          {
             return seq.get(i).type();
          }
@@ -803,7 +807,7 @@ namespace ipr {
          const ipr::Type& type() const;
          const ipr::Region& home_region() const;
          const ipr::Region& lexical_region() const;
-         int position() const;
+         std::size_t position() const;
          Optional<ipr::Expr> initializer() const final;
          // FIXME: This should go away.
          const Parameter_list& membership() const;
@@ -812,28 +816,28 @@ namespace ipr {
       struct Base_type final : unique_decl<ipr::Base_type> {
          const ipr::Type& base;
          const ipr::Region& where;
-         const int scope_pos;
+         const std::size_t scope_pos;
 
-         Base_type(const ipr::Type&, const ipr::Region&, int);
+         Base_type(const ipr::Type&, const ipr::Region&, std::size_t);
          const ipr::Type& type() const;
          const ipr::Region& lexical_region() const;
          const ipr::Region& home_region() const;
-         int position() const;
+         std::size_t position() const;
          Optional<ipr::Expr> initializer() const final;
       };
 
       struct Enumerator final : unique_decl<ipr::Enumerator> {
          const ipr::Name& id;
          const ipr::Enum& constraint;
-         const int scope_pos;
+         const std::size_t scope_pos;
          const ipr::Region* where;
          Optional<ipr::Expr> init;
 
-         Enumerator(const ipr::Name&, const ipr::Enum&, int);
+         Enumerator(const ipr::Name&, const ipr::Enum&, std::size_t);
          const ipr::Name& name() const;
          const ipr::Region& lexical_region() const;
          const ipr::Region& home_region() const;
-         int position() const;
+         std::size_t position() const;
          Optional<ipr::Expr> initializer() const final;
          // FIXME: this should go away.
          const ipr::Enum& membership() const;
@@ -847,6 +851,7 @@ namespace ipr {
       struct homogeneous_scope : impl::Node<ipr::Scope>,
                                  ipr::Sequence<ipr::Decl>,
                                  std::allocator<void> {
+         using Index = typename ipr::Sequence<ipr::Decl>::Index;
          typed_sequence<val_sequence<Member>> decls;
          empty_overload missing;
 
@@ -856,8 +861,8 @@ namespace ipr {
             decls.constraint = &t;
          }
 
-         int size() const final { return decls.size(); }
-         const Member& get(int i) const final { return decls.seq.get(i); }
+         Index size() const final { return decls.size(); }
+         const Member& get(Index i) const final { return decls.seq.get(i); }
 
          const ipr::Product& type() const final { return decls; }
 
@@ -877,8 +882,8 @@ namespace ipr {
       const ipr::Overload&
       homogeneous_scope<Member>::operator[](const ipr::Name& n) const
       {
-         const int s = decls.size();
-         for (int i = 0; i < s; ++i) {
+         const auto s = decls.size();
+         for (Index i = 0; i < s; ++i) {
             const auto& decl = decls.seq.get(i);
             if (&decl.name() == &n)
                return decl.overload;
@@ -891,13 +896,14 @@ namespace ipr {
                class RegionKind = Node<ipr::Region>>
       struct homogeneous_region : RegionKind {
          using location_span = ipr::Region::Location_span;
+         using Index = typename Sequence<Member>::Index;
          const ipr::Region& parent;
          location_span extent;
          Optional<ipr::Expr> owned_by { };
          homogeneous_scope<Member> scope;
 
-         int size() const { return scope.size(); }
-         const Member& get(int i) const { return scope.get(i); }
+         Index size() const { return scope.size(); }
+         const Member& get(Index i) const { return scope.get(i); }
          const ipr::Product& type() const { return scope.type(); }
 
          const ipr::Region& enclosing() const { return parent; }
@@ -949,7 +955,7 @@ namespace ipr {
             return this->decl_data.master_data->overload->where;
          }
 
-         int position() const
+         std::size_t position() const
          {
             return this->decl_data.scope_pos;
          }

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -350,17 +350,18 @@ namespace ipr {
       using value_type = T;
       using reference = const T&;
       using pointer = const T*;
+      using Index = std::size_t;
       using iterator = Iterator;
 
-      virtual int size() const = 0;
+      virtual Index size() const = 0;
       Iterator begin() const;
       Iterator end() const;
 
-      Iterator position(int) const;
-      const T& operator[](int) const;
+      Iterator position(Index) const;
+      const T& operator[](Index) const;
 
    protected:
-      virtual const T& get(int) const = 0;
+      virtual const T& get(Index) const = 0;
    };
 
                                 // -- Sequence<>::Iterator --
@@ -374,10 +375,11 @@ namespace ipr {
       using reference = const T&;
       using pointer = const T*;
       using difference_type = ptrdiff_t;
+      using Index = typename Sequence<T>::Index;
       using iterator_category = std::bidirectional_iterator_tag;
 
       Iterator() {}
-      Iterator(const Sequence* s, int i) : seq{ s }, index{ i } { }
+      Iterator(const Sequence* s, Index i) : seq{ s }, index{ i } { }
 
       const T& operator*() const
       { return seq->get(index); }
@@ -418,13 +420,13 @@ namespace ipr {
       { return !(*this == other); }
 
    private:
-      const Sequence* seq{};
-      int index{};
+      const Sequence* seq { };
+      Index index { };
    };
 
    template<class T>
    inline typename Sequence<T>::Iterator
-   Sequence<T>::position(int i) const
+   Sequence<T>::position(Index i) const
    { return { this, i }; }
 
    template<class T>
@@ -439,7 +441,7 @@ namespace ipr {
 
    template<class T>
    inline const T&
-   Sequence<T>::operator[](int p) const
+   Sequence<T>::operator[](Index p) const
    { return get(p); }
 
                                  // -- Delimiter --
@@ -631,7 +633,8 @@ namespace ipr {
    // Strings in IPR are immutable, and therefore unified.
    struct String : Category<Category_code::String, Node> {
       using iterator = const char*;
-      virtual int size() const = 0;
+      using Index = std::size_t;
+      virtual Index size() const = 0;
       virtual iterator begin() const = 0;
       virtual iterator end() const  = 0;
       static const String& empty_string();            // dedicated node for an empty string
@@ -877,7 +880,7 @@ namespace ipr {
       virtual const Overload& operator[](const Name&) const = 0;
 
       // How may declarations are there in this Scope.
-      int size() const { return members().size(); }
+      auto size() const { return members().size(); }
 
       Iterator begin() const { return members().begin(); }
       Iterator end() const { return members().end(); }
@@ -1024,9 +1027,10 @@ namespace ipr {
    // A Product represents a Cartesian product of Types.  Pragmatically,
    // it may be viewed as a Sequence of Types.  It is a Type.
    struct Product : Unary<Category<Category_code::Product, Type>, const Sequence<Type>&> {
+      using Index = std::size_t;
       Arg_type elements() const { return operand(); }
-      int size() const { return elements().size(); }
-      const Type& operator[](int i) const { return elements()[i]; }
+      auto size() const { return elements().size(); }
+      const Type& operator[](Index i) const { return elements()[i]; }
    };
 
                                 // -- Ptr_to_member --
@@ -1078,9 +1082,10 @@ namespace ipr {
    // A Sum type represents a distinct union of types.  This is currently
    // used only for dynamic exception specification in Function type.
    struct Sum : Unary<Category<Category_code::Sum, Type>, const Sequence<Type>&> {
+      using Index = std::size_t;
       Arg_type elements() const { return operand(); }
-      int size() const { return elements().size(); }
-      const Type& operator[](int i) const { return elements()[i]; }
+      auto size() const { return elements().size(); }
+      const Type& operator[](Index i) const { return elements()[i]; }
    };
 
                                 // -- Forall --
@@ -1209,9 +1214,10 @@ namespace ipr {
    // discarded except the last one.  The type of an Expr_list
    // is a Product.
    struct Expr_list : Unary<Category<Category_code::Expr_list>, const Sequence<Expr>&> {
+      using Index = std::size_t;
       Arg_type elements() const { return operand(); }
-      int size() const { return elements().size(); }
-      const Expr& operator[](int i) const { return elements()[i]; }
+      auto size() const { return elements().size(); }
+      const Expr& operator[](Index i) const { return elements()[i]; }
    };
 
                                 // -- Sizeof --
@@ -1908,7 +1914,7 @@ namespace ipr {
 
       virtual Optional<Expr> initializer() const = 0;
 
-      virtual int position() const = 0;
+      virtual std::size_t position() const = 0;
 
       // This is the first seen declaration for name() in a given
       // translation unit.  The master declaration is therefore the

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -19,7 +19,7 @@ namespace ipr {
    const String& String::empty_string()
    {
       struct Empty_string final : impl::Node<String> {
-         int size() const { return 0; }
+         Index size() const { return 0; }
          iterator begin() const { return ""; }
          iterator end() const { return begin(); }
       };
@@ -46,12 +46,12 @@ namespace ipr {
             return compare(lhs.scope_pos, rhs.scope_pos);
          }
 
-         int operator()(int pos, const scope_datum& s) const
+         int operator()(std::size_t pos, const scope_datum& s) const
          {
             return compare(pos, s.scope_pos);
          }
 
-         int operator()(const scope_datum& s, int pos) const
+         int operator()(const scope_datum& s, std::size_t pos) const
          {
             return compare(s.scope_pos, pos);
          }
@@ -79,13 +79,12 @@ namespace ipr {
       // -- impl::decl_sequence --
       // -------------------------
 
-      int
-      decl_sequence::size() const {
+      decl_sequence::Index decl_sequence::size() const {
          return decls.size();
       }
 
       const ipr::Decl&
-      decl_sequence::get(int i) const {
+      decl_sequence::get(Index i) const {
          scope_datum* result = decls.find(i, scope_datum::comp());
          return *util::check(result)->decl;
       }
@@ -103,13 +102,12 @@ namespace ipr {
             : name(n), where(0)
       { }
 
-      int
-      Overload::size() const {
+      Overload::Index Overload::size() const {
          return entries.size();
       }
 
       const ipr::Decl&
-      Overload::get(int i) const {
+      Overload::get(Index i) const {
          return *masters.at(i)->decl;
       }
 
@@ -144,13 +142,13 @@ namespace ipr {
          return seq.datum.type();
       }
 
-      int
+      singleton_overload::Index
       singleton_overload::size() const {
          return 1;
       }
 
       const ipr::Decl&
-      singleton_overload::get(int i) const {
+      singleton_overload::get(Index i) const {
          if (i != 1)
             throw std::domain_error("singleton_overload::get: out-of-range ");
          return seq.datum;
@@ -172,13 +170,12 @@ namespace ipr {
          throw std::domain_error("empty_overload::type");
       }
 
-      int
-      empty_overload::size() const {
+      empty_overload::Index empty_overload::size() const {
          return 0;
       }
 
       const ipr::Decl&
-      empty_overload::get(int) const {
+      empty_overload::get(Index) const {
          throw std::domain_error("impl::empty_overload::get");
       }
 
@@ -250,7 +247,7 @@ namespace ipr {
       // -- impl::Base_type --
       // ---------------------
 
-      Base_type::Base_type(const ipr::Type& t, const ipr::Region& r, int p)
+      Base_type::Base_type(const ipr::Type& t, const ipr::Region& r, std::size_t p)
             : base(t), where(r), scope_pos(p)
       { }
 
@@ -269,7 +266,7 @@ namespace ipr {
          return where;
       }
 
-      int
+      std::size_t
       Base_type::position() const {
          return scope_pos;
       }
@@ -283,7 +280,7 @@ namespace ipr {
       // -- impl::Enumerator --
       // ----------------------
 
-      Enumerator::Enumerator(const ipr::Name& n, const ipr::Enum& t, int p)
+      Enumerator::Enumerator(const ipr::Name& n, const ipr::Enum& t, std::size_t p)
             : id(n), constraint(t), scope_pos(p), where(0), init(0)
       { }
 
@@ -307,7 +304,7 @@ namespace ipr {
          return constraint;
       }
 
-      int
+      std::size_t
       Enumerator::position() const {
          return scope_pos;
       }
@@ -443,7 +440,7 @@ namespace ipr {
          return *util::check(where);
       }
 
-      int
+      std::size_t
       Parameter::position() const {
          return abstract_name.rep.second;
       }
@@ -752,8 +749,7 @@ namespace ipr {
       String::String(const util::string& s) : text(s)
       { }
 
-      int
-      String::size() const {
+      String::Index String::size() const {
          return text.size();
       }
 
@@ -2047,8 +2043,8 @@ namespace ipr {
       expr_factory::rname_for_next_param(const impl::Mapping& map,
                                          const ipr::Type& t) {
          using Rep = impl::Rname::Rep;
-         return rnames.insert(Rep{ t, map.nesting_level, map.parameters.size() },
-                              ternary_compare());
+         auto pos = static_cast<int>(map.parameters.size());
+         return rnames.insert(Rep{ t, map.nesting_level, pos }, ternary_compare());
       }
 
       impl::Mapping*


### PR DESCRIPTION
15+ years ago, we were hoping that WG21 would fix the mistake of making the return type of `size()` an unsigned type.  We defaulted to `int` as just the natural integer type of C and C++.  Despite all efforts over the years to convince WG21 (the most recent being with `std::span`), it is with sad heart that we have to make the change here to minimize the friction with using the standard library