### PR TITLE
Unify ipr::Symbol

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -1236,6 +1236,9 @@ namespace ipr {
          const ipr::Linkage& get_linkage(const std::string&);
          const ipr::Linkage& get_linkage(const ipr::String&);
 
+         // Return a symbol with a given name and type.
+         const ipr::Symbol& get_symbol(const ipr::Name&, const ipr::Type&);
+
          Annotation* make_annotation(const ipr::String&, const ipr::Literal&);
 
          // Build a node for a missing expression of an unspecified type.
@@ -1264,7 +1267,6 @@ namespace ipr {
 
          Guide_name* make_guide_name(const ipr::Template&);
 
-         Symbol* make_symbol(const ipr::Name&, Optional<ipr::Type> = { });
          Address* make_address(const ipr::Expr&, Optional<ipr::Type> = {});
          Array_delete* make_array_delete(const ipr::Expr&);
          Complement* make_complement(const ipr::Expr&, Optional<ipr::Type> = {});
@@ -1379,7 +1381,7 @@ namespace ipr {
          stable_farm<impl::Phantom> phantoms;
          stable_farm<impl::Eclipsis> eclipses;
 
-         stable_farm<impl::Symbol> symbols;
+         util::rb_tree::container<impl::Symbol> symbols;
          stable_farm<impl::Address> addresses;
          stable_farm<impl::Annotation> annotations;
          stable_farm<impl::Array_delete> array_deletes;

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -1206,6 +1206,8 @@ namespace ipr {
                                 // -- Symbol --
    // Representation of self-evaluating (generalized) expressions, i.e. irreducible expressions.
    // That includes builtin types, as well as designated special values such as `nullptr'.
+   // Note: A symbol is uniquely identified by the pair (name, type), so a symbol can be `overloaded'.
+   // Symbol nodes are unified, as they are self-evaluating, e.g. core values.
    struct Symbol : Unary<Category<Category_code::Symbol>, const Name&> {
       const Name& name() const { return operand(); }
    };

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -1509,6 +1509,18 @@ namespace ipr {
          return *linkages.insert(lang, unary_compare());
       }
 
+      const ipr::Symbol&
+      expr_factory::get_symbol(const ipr::Name& n, const ipr::Type& t)
+      {
+         const auto comparator = [](auto& x, auto& y) {
+            if (auto cmp = compare(x.name(), x.name()))
+               return cmp;
+            return compare(x.type(), y.type());
+         };
+
+         return *symbols.insert(impl::Symbol{ n, t }, comparator);
+      }
+
       impl::Phantom*
       expr_factory::make_phantom() {
          return phantoms.make();
@@ -1522,12 +1534,6 @@ namespace ipr {
       impl::Eclipsis* expr_factory::make_eclipsis(const ipr::Type& t)
       {
          return eclipses.make(&t);
-      }
-
-      impl::Symbol*
-      expr_factory::make_symbol(const ipr::Name& n, Optional<ipr::Type> t)
-      {
-         return make(symbols, n).with_type(t);
       }
 
       impl::Address*


### PR DESCRIPTION
Symbol values are core values, so they should be unified.  This patch adds that capability, in addition to explicitly providing the facility of symbol overloading.