### PR TITLE
Explicit representation of "this"

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -1160,6 +1160,11 @@ namespace ipr {
       using Phantom = Expr<ipr::Phantom>;
       using Eclipsis = Expr<ipr::Eclipsis>;
 
+      struct This : impl::Expr<ipr::This> {
+         Optional<ipr::Decl> owner;
+         Optional<ipr::Decl> context() const final { return owner; }
+      };
+
       struct Symbol final : Unary_expr<ipr::Symbol> {
          explicit Symbol(const ipr::Name&);
          Symbol(const ipr::Name&, const ipr::Type&);
@@ -1350,6 +1355,7 @@ namespace ipr {
          const ipr::Phantom* make_phantom(const ipr::Type&);
 
          Eclipsis* make_eclipsis(const ipr::Type&);
+         This* make_this();
 
          // Returns an IPR node for a typed literal expression.
          Literal* make_literal(const ipr::Type&, const ipr::String&);
@@ -1485,6 +1491,7 @@ namespace ipr {
 
          stable_farm<impl::Phantom> phantoms;
          stable_farm<impl::Eclipsis> eclipses;
+         stable_farm<impl::This> these;
 
          util::rb_tree::container<impl::Symbol> symbols;
          stable_farm<impl::Sizeof> sizeofs;

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -128,6 +128,7 @@ namespace ipr {
    struct Phantom;               // placeholder for arrays of unknown bounds,
                                  // rethrow, empty parts of a For, etc...
    struct Eclipsis;              // the `...' in a unary fold
+   struct This;                  // the special `this' reserved word for the address on the implicit object 
    struct Lambda;                // Lambda expression, packing an environment and a code pointer
 
    // -------------------------------------------------------
@@ -1309,6 +1310,20 @@ namespace ipr {
    // was omitted, hence the name.
    struct Eclipsis : Category<Category_code::Eclipsis> { };
 
+                                 // -- This --
+   // Representation of the `this' implicit parameter for non-static member functions.
+   // An earlier design sought to treat `this' no different from any other function parameter declaration, in part
+   // to account for multimethods and uniform function call syntax in the same framework.  The current
+   // design makes `this' explicit in the semantics graph in part based on recent ISO C++ extensions.
+   // The `this' parameter used to make sense only in the context of non-static member functions, so its
+   // enclosing context was always a function declaration.  Recent versions of C++ introduced default initializers
+   // for non-static data members that can make use of `this', so the function declaration context has to be
+   // inferred based on the constructor that makes uses of the default initializer and is completely unknown at
+   // point of the specification of the default member initializer.
+   struct This : Category<Category_code::This> {
+      virtual Optional<Decl> context() const = 0;  // declaration of the enclosing member function, if any.
+    };
+
    // Semantic description of the variety of lambda capture specifications:
    //   - default captures: indicated by the squiggles "=" (by value), and "&" (by reference) at source level
    //   - implicit object: indicated by "this" (by reference), and "*this" (by value) at source level
@@ -2352,6 +2367,7 @@ namespace ipr {
       virtual void visit(const Scope&);
       virtual void visit(const Phantom&);
       virtual void visit(const Eclipsis&);
+      virtual void visit(const This&);
       virtual void visit(const Lambda&);
 
       virtual void visit(const Symbol&);

--- a/include/ipr/node-category
+++ b/include/ipr/node-category
@@ -52,6 +52,7 @@ Rname,                              // ipr::Rname
 
 Phantom,                            // ipr::Phantom
 Eclipsis,                           // ipr::Eclipsis
+This,                               // ipr::This
 Lambda,                             // ipr::Lambda
 
 Symbol,                             // ipr::Symbol

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -1574,6 +1574,11 @@ namespace ipr {
          return eclipses.make(&t);
       }
 
+      impl::This* expr_factory::make_this()
+      {
+         return these.make();
+      }
+
       impl::Address*
       expr_factory::make_address(const ipr::Expr& e, Optional<ipr::Type> t)
       {

--- a/src/io.cxx
+++ b/src/io.cxx
@@ -400,6 +400,7 @@ namespace ipr
                pp << xpr_primary_expr(t.expr());
          }
          void visit(const Phantom&) final { } // nothing to print
+         void visit(const This&) final { pp << xpr_identifier{"this"}; }
          void visit(const Enclosure& e) final
          {
             static constexpr const char* syntax[] = { "\0\0", "()", "{}", "[]", "<>" };

--- a/src/traversal.cxx
+++ b/src/traversal.cxx
@@ -288,6 +288,11 @@ void ipr::Visitor::visit(const Eclipsis& e)
    visit(as<Expr>(e));
 }
 
+void ipr::Visitor::visit(const This& e)
+{
+   visit(as<Expr>(e));
+}
+
 void ipr::Visitor::visit(const Lambda& e)
 {
    visit(as<Expr>(e));


### PR DESCRIPTION
Revert from Classic IPR design decision to treat `this` no different from any other function parameter.

Fix #28