### PR TITLE
Miscellaneous cleanup [1/n]

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -1579,6 +1579,7 @@ namespace ipr {
 
 
       struct Template : impl::Decl<ipr::Template> {
+         util::ref<const ipr::Udt<ipr::Decl>> member_of;
          impl::Mapping* init;
          util::ref<const ipr::Region> lexreg;
          impl::Expr_list args;

--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -671,7 +671,7 @@ namespace ipr {
       struct master_decl_data : basic_decl_data<Interface>, overload_entry {
          // The declaration that is considered to be the definition.
          Optional<Interface> def { };
-         Optional<ipr::Linkage> langlinkage { };
+         util::ref<const ipr::Linkage> langlinkage { };
 
          // The overload set that contains this master declaration.  It
          // shall be set at the time the node for the master declaration
@@ -691,7 +691,7 @@ namespace ipr {
          using Base = basic_decl_data<ipr::Template>;
          // The declaration that is considered to be the definition.
          Optional<ipr::Template> def { };
-         Optional<ipr::Linkage> langlinkage { };
+         util::ref<ipr::Linkage> langlinkage { };
          const ipr::Template* primary;
          const ipr::Region* home;
 
@@ -942,7 +942,7 @@ namespace ipr {
       template<class Interface>
       struct unique_decl : impl::Stmt<Node<Interface>> {
          ipr::DeclSpecifiers spec;
-         Optional<ipr::Linkage> langlinkage { };
+         util::ref<const ipr::Linkage> langlinkage { };
          singleton_overload overload;
 
          unique_decl() : spec(ipr::DeclSpecifiers::None),
@@ -965,13 +965,10 @@ namespace ipr {
          Optional<ipr::Expr> init;
 
          Parameter(const ipr::Name&, const impl::Rname&);
-
          const ipr::Name& name() const;
          const ipr::Type& type() const;
-         const ipr::Region& home_region() const;
-         const ipr::Region& lexical_region() const;
          Decl_position position() const;
-         Optional<ipr::Expr> initializer() const final;
+         Optional<ipr::Expr> initializer() const final { return init; }
          // FIXME: This should go away.
          const Parameter_list& membership() const;
       };
@@ -1001,7 +998,7 @@ namespace ipr {
          const ipr::Region& lexical_region() const;
          const ipr::Region& home_region() const;
          Decl_position position() const;
-         Optional<ipr::Expr> initializer() const final;
+         Optional<ipr::Expr> initializer() const final { return init; }
          // FIXME: this should go away.
          const ipr::Enum& membership() const;
       };
@@ -1171,7 +1168,7 @@ namespace ipr {
       };
 
       struct Lambda : impl::Node<ipr::Lambda> {
-         Optional<ipr::Closure> constraint;
+         util::ref<const ipr::Closure> constraint;
          Optional<ipr::Type> value_type;
          impl::Parameter_list parms;
          const ipr::Expr* body = nullptr;
@@ -1286,7 +1283,7 @@ namespace ipr {
 
       struct Mapping : impl::Expr<ipr::Mapping> {
          impl::Parameter_list parms;
-         Optional<ipr::Type> value_type;
+         util::ref<const ipr::Type> value_type;
          Optional<ipr::Expr> body;
 
          Mapping(const ipr::Region&, Mapping_level);
@@ -1582,18 +1579,16 @@ namespace ipr {
 
 
       struct Template : impl::Decl<ipr::Template> {
-         const ipr::Udt<ipr::Decl>* member_of;
          impl::Mapping* init;
-         const ipr::Region* lexreg;
+         util::ref<const ipr::Region> lexreg;
          impl::Expr_list args;
 
          Template();
-
          const ipr::Template& primary_template() const final;
          const ipr::Sequence<ipr::Decl>& specializations() const final;
          const ipr::Mapping& mapping() const final;
          Optional<ipr::Expr> initializer() const final;
-         const ipr::Region& lexical_region() const final;
+         const ipr::Region& lexical_region() const final { return lexreg.get(); }
       };
 
       template<>
@@ -1631,11 +1626,11 @@ namespace ipr {
 
       struct Alias : impl::Decl<ipr::Alias> {
          const ipr::Expr* aliasee;
-         const ipr::Region* lexreg;
+         util::ref<const ipr::Region> lexreg;
 
          Alias();
-         Optional<ipr::Expr> initializer() const final;
-         const ipr::Region& lexical_region() const;
+         Optional<ipr::Expr> initializer() const final { return aliasee; }
+         const ipr::Region& lexical_region() const final { return lexreg.get(); }
       };
 
       template<>
@@ -1645,12 +1640,11 @@ namespace ipr {
 
       struct Var : impl::Decl<ipr::Var> {
          Optional<ipr::Expr> init;
-         const ipr::Region* lexreg;
+         util::ref<const ipr::Region> lexreg;
 
          Var();
-
-         Optional<ipr::Expr> initializer() const final;
-         const ipr::Region& lexical_region() const final;
+         Optional<ipr::Expr> initializer() const final { return init; }
+         const ipr::Region& lexical_region() const final { return lexreg.get(); }
       };
 
       template<>
@@ -1660,19 +1654,18 @@ namespace ipr {
 
       // FIXME: Field should use unique_decl, not impl::Decl.
       struct Field : impl::Decl<ipr::Field> {
-         const ipr::Udt<ipr::Decl>* member_of;
+         util::ref<const ipr::Udt<ipr::Decl>> member_of;
          Optional<ipr::Expr> init;
 
          Field();
-
-         const ipr::Udt<ipr::Decl>& membership() const final;
+         const ipr::Udt<ipr::Decl>& membership() const final { return member_of.get(); }
 
          // Override ipr::Decl::lexical_region.  Which is the
          // same as home_region for a Field.  Note that fields
          // are always nonstatic data members.
-         const ipr::Region& lexical_region() const final;
-         const ipr::Region& home_region() const final;
-         Optional<ipr::Expr> initializer() const final;
+         const ipr::Region& lexical_region() const final { return membership().region(); }
+         const ipr::Region& home_region() const final { return membership().region(); }
+         Optional<ipr::Expr> initializer() const final { return init; }
       };
 
       template<>
@@ -1682,17 +1675,16 @@ namespace ipr {
 
       // FIXME: Bitfield should use unique_decl, not impl::Decl
       struct Bitfield : impl::Decl<ipr::Bitfield> {
-         const ipr::Expr* length;
-         const ipr::Udt<ipr::Decl>* member_of;
+         util::ref<const ipr::Expr> length;
+         util::ref<const ipr::Udt<ipr::Decl>> member_of;
          Optional<ipr::Expr> init;
 
          Bitfield();
-
-         const ipr::Expr& precision() const final;
-         const ipr::Region& lexical_region() const final;
-         const ipr::Region& home_region() const final;
-         const ipr::Udt<ipr::Decl>& membership() const final;
-         Optional<ipr::Expr> initializer() const final;
+         const ipr::Expr& precision() const final { return length.get(); }
+         const ipr::Region& lexical_region() const final { return membership().region(); }
+         const ipr::Region& home_region() const final { return membership().region(); }
+         const ipr::Udt<ipr::Decl>& membership() const final { return member_of.get(); }
+         Optional<ipr::Expr> initializer() const final { return init; }
       };
 
       template<>
@@ -1702,14 +1694,14 @@ namespace ipr {
 
       struct Typedecl : impl::Decl<ipr::Typedecl> {
          Optional<ipr::Type> init;
-         const ipr::Expr* member_of;
-         const ipr::Region* lexreg;
+         util::ref<const ipr::Expr> member_of;
+         util::ref<const ipr::Region> lexreg;
 
          Typedecl();
 
-         const ipr::Expr& membership() const final;
-         Optional<ipr::Expr> initializer() const final;
-         const ipr::Region& lexical_region() const final;
+         const ipr::Expr& membership() const final { return member_of.get(); }
+         Optional<ipr::Expr> initializer() const final { return init; }
+         const ipr::Region& lexical_region() const final { return lexreg.get(); }
       };
 
       template<>
@@ -1727,17 +1719,17 @@ namespace ipr {
       };
 
       struct Fundecl : impl::Decl<ipr::Fundecl> {
-         const ipr::Udt<ipr::Decl>* member_of;
+         util::ref<const ipr::Udt<ipr::Decl>> member_of;
          fundecl_data data;
-         const ipr::Region* lexreg;
+         util::ref<const ipr::Region> lexreg;
 
          Fundecl();
 
          const ipr::Parameter_list& parameters() const final;
          Optional<ipr::Mapping> mapping() const final;
-         const ipr::Udt<ipr::Decl>& membership() const final;
+         const ipr::Udt<ipr::Decl>& membership() const final { return member_of.get(); }
          Optional<ipr::Expr> initializer() const final;
-         const ipr::Region& lexical_region() const final;
+         const ipr::Region& lexical_region() const final { return lexreg.get(); }
       };
 
       template<>

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -2202,6 +2202,8 @@ namespace ipr {
    // a parameter list.
    struct Parameter : Category<Category_code::Parameter, Decl> {
       virtual const Parameter_list& membership() const = 0;
+      const Region& lexical_region() const final { return membership().region(); }
+      const Region& home_region() const final { return membership().region(); }
       Optional<Expr> default_value() const { return initializer(); }
    };
 

--- a/include/ipr/utility
+++ b/include/ipr/utility
@@ -27,6 +27,20 @@ namespace ipr {
          return ptr;
       }
 
+      // At various places in the implementation of the IPR interface, certain logical
+      // references are stored as pointers because of implementation necessity, or sometimes convenience.
+      // This wrapper class ensures that when the data behind those logical references are 
+      // access the implementation pointer is not null.  Note that the role served by this
+      // class is not the same as ipr::Optional (which is a genuine representation of optional information),
+      // or std::reference_wrapper (which assumes existence of reference to begin with).
+      template<typename T>
+      struct ref {
+         ref(T* p = { }) : ptr{p} { }
+         T& get() const { return *util::check(ptr); }
+      private:
+         T* ptr;
+      };
+
       // --------------------
       // -- Red-back trees --
       // --------------------

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -429,7 +429,7 @@ namespace ipr {
       // -- impl::Template --
       // --------------------
 
-      Template::Template() : init{}, lexreg{} { }
+      Template::Template() : member_of{}, init{}, lexreg{} { }
 
       const ipr::Template&
       Template::primary_template() const {

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -317,48 +317,15 @@ namespace ipr {
       // -- impl::Alias --
       // -----------------
 
-      Alias::Alias() : aliasee(0), lexreg(0)
+      Alias::Alias() : aliasee{nullptr}, lexreg{}
       { }
-
-      Optional<ipr::Expr> Alias::initializer() const {
-         return { aliasee };
-      }
-
-      const ipr::Region&
-      Alias::lexical_region() const {
-         return *util::check(lexreg);
-      }
 
       // --------------------
       // -- impl::Bitfield --
       // --------------------
 
-      Bitfield::Bitfield() : length(0), member_of(0), init(0)
+      Bitfield::Bitfield() : length{}, member_of{}, init{}
       { }
-
-      const ipr::Expr&
-      Bitfield::precision() const {
-         return *util::check(length);
-      }
-
-      const ipr::Udt<ipr::Decl>&
-      Bitfield::membership() const {
-         return *util::check(member_of);
-      }
-
-      Optional<ipr::Expr> Bitfield::initializer() const {
-         return init;
-      }
-
-      const ipr::Region&
-      Bitfield::lexical_region() const {
-         return util::check(member_of)->region();
-      }
-
-      const ipr::Region&
-      Bitfield::home_region() const {
-         return util::check(member_of)->region();
-      }
 
       // ---------------------
       // -- impl::Base_type --
@@ -424,43 +391,20 @@ namespace ipr {
          return scope_pos;
       }
 
-      Optional<ipr::Expr> Enumerator::initializer() const {
-         return init;
-      }
-
       // -----------------
       // -- impl::Field --
       // -----------------
 
       Field::Field()
-            : member_of(0), init(0)
+            : member_of{}, init{}
       { }
-
-      Optional<ipr::Expr> Field::initializer() const {
-         return init;
-      }
-
-      const ipr::Udt<ipr::Decl>&
-      Field::membership() const {
-         return *util::check(member_of);
-      }
-
-      const ipr::Region&
-      Field::lexical_region() const {
-         return util::check(member_of)->region();
-      }
-
-      const ipr::Region&
-      Field::home_region() const {
-         return util::check(member_of)->region();
-      }
 
       // -------------------
       // -- impl::Fundecl --
       // -------------------
 
       Fundecl::Fundecl()
-            : member_of(nullptr), data{ }, lexreg(nullptr)
+            : member_of{}, data{}, lexreg{}
       { }
 
       const ipr::Parameter_list& Fundecl::parameters() const {
@@ -475,27 +419,17 @@ namespace ipr {
          return { data.mapping() };
       }
 
-      const ipr::Udt<ipr::Decl>&
-      Fundecl::membership() const {
-         return *util::check(member_of);
-      }
-
       Optional<ipr::Expr> Fundecl::initializer() const {
          if (data.index() == 0)
             return { };
          return { data.mapping() };
       }
 
-      const ipr::Region&
-      Fundecl::lexical_region() const {
-         return *util::check(lexreg);
-      }
-
       // --------------------
       // -- impl::Template --
       // --------------------
 
-      Template::Template() : member_of(0), init(0), lexreg(0) { }
+      Template::Template() : init{}, lexreg{} { }
 
       const ipr::Template&
       Template::primary_template() const {
@@ -516,18 +450,13 @@ namespace ipr {
          return { util::check(init)->body };
       }
 
-      const ipr::Region&
-      Template::lexical_region() const {
-         return *util::check(lexreg);
-      }
-
       // ---------------------
       // -- impl::Parameter --
       // ---------------------
 
       Parameter::Parameter(const ipr::Name& n, const impl::Rname& rn)
             :id(n), abstract_name(rn),
-             where(0), init(0)
+             where{}, init{}
       { }
 
       const ipr::Name&
@@ -540,16 +469,6 @@ namespace ipr {
          return abstract_name.rep.first;
       }
 
-      const ipr::Region&
-      Parameter::home_region() const {
-         return util::check(where)->region();
-      }
-
-      const ipr::Region&
-      Parameter::lexical_region() const {
-         return util::check(where)->region();
-      }
-
       const ipr::Parameter_list&
       Parameter::membership() const {
          return *util::check(where);
@@ -559,47 +478,19 @@ namespace ipr {
          return abstract_name.rep.third;
       }
 
-      Optional<ipr::Expr> Parameter::initializer() const {
-         return init;
-      }
-
       // --------------------
       // -- impl::Typedecl --
       // --------------------
 
-      Typedecl::Typedecl() : init{ }, member_of(0), lexreg(0)
+      Typedecl::Typedecl() : init{}, member_of{}, lexreg{}
       { }
-
-      Optional<ipr::Expr> Typedecl::initializer() const { return init; }
-
-      const ipr::Expr&
-      Typedecl::membership() const {
-         return *util::check(member_of);
-      }
-
-      const ipr::Region&
-      Typedecl::lexical_region() const {
-         // return util::check(member_of)->region();
-         // 31OCT08 - PIR: since a Typedecl has a lexreg field
-         //    I assume that it should be returned by lexical_region()
-         return *util::check(lexreg);
-      }
 
       // ---------------
       // -- impl::Var --
       // ---------------
 
-      Var::Var() : init(0), lexreg(0)
+      Var::Var() : init{}, lexreg{}
       { }
-
-      Optional<ipr::Expr> Var::initializer() const {
-         return init;
-      }
-
-      const ipr::Region&
-      Var::lexical_region() const {
-         return *util::check(lexreg);
-      }
 
       // -----------------
       // -- impl::Block --


### PR DESCRIPTION
Introduce `util::ref` to automate implementation of logical references as pointers.