### PR TITLE
Miscellaneous cleanup [3/n]

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -1990,7 +1990,6 @@ namespace ipr {
          impl::Closure* make_closure(const ipr::Region&, const ipr::Type&);
       private:
          util::rb_tree::container<impl::Array> arrays;
-         util::rb_tree::container<impl::Decltype> decltypes;
          util::rb_tree::container<impl::As_type> type_refs;
          util::rb_tree::container<impl::Function> functions;
          util::rb_tree::container<impl::Pointer> pointers;
@@ -2001,6 +2000,7 @@ namespace ipr {
          util::rb_tree::container<impl::Rvalue_reference> refrefs;
          util::rb_tree::container<impl::Sum> sums;
          util::rb_tree::container<impl::Forall> foralls;
+         stable_farm<impl::Decltype> decltypes;
          stable_farm<impl::Enum> enums;
          stable_farm<impl::Class> classes;
          stable_farm<impl::Union> unions;
@@ -2030,29 +2030,27 @@ namespace ipr {
       // block.  It also holds a sequence of handlers, when the
       // block actually represents a C++ try-block.
 
-      struct Block : impl::Stmt<Node<ipr::Block>> {
-         Region region;
-         ref_sequence<ipr::Stmt> stmt_seq;
-         ref_sequence<ipr::Handler> handler_seq;
+      struct Block : impl::Stmt<Expr<ipr::Block>> {
+         impl::Region region;
+         impl::ref_sequence<ipr::Stmt> stmt_seq;
+         impl::ref_sequence<ipr::Handler> handler_seq;
 
-         Block(const ipr::Region&, const ipr::Type&);
-
-         const ipr::Type& type() const final;
-         const ipr::Scope& members() const final;
-         const ipr::Sequence<ipr::Stmt>& body() const final;
-         const ipr::Sequence<ipr::Handler>& handlers() const final;
+         explicit Block(const ipr::Region&);
+         const ipr::Scope& members() const final { return region.scope; }
+         const ipr::Sequence<ipr::Stmt>& body() const final { return stmt_seq; }
+         const ipr::Sequence<ipr::Handler>& handlers() const final { return handler_seq; }
 
          // The scope of declarations in this block
-         Scope* scope() { return &region.scope; }
+         impl::Scope* scope() { return &region.scope; }
 
-         void add_stmt(const ipr::Stmt* s)
+         void add_stmt(const ipr::Stmt& s)
          {
-            stmt_seq.push_back(s);
+            stmt_seq.push_back(&s);
          }
 
-         void add_handler(const ipr::Handler* h)
+         void add_handler(const ipr::Handler& h)
          {
-            handler_seq.push_back(h);
+            handler_seq.push_back(&h);
          }
       };
 
@@ -2062,31 +2060,29 @@ namespace ipr {
       // supports settings of its components after construction.
 
       struct For : impl::Stmt<impl::Node<ipr::For>> {
-         const ipr::Expr* init;
-         const ipr::Expr* cond;
-         const ipr::Expr* inc;
-         const ipr::Stmt* stmt;
+         util::ref<const ipr::Expr> init;
+         util::ref<const ipr::Expr> cond;
+         util::ref<const ipr::Expr> inc;
+         util::ref<const ipr::Stmt> stmt;
 
          For();
-
-         const ipr::Type& type() const final;
-         const ipr::Expr& initializer() const final;
-         const ipr::Expr& condition() const final;
-         const ipr::Expr& increment() const final;
-         const ipr::Stmt& body() const final;
+         const ipr::Type& type() const final { return body().type(); }
+         const ipr::Expr& initializer() const final { return init.get(); }
+         const ipr::Expr& condition() const final { return cond.get(); }
+         const ipr::Expr& increment() const final { return inc.get(); }
+         const ipr::Stmt& body() const final { return stmt.get(); }
       };
 
       struct For_in : impl::Stmt<impl::Node<ipr::For_in>> {
-         const ipr::Var* var;
-         const ipr::Expr* seq;
-         const ipr::Stmt* stmt;
+         util::ref<const ipr::Var> var;
+         util::ref<const ipr::Expr> seq;
+         util::ref<const ipr::Stmt> stmt;
 
          For_in();
-
-         const ipr::Type& type() const final;
-         const ipr::Var& variable() const final;
-         const ipr::Expr& sequence() const final;
-         const ipr::Stmt& body() const final;
+         const ipr::Type& type() const final { return body().type(); }
+         const ipr::Var& variable() const final { return var.get(); }
+         const ipr::Expr& sequence() const final { return seq.get(); }
+         const ipr::Stmt& body() const final { return stmt.get(); }
       };
 
 
@@ -2094,19 +2090,19 @@ namespace ipr {
       // transfers control out of.
 
       struct Break : Stmt<Expr<ipr::Break>> {
-         const ipr::Stmt* stmt;
+         util::ref<const ipr::Stmt> stmt;
 
          Break();
-         const ipr::Stmt& from() const final;
+         const ipr::Stmt& from() const final { return stmt.get(); }
       };
 
       // Like a Break, a Continue node can refer back to the
       // iteration-statement containing it.
       struct Continue : Stmt<Expr<ipr::Continue>> {
-         const ipr::Stmt* stmt;
+         util::ref<const ipr::Stmt> stmt;
 
          Continue();
-         const ipr::Stmt& iteration() const final;
+         const ipr::Stmt& iteration() const final { return stmt.get(); }
       };
 
 
@@ -2117,7 +2113,7 @@ namespace ipr {
          impl::Break* make_break(const ipr::Type&);
          impl::Continue* make_continue(const ipr::Type&);
          impl::Empty_stmt* make_empty_stmt(const ipr::Type&);
-         impl::Block* make_block(const ipr::Region&, const ipr::Type&);
+         impl::Block* make_block(const ipr::Region&, Optional<ipr::Type> = { });
          impl::Ctor_body* make_ctor_body(const ipr::Expr_list&,
                                          const ipr::Block&);
          impl::Expr_stmt* make_expr_stmt(const ipr::Expr&);

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -496,112 +496,36 @@ namespace ipr {
       // -- impl::Block --
       // -----------------
 
-      Block::Block(const ipr::Region& pr, const ipr::Type& t)
+      Block::Block(const ipr::Region& pr)
             : region(&pr)
       {
-         // >>>> pmp 16jun08
-         // regions' owners are set typically by IPR
          region.owned_by = this;
-         // <<<< pmp 16jun08
-      }
-
-      const ipr::Type&
-      Block::type() const {
-         return region.scope.type();
-      }
-
-      const ipr::Scope&
-      Block::members() const {
-         return region.scope;
-      }
-
-      const ipr::Sequence<ipr::Stmt>&
-      Block::body() const {
-         return stmt_seq;
-      }
-
-      const ipr::Sequence<ipr::Handler>&
-      Block::handlers() const {
-         return handler_seq;
       }
 
       // ---------------
       // -- impl::For --
       // ---------------
 
-      For::For() : init(0), cond(0), inc(0), stmt(0) { }
-
-      const ipr::Type&
-      For::type() const {
-         return util::check(stmt)->type();
-      }
-
-      const ipr::Expr&
-      For::initializer() const {
-         return *util::check(init);
-      }
-
-      const ipr::Expr&
-      For::condition() const {
-         return *util::check(cond);
-      }
-
-      const ipr::Expr&
-      For::increment() const {
-         return *util::check(inc);
-      }
-
-      const ipr::Stmt&
-      For::body() const {
-         return *util::check(stmt);
-      }
+      For::For() : init{}, cond{}, inc{}, stmt{}
+      { }
 
       // ------------------
       // -- impl::For_in --
       // ------------------
-      For_in::For_in() : var(), seq(), stmt() { }
-
-      const ipr::Var&
-      For_in::variable() const {
-         return *util::check(var);
-      }
-
-      const ipr::Expr&
-      For_in::sequence() const {
-         return *util::check(seq);
-      }
-
-      const ipr::Type&
-      For_in::type() const {
-         return util::check(stmt)->type();
-      }
-
-      const ipr::Stmt&
-      For_in::body() const {
-         return *util::check(stmt);
-      }
+      For_in::For_in() : var{}, seq{}, stmt{}
+      { }
 
       // -----------------
       // -- impl::Break --
       // -----------------
 
-      Break::Break() : stmt(0) { }
-
-      const ipr::Stmt&
-      Break::from() const {
-         return *util::check(stmt);
-      }
+      Break::Break() : stmt{} { }
 
       // --------------------
       // -- impl::Continue --
       // --------------------
 
-      Continue::Continue() : stmt(0) { }
-
-      const ipr::Stmt&
-      Continue::iteration() const {
-         return *util::check(stmt);
-      }
+      Continue::Continue() : stmt{} { }
 
       // ------------------------
       // -- impl::stmt_factory --
@@ -623,8 +547,8 @@ namespace ipr {
       }
 
       impl::Block*
-      stmt_factory::make_block(const ipr::Region& pr, const ipr::Type& t) {
-         return blocks.make(pr, t);
+      stmt_factory::make_block(const ipr::Region& pr, Optional<ipr::Type> t) {
+         return make(blocks, pr).with_type(t);
       }
 
       impl::Ctor_body*
@@ -927,7 +851,7 @@ namespace ipr {
       impl::Decltype*
       type_factory::make_decltype(const ipr::Expr& e)
       {
-         return decltypes.insert(e, unary_compare());
+         return decltypes.make(e);
       }
 
       impl::As_type*


### PR DESCRIPTION
More cleanups.  Define more `final` functions `as inline`.

Source breaking change: `Block::add_stmt()` and `Block::add_handler()` now take references to node of interface class types, instead of pointers.