### PR TITLE
Predicate for testing global region

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(
-   VERSION 3.5
+   VERSION 3.8
 )
 
 option(BUILD_DOC
@@ -8,7 +8,7 @@ option(BUILD_DOC
 )
 
 project(ipr
-   VERSION 0.47
+   VERSION 0.50
    LANGUAGES CXX
 )
 
@@ -29,7 +29,7 @@ set_target_properties(${PROJECT_NAME}
    PROPERTIES
       CXX_STANDARD 17
       CXX_STANDARD_REQUIRED ON
-	  CXX_EXTENSIONS OFF
+	   CXX_EXTENSIONS OFF
 )
 				
 target_compile_options(${PROJECT_NAME}

--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -1056,10 +1056,11 @@ namespace ipr {
          Optional<ipr::Expr> owned_by { };
          homogeneous_scope<Member> scope;
 
-         const ipr::Region& enclosing() const { return parent; }
-         const ipr::Scope& bindings() const { return scope; }
-         const location_span& span() const { return extent; }
-         const ipr::Expr& owner() const { return owned_by.get(); }
+         const ipr::Region& enclosing() const final { return parent; }
+         const ipr::Scope& bindings() const final { return scope; }
+         const location_span& span() const final { return extent; }
+         const ipr::Expr& owner() const final { return owned_by.get(); }
+         bool global() const final { return false; }
 
          explicit homogeneous_region(const ipr::Region& p)
                : parent(p)
@@ -1781,15 +1782,16 @@ namespace ipr {
 
       struct Region : impl::Node<ipr::Region> {
          using location_span = ipr::Region::Location_span;
-         const ipr::Region* parent;
+         Optional<ipr::Region> parent;
          location_span extent;
-         const ipr::Expr* owned_by;
+         util::ref<const ipr::Expr> owned_by;
          impl::Scope scope;
 
-         const ipr::Region& enclosing() const final;
+         const ipr::Region& enclosing() const final { return parent.get(); }
          const ipr::Scope& bindings() const final { return scope; }
          const location_span& span() const final { return extent; }
-         const ipr::Expr& owner() const final;
+         const ipr::Expr& owner() const final { return owned_by.get(); }
+         bool global() const final { return not parent.is_valid(); }
 
          impl::Region* make_subregion();
 
@@ -1835,7 +1837,7 @@ namespace ipr {
             return scope.make_secondary_template(n, t);
          }
 
-         explicit Region(const ipr::Region*);
+         explicit Region(Optional<ipr::Region>);
 
       private:
          stable_farm<Region> subregions;

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -794,7 +794,7 @@ namespace ipr {
    // A Region node represents a region of program text.  It is mostly
    // useful for capturing the notion of scope (in Standard C++ sense).
    // In IPR, we're using a generalized notion of Scope (a sequence of
-   // declarations).  The  notion of Region helps making precise when
+   // declarations).  The  notion of Region helps make precise when
    // some implicit actions like cleanup-ups happen, or nesting of scopes.
    // The sequence of declarations appearing in a Region makes up the
    // Scope of that region.
@@ -804,6 +804,7 @@ namespace ipr {
       virtual const Region& enclosing() const = 0;
       virtual const Scope& bindings() const = 0;
       virtual const Expr& owner() const = 0;
+      virtual bool global() const = 0;                   // is this region the global region?
    };
 
                                 // -- Expr --

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -1229,19 +1229,10 @@ namespace ipr {
       // -- impl::Region --
       // --------------------------------
 
-      Region::Region(const ipr::Region* pr)
-            : parent(pr), owned_by()
+      Region::Region(Optional<ipr::Region> pr)
+            : parent{pr}, owned_by{}
       { }
 
-      const ipr::Region&
-      Region::enclosing() const {
-         return *util::check(parent);
-      }
-
-      const ipr::Expr&
-      Region::owner() const {
-         return *util::check(owned_by);
-      }
 
       Region*
       Region::make_subregion() {

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -20,5 +20,22 @@ set_target_properties(${TEST_BINARY}
       CXX_EXTENSIONS OFF
 )
 
+target_compile_options(${TEST_BINARY}
+   PRIVATE
+      $<$<CXX_COMPILER_ID:MSVC>:
+         /W2           # Usual warnings
+         /permissive-  # Turn on strict language conformance
+         /EHsc         # Turn on exception handling semantics
+      >
+      $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:
+         -Wall         # Turn on all useful warnings
+         -pedantic     # Turn on strict language conformance
+      >
+      $<$<CXX_COMPILER_ID:Clang>:
+		 -Wno-overloaded-virtual                   # Too many false positives
+		 -Wno-delete-non-abstract-non-virtual-dtor # System headers plagued
+      >
+)
+
 add_test(simple ${TEST_BINARY})
 


### PR DESCRIPTION
This patch adds a `Region::global()` predicate that holds for the global region, i.e. the region of the global scope.

Fix #33 .

Note: the patch also ensures that the tests are run with flags consistent with the build.  Someone more versed in CMake should have a look and devise a better way to do this so we don't have two places to update.