### PR TITLE
Fix duplicate linkage nodes

### DIFF
--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -10,6 +10,7 @@
 #include <stdexcept>
 #include <algorithm>
 #include <typeinfo>
+#include <type_traits>
 #include <cassert>
 #include <iterator>
 #include <utility>
@@ -679,14 +680,20 @@ namespace ipr {
             return compare(lhs, rhs.node);
          }
 
-         template<class T>
+         template<class T,
+            class = std::enable_if_t<!std::is_same_v<
+              std::remove_reference_t<typename Unary<T>::Arg_type>,
+              std::remove_reference_t<ipr::Sequence<ipr::Type>>>>>
          int operator()(const Unary<T>& lhs,
                         const typename Unary<T>::Arg_type& rhs) const
          {
             return compare(lhs.rep, rhs);
          }
 
-         template<class T>
+         template<class T,
+            class = std::enable_if_t<!std::is_same_v<
+              std::remove_reference_t<typename Unary<T>::Arg_type>,
+              std::remove_reference_t<ipr::Sequence<ipr::Type>>>>>
          int operator()(const typename Unary<T>::Arg_type& lhs,
                         const Unary<T>& rhs) const
          {

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -681,6 +681,20 @@ namespace ipr {
 
          template<class T>
          int operator()(const Unary<T>& lhs,
+                        const typename Unary<T>::Arg_type& rhs) const
+         {
+            return compare(lhs.rep, rhs);
+         }
+
+         template<class T>
+         int operator()(const typename Unary<T>::Arg_type& lhs,
+                        const Unary<T>& rhs) const
+         {
+            return compare(lhs, rhs.rep);
+         }
+
+         template<class T>
+         int operator()(const Unary<T>& lhs,
                         const ipr::Sequence<ipr::Type>& rhs) const
          {
             return util::lexicographical_compare()

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -10,7 +10,6 @@
 #include <stdexcept>
 #include <algorithm>
 #include <typeinfo>
-#include <type_traits>
 #include <cassert>
 #include <iterator>
 #include <utility>
@@ -680,26 +679,22 @@ namespace ipr {
             return compare(lhs, rhs.node);
          }
 
-         template<class T,
-            class = std::enable_if_t<!std::is_same_v<
-              std::remove_reference_t<typename Unary<T>::Arg_type>,
-              std::remove_reference_t<ipr::Sequence<ipr::Type>>>>>
+         template<class T>
          int operator()(const Unary<T>& lhs,
                         const typename Unary<T>::Arg_type& rhs) const
          {
             return compare(lhs.rep, rhs);
          }
 
-         template<class T,
-            class = std::enable_if_t<!std::is_same_v<
-              std::remove_reference_t<typename Unary<T>::Arg_type>,
-              std::remove_reference_t<ipr::Sequence<ipr::Type>>>>>
+         template<class T>
          int operator()(const typename Unary<T>::Arg_type& lhs,
                         const Unary<T>& rhs) const
          {
             return compare(lhs, rhs.rep);
          }
+      };
 
+      struct unary_lexicographic_compare {
          template<class T>
          int operator()(const Unary<T>& lhs,
                         const ipr::Sequence<ipr::Type>& rhs) const
@@ -884,7 +879,7 @@ namespace ipr {
 
       impl::Product*
       type_factory::make_product(const ipr::Sequence<ipr::Type>& seq) {
-         return products.insert(seq, unary_compare());
+         return products.insert(seq, unary_lexicographic_compare());
       }
 
       impl::Ptr_to_member*
@@ -906,7 +901,7 @@ namespace ipr {
 
       impl::Sum*
       type_factory::make_sum(const ipr::Sequence<ipr::Type>& seq) {
-         return sums.insert(seq, unary_compare());
+         return sums.insert(seq, unary_lexicographic_compare());
       }
 
       impl::Forall*
@@ -2154,7 +2149,7 @@ namespace ipr {
       const ipr::Product&
       Lexicon::get_product(const ref_sequence<ipr::Type>& s) {
          return *finish_type
-            (types.make_product(*type_seqs.insert(s, unary_compare())));
+            (types.make_product(*type_seqs.insert(s, unary_lexicographic_compare())));
       }
 
       const ipr::Ptr_to_member&
@@ -2181,7 +2176,7 @@ namespace ipr {
       const ipr::Sum&
       Lexicon::get_sum(const ref_sequence<ipr::Type>& s) {
          return *finish_type
-            (types.make_sum(*type_seqs.insert(s, unary_compare())));
+            (types.make_sum(*type_seqs.insert(s, unary_lexicographic_compare())));
       }
 
       const ipr::Forall&

--- a/tests/unit-tests/simple.cpp
+++ b/tests/unit-tests/simple.cpp
@@ -53,3 +53,11 @@ TEST_CASE("Can create and print line numbers")
   CHECK(ss.str().find("F1:1:2") != std::string::npos);
 }
 
+TEST_CASE("linkages are deduplicated") {
+  using namespace ipr;
+  impl::Lexicon lexicon{};
+  auto& l1 = lexicon.cxx_linkage();
+  auto& l2 = lexicon.cxx_linkage();
+  CHECK(&l1 == &l2);
+}
+


### PR DESCRIPTION
Previously, we picked the most general unary_compare overload that
compared the addess of Linkage to Linkage::rep. As a result, those never
compared equal and we ended up creating a new node for linkage each time
Lexicon::cxx_linkage was called. This patch adds an overload to resolve
this problem.