### PR TITLE
chore: move doctest's main function into main.cpp

### DIFF
--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(TEST_BINARY unittests)
 
 add_executable(${TEST_BINARY}
+   main.cpp
    conversions.cpp
    simple.cpp
 )

--- a/tests/unit-tests/conversions.cpp
+++ b/tests/unit-tests/conversions.cpp
@@ -1,4 +1,4 @@
-#include "doctest/doctest.h"
+#include <doctest/doctest.h>
 
 #include <ipr/impl>
 

--- a/tests/unit-tests/main.cpp
+++ b/tests/unit-tests/main.cpp
@@ -1,0 +1,2 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest/doctest.h>

--- a/tests/unit-tests/simple.cpp
+++ b/tests/unit-tests/simple.cpp
@@ -1,5 +1,4 @@
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
-#include "doctest/doctest.h"
+#include <doctest/doctest.h>
 
 #include <ipr/impl>
 #include <ipr/io>


### PR DESCRIPTION
Moving doctest's main function into a separate main.cpp makes it clearer
that it is distinguished from regular tests. All tests now follow the
same pattern (include doctest).

I also changed the includes to use <> instead of "", because doctest is
on the search path of the test files, not relative to them.