### PR TITLE
Miscellaneous cleanup 5/n

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -16,6 +16,7 @@
 #include <forward_list>
 #include <variant>
 #include <functional>
+#include <string_view>
 #include <ipr/interface>
 #include <ipr/utility>
 
@@ -37,6 +38,46 @@
 // impl::Unary overrides ipr::Node::accept() and forward to the right
 // ipr::Visitor::visit() hook.
 
+namespace ipr::impl {
+                             // -- impl::Node --
+   template<class T>
+   struct Node : T {
+      using Interface = T;
+      void accept(ipr::Visitor& v) const final { v.visit(*this); }
+   };
+}
+
+namespace ipr::util {
+   // Type for representing the hash of data (mostly character strings) used internally.
+   enum class hash_code : std::size_t { };
+
+   // Type of view over words as stored internally.
+   // FIXME: The word view should base on UTF-8 encoding.
+   using word_view = std::string_view;
+}
+
+namespace ipr::impl {
+                             // -- impl::String --
+   struct String : impl::Node<ipr::String> {
+      constexpr String(const char* s) : txt{ s } { }
+      constexpr String(util::word_view w) : txt{ w } { }
+      constexpr const auto& text() const { return txt; }
+      constexpr Index size() const final { return text().length(); }
+      constexpr const char* begin() const final { return text().data(); }
+      constexpr const char* end() const final { return begin() + text().length(); }
+   private:
+      const util::word_view txt;
+   };
+}
+
+namespace ipr::util {
+   // String pool.  Used to intern words used for external designation of entities.
+   struct string_pool : private std::map<hash_code, std::forward_list<impl::String>> {
+      const ipr::String& intern(word_view);
+   private:
+      util::string::arena strings;
+   };
+}
 
 namespace ipr {
    namespace impl {
@@ -162,19 +203,18 @@ namespace ipr {
 
                                 // -- impl::Token --
       struct Token : ipr::Lexeme, ipr::Token {
-         const String& spelling() const final { return text; }
+         Token(const ipr::String&, const Source_location&, TokenValue, TokenCategory);
+         const ipr::String& spelling() const final { return text; }
          const Source_location& locus() const final { return location; }
          const ipr::Lexeme& lexeme() const final { return *this; }
          TokenValue value() const final { return token_value; }
          TokenCategory category() const final { return token_category; }
 
       private:
-         const String& text;
+         const ipr::String& text;
          Source_location location;
          TokenValue token_value;
          TokenCategory token_category;
-         Token(const String&, const Source_location&, TokenValue, TokenCategory);
-         friend impl::Lexicon;
       };
 
       // -- Parameterized implementation of ipr::Attribute.
@@ -356,12 +396,6 @@ namespace ipr {
          const ipr::Sequence<ipr::Identifier>& stems() const final;
       };
 
-                                // -- impl::Node --
-      template<class T>
-      struct Node : T {
-         using Interface = T;
-         void accept(ipr::Visitor& v) const final { v.visit(*this); }
-      };
 
       template<typename T,
           typename std::enable_if_t<std::is_scalar_v<T>, int> = 0>
@@ -491,18 +525,6 @@ namespace ipr {
          using Base::Base;
 
          const ipr::Type& type() const { return this->rep.first; }
-      };
-
-                                // -- String --
-      struct String : impl::Node<ipr::String> {
-         explicit String(const util::string&);
-
-         Index size() const final;
-         const char* begin() const final;
-         const char* end() const final;
-
-      private:
-         const util::string& text;
       };
 
                                 // -- Linkage --
@@ -1336,12 +1358,10 @@ namespace ipr {
 
       struct expr_factory {
          // Returns an IPR node for unified string literals.
-         const ipr::String& get_string(const char*);
-         const ipr::String& get_string(const std::string&);
+         const ipr::String& get_string(util::word_view);
 
          // Returns an IPR node a language linkage.
-         const ipr::Linkage& get_linkage(const char*);
-         const ipr::Linkage& get_linkage(const std::string&);
+         const ipr::Linkage& get_linkage(util::word_view);
          const ipr::Linkage& get_linkage(const ipr::String&);
 
          // Return a symbol with a given name and type.
@@ -1359,20 +1379,17 @@ namespace ipr {
 
          // Returns an IPR node for a typed literal expression.
          Literal* make_literal(const ipr::Type&, const ipr::String&);
-         Literal* make_literal(const ipr::Type&, const char*);
-         Literal* make_literal(const ipr::Type&, const std::string&);
+         Literal* make_literal(const ipr::Type&, util::word_view);
 
          // Builds an IPR object for an identifier.
          Identifier* make_identifier(const ipr::String&);
-         Identifier* make_identifier(const char*);
-         Identifier* make_identifier(const std::string&);
+         Identifier* make_identifier(util::word_view);
 
          Suffix* make_suffix(const ipr::Identifier&);
 
          // Builds an IPR object for an operator name.
          Operator* make_operator(const ipr::String&);
-         Operator* make_operator(const char*);
-         Operator* make_operator(const std::string&);
+         Operator* make_operator(util::word_view);
 
          Guide_name* make_guide_name(const ipr::Template&);
 
@@ -1471,8 +1488,7 @@ namespace ipr {
          Lambda* make_lambda(const ipr::Region&, Mapping_level);
 
       private:
-         util::string::arena string_pool;
-         util::rb_tree::container<impl::String> strings;
+         util::string_pool strings;
 
          // Language linkage nodes.
          util::rb_tree::container<impl::Linkage> linkages;
@@ -1577,8 +1593,6 @@ namespace ipr {
          stable_farm<impl::Conditional> conds;
          stable_farm<impl::Mapping> mappings;
          stable_farm<impl::Lambda> lambdas;
-
-         const ipr::String& get_string(const char*, int);
       };
 
 
@@ -2161,14 +2175,12 @@ namespace ipr {
          const ipr::Linkage& cxx_linkage() const final;
          const ipr::Linkage& c_linkage() const final;
 
-         const ipr::Identifier& get_identifier(const char*);
-         const ipr::Identifier& get_identifier(const std::string&);
+         const ipr::Identifier& get_identifier(util::word_view);
          const ipr::Identifier& get_identifier(const ipr::String&);
 
          const ipr::Suffix& get_suffix(const ipr::Identifier&);
 
-         const ipr::Operator& get_operator(const char*);
-         const ipr::Operator& get_operator(const std::string&);
+         const ipr::Operator& get_operator(util::word_view);
          const ipr::Operator& get_operator(const ipr::String&);
 
          const ipr::Ctor_name& get_ctor_name(const ipr::Type&);
@@ -2179,8 +2191,7 @@ namespace ipr {
          const ipr::Template_id& get_template_id(const ipr::Name&,
                                                  const ipr::Expr_list&);
 
-         const ipr::Literal& get_literal(const ipr::Type&, const char*);
-         const ipr::Literal& get_literal(const ipr::Type&, const std::string&);
+         const ipr::Literal& get_literal(const ipr::Type&, util::word_view);
          const ipr::Literal& get_literal(const ipr::Type&, const ipr::String&);
 
          const ipr::Type& void_type() const final;

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -752,6 +752,7 @@ namespace ipr {
 
                                 // -- String --
    // Strings in IPR are immutable, and therefore unified.
+   // FIXME: Internal representation should default to UTF-8 encoding.
    struct String : Category<Category_code::String, Node> {
       using iterator = const char*;
       using Index = std::size_t;

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -91,7 +91,7 @@ namespace ipr::util {
         // Dynamically allocated words are slotted by their hash codes into singly-linked lists.
         const hash_code h { std::hash<word_view>{ }(w) };
         auto& bucket = (*this)[h];
-        constexpr auto eq = [&w](auto& x) { return x.text() == w; };
+        const auto eq = [&w](auto& x) { return x.text() == w; };
         if (const auto p = std::find_if(bucket.begin(), bucket.end(), eq); p != bucket.end())
             return *p;
         const auto fresh = strings.make_string(w.data(), w.length());

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -100,9 +100,7 @@ namespace ipr::util {
     }
 }
 
-
-namespace ipr {
-   namespace impl {
+namespace ipr::impl {
       Token::Token(const ipr::String& s, const Source_location& l,
                    TokenValue v, TokenCategory c)
             : text{ s }, location{ l }, token_value{ v }, token_category{ c }
@@ -802,18 +800,18 @@ namespace ipr {
          }
       };
 
-	  struct id_compare
-	  {
-		  int operator()(const ipr::Identifier& lhs, const ipr::String& rhs) const
-		  {
-			  return compare(lhs.string(), rhs);
-		  }
+      struct id_compare
+      {
+          int operator()(const ipr::Identifier& lhs, const ipr::String& rhs) const
+          {
+              return compare(lhs.string(), rhs);
+          }
 
-		  int operator()(const ipr::String& lhs, const ipr::Identifier& rhs) const
-		  {
-			  return compare(lhs, rhs.string());
-		  }
-	  };
+          int operator()(const ipr::String& lhs, const ipr::Identifier& rhs) const
+          {
+              return compare(lhs, rhs.string());
+          }
+      };
 
 
       // >>>> Yuriy Solodkyy: 2008/07/10
@@ -822,14 +820,14 @@ namespace ipr {
       // on RHS we would be called with already allocated Pointer types. Thus we
       // have to check whether any of the existing Pointer types does not already
       // have a points_to (its operand()) equal to the type in LHS.
-	  struct unified_type_compare
-	  {
+      struct unified_type_compare
+      {
           template<class Cat, class Operand>
-    	  int operator()(const ipr::Type& lhs, const ipr::Unary<Cat,Operand>& rhs) const
-		  {
+          int operator()(const ipr::Type& lhs, const ipr::Unary<Cat,Operand>& rhs) const
+          {
               return compare(lhs, rhs.operand());
-		  }
-	  };
+          }
+      };
       // <<<< Yuriy Solodkyy: 2008/07/10
 
       impl::Array*
@@ -1661,7 +1659,7 @@ namespace ipr {
       impl::Literal*
       expr_factory::make_literal(const ipr::Type& t, const ipr::String& s) {
          using rep = impl::Literal::Rep;
-		 return lits.insert(rep{ t, s }, binary_compare());
+         return lits.insert(rep{ t, s }, binary_compare());
       }
 
       impl::Literal*
@@ -2214,8 +2212,6 @@ namespace ipr {
       impl::Module_unit* Module::make_unit() {
          return units.push_back(lexicon, *this);
       }
-
-   }
 }
 
 

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -72,7 +72,10 @@ namespace ipr::impl {
         }
 
         // Ensure the table of statically known words is lexicographically sorted.
+        // FIXME: Unfortunately, GCC's support for basic C++20 constexpr algorithms is wobbly.
+#        if !__GNUC__        
         static_assert(std::is_sorted(std::begin(known_words), std::end(known_words), word_less));
+#        endif
     }
 }
 

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -14,7 +14,8 @@
 #include <iterator>
 #include <utility>
 #include <cstring>
-#include <string>
+#include <array>
+
 namespace ipr {
    const String& String::empty_string()
    {
@@ -27,10 +28,81 @@ namespace ipr {
       static constexpr Empty_string empty { };
       return empty;
    }
+}
+
+namespace ipr::impl {
+    namespace {
+        // A table of statically known words used in the internal representation.
+        constexpr impl::String known_words[] {
+           "...",
+           "C",
+           "C++",
+           "bool",
+           "char",
+           "char16_t",
+           "char32_t",
+           "char8_t",
+           "class",
+           "double",
+           "enum",
+           "float",
+           "int",
+           "long",
+           "long double",
+           "long long",
+           "namespace",
+           "nullptr",
+           "short",
+           "signed char",
+           "typename",
+           "union",
+           "unsigned char",
+           "unsigned int",
+           "unsigned long",
+           "unsigned long long",
+           "unsigned short",
+           "void",
+           "wchar_t",
+        };
+
+        // Lexicographical less-than comparison between two known words.
+        constexpr bool word_less(const impl::String& x, const impl::String& y)
+        {
+           return x.text() < y.text();
+        }
+
+        // Ensure the table of statically known words is lexicographically sorted.
+        static_assert(std::is_sorted(std::begin(known_words), std::end(known_words), word_less));
+    }
+}
+
+namespace ipr::util {
+    const ipr::String& string_pool::intern(word_view w)
+    {
+       if (w.empty())
+         return ipr::String::empty_string();
+
+        // For statically known words, just return the statically allocated address.
+        constexpr auto lt = [](auto& x, auto& y) { return x.text() < y; };
+        if (const auto p = std::lower_bound(std::begin(impl::known_words), std::end(impl::known_words), w, lt);
+            p < std::end(impl::known_words) and p->text() == w)
+            return *p;
+
+        // Dynamically allocated words are slotted by their hash codes into singly-linked lists.
+        const hash_code h { std::hash<word_view>{ }(w) };
+        auto& bucket = (*this)[h];
+        constexpr auto eq = [&w](auto& x) { return x.text() == w; };
+        if (const auto p = std::find_if(bucket.begin(), bucket.end(), eq); p != bucket.end())
+            return *p;
+        const auto fresh = strings.make_string(w.data(), w.length());
+        bucket.emplace_front(util::word_view(fresh->data, fresh->length));
+        return bucket.front();
+    }
+}
 
 
+namespace ipr {
    namespace impl {
-
       Token::Token(const ipr::String& s, const Source_location& l,
                    TokenValue v, TokenCategory c)
             : text{ s }, location{ l }, token_value{ v }, token_category{ c }
@@ -611,26 +683,6 @@ namespace ipr {
          : impl::Udt<ipr::Closure>(&r, t)
       { }
 
-      // ------------------
-      // -- impl::String --
-      // ------------------
-      String::String(const util::string& s) : text(s)
-      { }
-
-      String::Index String::size() const {
-         return text.size();
-      }
-
-      const char*
-      String::begin() const {
-         return text.begin();
-      }
-
-      const char*
-      String::end() const {
-         return text.end();
-      }
-
       // --------------------------
       // -- impl::Parameter_list --
       // --------------------------
@@ -1171,81 +1223,15 @@ namespace ipr {
       // ------------------------
       // -- impl::expr_factory --
       // ------------------------
-
       const ipr::String&
-      expr_factory::get_string(const char* s) {
-         return get_string(s,std::strlen(s));
+      expr_factory::get_string(util::word_view w) {
+         return strings.intern(w);
       }
-
-      const ipr::String&
-      expr_factory::get_string(const std::string& s) {
-         return get_string(s.data(), s.size());
-      }
-
-      struct string_comp {
-         using proxy = std::pair<const char*, int>;
-
-         struct char_compare {
-            int operator()(unsigned char lhs, unsigned char rhs) const
-            {
-               return compare(lhs, rhs);
-            }
-         };
-
-         int
-         operator()(const proxy& lhs, const impl::String& rhs) const
-         {
-            return util::lexicographical_compare()
-               (lhs.first, lhs.first + lhs.second,
-                rhs.begin(), rhs.end(), char_compare());
-         }
-
-         int
-         operator()(const impl::String& lhs, const proxy& rhs) const
-         {
-            return util::lexicographical_compare()
-               (lhs.begin(), lhs.end(),
-                rhs.first, rhs.first + rhs.second, char_compare());
-         }
-
-         int
-         operator()(const util::string& lhs, const impl::String& rhs) const
-         {
-            return util::lexicographical_compare()
-               (lhs.data, lhs.data + lhs.length,
-                rhs.begin(), rhs.end(), char_compare());
-         }
-
-         int
-         operator()(const impl::String& lhs, const util::string& rhs) const
-         {
-            return util::lexicographical_compare()
-               (lhs.begin(), lhs.end(),
-                rhs.data, rhs.data + rhs.length, char_compare());
-         }
-      };
-
-      const ipr::String&
-      expr_factory::get_string(const char* s, int n) {
-         const impl::String* item = strings.find(std::make_pair(s, n),
-                                                 string_comp());
-         if (item == 0)
-            item = strings.insert(*string_pool.make_string(s, n),
-                                  string_comp());
-
-         return *item;
-      }
-
 
       // -- Language linkage
       const ipr::Linkage&
-      expr_factory::get_linkage(const char* s) {
-         return get_linkage(get_string(s));
-      }
-
-      const ipr::Linkage&
-      expr_factory::get_linkage(const std::string& s) {
-         return get_linkage(get_string(s));
+      expr_factory::get_linkage(util::word_view w) {
+         return get_linkage(get_string(w));
       }
 
       const ipr::Linkage&
@@ -1345,13 +1331,8 @@ namespace ipr {
       }
 
       impl::Identifier*
-      expr_factory::make_identifier(const char* s) {
-         return make_identifier(get_string(s));
-      }
-
-      impl::Identifier*
-      expr_factory::make_identifier(const std::string& s) {
-         return make_identifier(get_string(s));
+      expr_factory::make_identifier(util::word_view w) {
+         return make_identifier(get_string(w));
       }
 
       impl::Suffix*
@@ -1402,13 +1383,8 @@ namespace ipr {
       }
 
       impl::Operator*
-      expr_factory::make_operator(const char* s) {
-         return make_operator(get_string(s));
-      }
-
-      impl::Operator*
-      expr_factory::make_operator(const std::string& s) {
-         return make_operator(get_string(s));
+      expr_factory::make_operator(util::word_view w) {
+         return make_operator(get_string(w));
       }
 
       impl::Enclosure*
@@ -1673,13 +1649,8 @@ namespace ipr {
       }
 
       impl::Literal*
-      expr_factory::make_literal(const ipr::Type& t, const char* s) {
-         return make_literal(t, get_string(s));
-      }
-
-      impl::Literal*
-      expr_factory::make_literal(const ipr::Type& t, const std::string& s) {
-         return make_literal(t, get_string(s));
+      expr_factory::make_literal(const ipr::Type& t, util::word_view w) {
+         return make_literal(t, get_string(w));
       }
 
       impl::Lshift*
@@ -1944,13 +1915,8 @@ namespace ipr {
       Lexicon::~Lexicon() { }
 
       const ipr::Literal&
-      Lexicon::get_literal(const ipr::Type& t, const char* s) {
-         return get_literal(t, get_string(s));
-      }
-
-      const ipr::Literal&
-      Lexicon::get_literal(const ipr::Type& t, const std::string& s) {
-         return get_literal(t, get_string(s));
+      Lexicon::get_literal(const ipr::Type& t, util::word_view w) {
+         return get_literal(t, get_string(w));
       }
 
       const ipr::Literal&
@@ -1959,13 +1925,8 @@ namespace ipr {
       }
 
       const ipr::Identifier&
-      Lexicon::get_identifier(const char* s) {
-         return get_identifier(get_string(s));
-      }
-
-      const ipr::Identifier&
-      Lexicon::get_identifier(const std::string& s) {
-         return get_identifier(get_string(s));
+      Lexicon::get_identifier(util::word_view w) {
+         return get_identifier(get_string(w));
       }
 
       const ipr::Identifier&
@@ -2056,13 +2017,8 @@ namespace ipr {
       }
 
       const ipr::Operator&
-      Lexicon::get_operator(const char* s) {
-         return get_operator(get_string(s));
-      }
-
-      const ipr::Operator&
-      Lexicon::get_operator(const std::string& s) {
-         return get_operator(get_string(s));
+      Lexicon::get_operator(util::word_view w) {
+         return get_operator(get_string(w));
       }
 
       const ipr::Operator&

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -72,10 +72,7 @@ namespace ipr::impl {
         }
 
         // Ensure the table of statically known words is lexicographically sorted.
-        // FIXME: Unfortunately, GCC's support for basic C++20 constexpr algorithms is wobbly.
-#        if !__GNUC__        
         static_assert(std::is_sorted(std::begin(known_words), std::end(known_words), word_less));
-#        endif
     }
 }
 

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -3,6 +3,7 @@ set(TEST_BINARY unittests)
 add_executable(${TEST_BINARY}
    conversions.cpp
    simple.cpp
+   words.cxx
 )
 
 target_link_libraries(${TEST_BINARY}
@@ -15,7 +16,7 @@ target_include_directories(${TEST_BINARY}
 
 set_target_properties(${TEST_BINARY}
    PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
       CXX_STANDARD_REQUIRED ON
       CXX_EXTENSIONS OFF
 )

--- a/tests/unit-tests/words.cxx
+++ b/tests/unit-tests/words.cxx
@@ -1,0 +1,17 @@
+#include "doctest/doctest.h"
+
+#include <ipr/traversal>
+#include <ipr/impl>
+
+TEST_CASE("words are unified")
+{
+    ipr::util::string_pool pool { };
+
+    auto& int1 = pool.intern("int");
+    auto& int2 = pool.intern("int");
+    CHECK(ipr::physically_same(int1, int2));
+
+    auto& foo1 = pool.intern("fhoo");
+    auto& foo2 = pool.intern("fhoo");
+    CHECK(ipr::physically_same(foo1, foo2));
+}


### PR DESCRIPTION
Back in the 2000s, we didn't have `constexpr` to enforce static initialization of global objects of class types with constructors, so we 'manually' constructed many commonly used objects at startup; these include allocating some statically known `String` objects.  This patch makes such `String` objects statically allocated.  In the process, it also removed uses of `const char*` and `std::string` as interface for trucking character strings.  A follow up patch will switch to consistent uses of UTF-8 encoded character strings for the internal representation.