### PR TITLE
Remove bracketing from Sequence

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -139,7 +139,6 @@ namespace ipr {
 
          Index size() const final { return Rep::size(); }
 
-         using Seq::operator[];
          using Seq::begin;
          using Seq::end;
 
@@ -162,7 +161,6 @@ namespace ipr {
          using Iterator = typename Seq::Iterator;
          using Index = typename Seq::Index;
 
-         using Seq::operator[];
          using Seq::begin;
          using Seq::end;
 
@@ -1058,7 +1056,7 @@ namespace ipr {
 
          const ipr::Product& type() const final { return decls; }
 
-         const ipr::Sequence<ipr::Decl>& members() const final { return *this; }
+         const ipr::Sequence<ipr::Decl>& elements() const final { return *this; }
 
          const ipr::Overload& operator[](const Name&) const final;
 
@@ -1113,7 +1111,7 @@ namespace ipr {
          const ipr::Product& type() const final;
          const ipr::Region& region() const final;
          Mapping_level level() const final { return nesting; }
-         const ipr::Sequence<ipr::Parameter>& members() const final;
+         const ipr::Sequence<ipr::Parameter>& elements() const final;
 
          impl::Parameter* add_member(const ipr::Name&, const impl::Rname&);
       };
@@ -1762,7 +1760,7 @@ namespace ipr {
       struct Scope : impl::Node<ipr::Scope> {
          Scope();
          const ipr::Type& type() const final { return decls; }
-         const ipr::Sequence<ipr::Decl>& members() const final { return decls.seq; }
+         const ipr::Sequence<ipr::Decl>& elements() const final { return decls.seq; }
          const ipr::Overload& operator[](const ipr::Name&) const final;
 
          impl::Alias* make_alias(const ipr::Name&, const ipr::Expr&);
@@ -2046,7 +2044,7 @@ namespace ipr {
          impl::ref_sequence<ipr::Handler> handler_seq;
 
          explicit Block(const ipr::Region&);
-         const ipr::Scope& members() const final { return region.scope; }
+         const ipr::Scope& elements() const final { return region.scope; }
          const ipr::Sequence<ipr::Stmt>& body() const final { return stmt_seq; }
          const ipr::Sequence<ipr::Handler>& handlers() const final { return handler_seq; }
 

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -364,11 +364,10 @@ namespace ipr {
       using iterator = Iterator;
 
       virtual Index size() const = 0;
+      bool empty() const { return not (size() > 0); }
       Iterator begin() const;
       Iterator end() const;
-
       Iterator position(Index) const;
-      const T& operator[](Index) const;
 
    protected:
       virtual const T& get(Index) const = 0;
@@ -448,11 +447,6 @@ namespace ipr {
    inline typename Sequence<T>::Iterator
    Sequence<T>::end() const
    { return { this, size() }; }
-
-   template<class T>
-   inline const T&
-   Sequence<T>::operator[](Index p) const
-   { return get(p); }
 
                                  // -- Delimiter --
    // Enclosure delimiters of expressions
@@ -978,9 +972,6 @@ namespace ipr {
    // look-up by type.  The result of such lookup is the sequence of
    // declarations of that name with that type.
    struct Overload : Sequence<Decl>, Category<Category_code::Overload> {
-      // Bring Sequence<Decl>::operator[] into
-      // scope before overloading.
-      using Sequence<Decl>::operator[];
       virtual const Sequence<Decl>& operator[](const Type&) const = 0;
    };
 
@@ -997,18 +988,17 @@ namespace ipr {
       using Iterator = Sequence<Decl>::Iterator;
 
       // The sequence of declarations this scope contain.
-      virtual const Sequence<Decl>& members() const = 0;
+      virtual const Sequence<Decl>& elements() const = 0;
 
       // Look-up by name returns the overload-set of all declarations,
       // for the subscripting name, contained in this scope.
       virtual const Overload& operator[](const Name&) const = 0;
 
       // How may declarations are there in this Scope.
-      auto size() const { return members().size(); }
+      auto size() const { return elements().size(); }
 
-      Iterator begin() const { return members().begin(); }
-      Iterator end() const { return members().end(); }
-      const Decl& operator[](int i) const { return members()[i]; }
+      Iterator begin() const { return elements().begin(); }
+      Iterator end() const { return elements().end(); }
    };
 
                                 // -- General types --
@@ -1154,7 +1144,7 @@ namespace ipr {
       using Index = std::size_t;
       Arg_type elements() const { return operand(); }
       auto size() const { return elements().size(); }
-      const Type& operator[](Index i) const { return elements()[i]; }
+      const Type& operator[](Index i) const { return *elements().position(i); }
    };
 
                                 // -- Ptr_to_member --
@@ -1209,7 +1199,7 @@ namespace ipr {
       using Index = std::size_t;
       Arg_type elements() const { return operand(); }
       auto size() const { return elements().size(); }
-      const Type& operator[](Index i) const { return elements()[i]; }
+      const Type& operator[](Index i) const { return *elements().position(i); }
    };
 
                                 // -- Forall --
@@ -1247,18 +1237,18 @@ namespace ipr {
    // that is initialized with a sequence of declarations.  The type of 
    // such a variable is given by an IPR "namespace" type.
    struct Namespace : Category<Category_code::Namespace, Udt<Decl>> {
-      const Sequence<Decl>& members() const final { return scope().members(); }
+      const Sequence<Decl>& members() const final { return scope().elements(); }
    };
 
                                 // -- Class --
    struct Class : Category<Category_code::Class, Udt<Decl>> {
-      const Sequence<Decl>& members() const final { return scope().members(); }
+      const Sequence<Decl>& members() const final { return scope().elements(); }
       virtual const Sequence<Base_type>& bases() const = 0;
    };
 
                                 // -- Union --
    struct Union : Category<Category_code::Union, Udt<Decl>> {
-      const Sequence<Decl>& members() const final { return scope().members(); }
+      const Sequence<Decl>& members() const final { return scope().elements(); }
    };
 
                                 // -- Enum --
@@ -1459,7 +1449,6 @@ namespace ipr {
       using Index = std::size_t;
       Arg_type elements() const { return operand(); }
       auto size() const { return elements().size(); }
-      const Expr& operator[](Index i) const { return elements()[i]; }
    };
 
                                 // -- Sizeof --
@@ -1888,10 +1877,10 @@ namespace ipr {
    struct Parameter_list : Category<Category_code::Parameter_list> {
       virtual const Region& region() const = 0;
       virtual Mapping_level level() const = 0;
-      virtual const Sequence<Parameter>& members() const = 0;
-      auto begin() const { return members().begin(); }
-      auto end() const { return members().end(); }
-      auto size() const { return members().size(); }
+      virtual const Sequence<Parameter>& elements() const = 0;
+      auto begin() const { return elements().begin(); }
+      auto end() const { return elements().end(); }
+      auto size() const { return elements().size(); }
    };
 
                                 // -- Stmt --
@@ -1977,7 +1966,7 @@ namespace ipr {
                                 // -- Block --
    // A Block is any sequence of statements bracketed by curly braces.
    struct Block : Category<Category_code::Block, Stmt> {
-      virtual const Scope& members() const = 0;
+      virtual const Scope& elements() const = 0;
       virtual const Sequence<Stmt>& body() const = 0;
       virtual const Sequence<Handler>& handlers() const = 0;
    };

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -694,7 +694,7 @@ namespace ipr::impl {
       const ipr::Region& Parameter_list::region() const { return parms; }
 
       const ipr::Sequence<ipr::Parameter>&
-      Parameter_list::members() const {
+      Parameter_list::elements() const {
          return parms.scope.decls.seq;
       }
 


### PR DESCRIPTION
The `Seuquence` interface is exposed as a sequence iterated over by a bidirectional iterator even if in some circumstances it admits a random access operation (via the protected operation `get()`).  This patch removes the bracketing syntax, which is conventionally reserved for random access sequences.

Additionally, remove some cruft; consistently use `elements` for the constituents of a `Sequence`, and reserve `members` for declarations of a region.