### PR TITLE
Enable rules for the Microsoft C++ Analysis action

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -14,7 +14,7 @@ env:
   build: '${{ github.workspace }}/build'
 
 jobs:
-  microsoft:
+  build:
     name: Microsoft C++ Code Analysis
     runs-on: windows-latest
 

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -12,7 +12,6 @@ on:
 
 env:
   build: '${{ github.workspace }}/build'
-  results: '${{ github.workspace }}/build/results'
 
 jobs:
   build:
@@ -30,22 +29,21 @@ jobs:
         cmakeGenerator: VS16Win64
 
     - name: Run Microsoft Visual C++ Analysis
+      id: run-analysis
       uses: microsoft/msvc-code-analysis-action@redesign
       with:
         cmakeBuildDirectory: ${{ env.build }}
-        ignoreSystemHeaders: true
         ignoredTargetPaths: ${{ github.workspace }}/tests
-        resultsDirectory: ${{ env.results }}
         ruleset: '${{ github.workspace }}/infra/Analysis.ruleset'
 
-    - name: Upload SARIF as Artifacts
+    - name: Upload SARIF as an Artifact
       uses: actions/upload-artifact@v2
       with:
-        name: sarif-files
-        path: ${{ env.results }}
+        name: sarif-file
+        path: ${{ steps.run-analysis.output.sarif }}
         if-no-files-found: error
 
     - name: Upload SARIF to GitHub
       uses: github/codeql-action/upload-sarif@v1
       with:
-        sarif_file: ${{ env.results }}
+        sarif_file: ${{ steps.run-analysis.output.sarif }}

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -12,6 +12,7 @@ on:
 
 env:
   build: '${{ github.workspace }}/build'
+  config: 'Debug'
 
 jobs:
   build:
@@ -22,13 +23,14 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Configure CMake
-        run: cmake -B ${{ env.build }}
+        run: cmake -B ${{ env.build }} -DCMAKE_BUILD_TYPE=${{ env.config }}
 
       - name: Run Microsoft Visual C++ Analysis
         id: run-analysis
         uses: microsoft/msvc-code-analysis-action@v0.1.0
         with:
           cmakeBuildDirectory: ${{ env.build }}
+          buildConfiguration: ${{ env.config }}
           ignoredTargetPaths: ${{ github.workspace }}/tests
           ruleset: '${{ github.workspace }}/infra/Analysis.ruleset'
 

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -12,7 +12,6 @@ on:
 
 env:
   build: '${{ github.workspace }}/build'
-  BUILD_TYPE: Debug
 
 jobs:
   microsoft:
@@ -23,7 +22,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Configure CMake
-        run: cmake -B ${{ env.build }} --config ${{env.BUILD_TYPE}}
+        run: cmake -B ${{ env.build }}
 
       - name: Run Microsoft Visual C++ Analysis
         id: run-analysis

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -40,10 +40,10 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: sarif-file
-        path: ${{ steps.run-analysis.output.sarif }}
+        path: ${{ steps.run-analysis.outputs.sarif }}
         if-no-files-found: error
 
     - name: Upload SARIF to GitHub
       uses: github/codeql-action/upload-sarif@v1
       with:
-        sarif_file: ${{ steps.run-analysis.output.sarif }}
+        sarif_file: ${{ steps.run-analysis.outputs.sarif }}

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -12,38 +12,35 @@ on:
 
 env:
   build: '${{ github.workspace }}/build'
+  BUILD_TYPE: Debug
 
 jobs:
-  build:
+  microsoft:
     name: Microsoft C++ Code Analysis
-    runs-on: windows-2019
+    runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Configure CMake
-      uses: lukka/run-cmake@v3
-      with:
-        buildDirectory: ${{ env.build }}
-        buildWithCMake: false
-        cmakeGenerator: VS16Win64
+      - name: Configure CMake
+        run: cmake -B ${{ env.build }} --config ${{env.BUILD_TYPE}}
 
-    - name: Run Microsoft Visual C++ Analysis
-      id: run-analysis
-      uses: microsoft/msvc-code-analysis-action@redesign
-      with:
-        cmakeBuildDirectory: ${{ env.build }}
-        ignoredTargetPaths: ${{ github.workspace }}/tests
-        ruleset: '${{ github.workspace }}/infra/Analysis.ruleset'
+      - name: Run Microsoft Visual C++ Analysis
+        id: run-analysis
+        uses: microsoft/msvc-code-analysis-action@v0.0.1
+        with:
+          cmakeBuildDirectory: ${{ env.build }}
+          ignoredTargetPaths: ${{ github.workspace }}/tests
+          ruleset: '${{ github.workspace }}/infra/Analysis.ruleset'
 
-    - name: Upload SARIF as an Artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: sarif-file
-        path: ${{ steps.run-analysis.outputs.sarif }}
-        if-no-files-found: error
+      - name: Upload SARIF as an Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: sarif-file
+          path: ${{ steps.run-analysis.outputs.sarif }}
+          if-no-files-found: error
 
-    - name: Upload SARIF to GitHub
-      uses: github/codeql-action/upload-sarif@v1
-      with:
-        sarif_file: ${{ steps.run-analysis.outputs.sarif }}
+      - name: Upload SARIF to GitHub
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: ${{ steps.run-analysis.outputs.sarif }}

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -12,7 +12,7 @@ on:
 
 env:
   build: '${{ github.workspace }}/build'
-  config: 'Debug'
+  config: 'Release'
 
 jobs:
   build:

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -34,6 +34,7 @@ jobs:
       with:
         cmakeBuildDirectory: ${{ env.build }}
         ignoreSystemHeaders: true
+        ignoredTargetPaths: ${{ github.workspace }}/tests
         resultsDirectory: ${{ env.results }}
         ruleset: '${{ github.workspace }}/infra/Analysis.ruleset'
 

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Run Microsoft Visual C++ Analysis
         id: run-analysis
-        uses: microsoft/msvc-code-analysis-action@v0.0.1
+        uses: microsoft/msvc-code-analysis-action@v0.1.0
         with:
           cmakeBuildDirectory: ${{ env.build }}
           ignoredTargetPaths: ${{ github.workspace }}/tests

--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -370,8 +370,8 @@ namespace ipr {
       struct Binding_capture_specification : Capture_specification<ipr::Capture_specification::Binding> {
          Binding_capture_specification(const ipr::Identifier& n, const ipr::Expr& x, Capture_mode m) : id{n}, init{x}, md{m} { }
          Capture_mode mode() const final { return md; }
-         const ipr::Identifier& name() const { return id; }
-         const ipr::Expr& initializer() const { return init; }
+         const ipr::Identifier& name() const final { return id; }
+         const ipr::Expr& initializer() const final { return init; }
       private:
          const ipr::Identifier& id;
          const ipr::Expr& init;
@@ -536,7 +536,7 @@ namespace ipr {
          using Base = impl::Classic<Binary_node<Interface>>;
          using Base::Base;
 
-         const ipr::Type& type() const { return this->rep.first; }
+         const ipr::Type& type() const final { return this->rep.first; }
       };
 
                                 // -- Linkage --
@@ -713,9 +713,9 @@ namespace ipr {
          impl::Overload* overload;
          const ipr::Region* home;
          master_decl_data(impl::Overload* ovl, const ipr::Type& t)
-               : basic_decl_data<Interface>(this),
-                 overload_entry(t),
-                 overload(ovl),home(0)
+               : basic_decl_data<Interface>{this},
+                 overload_entry{t},
+                 overload{ovl},home{}
          { }
       };
 
@@ -1145,17 +1145,17 @@ namespace ipr {
             return this->decl_data.master_data->overload->where;
          }
 
-         Decl_position position() const
+         Decl_position position() const final
          {
             return this->decl_data.scope_pos;
          }
 
-         const ipr::Decl& master() const
+         const ipr::Decl& master() const final
          {
             return *util::check(this->decl_data.master_data->decl);
          }
 
-         const ipr::Sequence<ipr::Decl>& decl_set() const
+         const ipr::Sequence<ipr::Decl>& decl_set() const final
          {
             return this->decl_data.master_data->declset;
          }

--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -1148,7 +1148,7 @@ namespace ipr {
             return this->decl_data.master_data->overload->where;
          }
 
-         Decl_position position() const final
+         Decl_position position() const
          {
             return this->decl_data.scope_pos;
          }

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -667,8 +667,7 @@ namespace ipr {
 
    constexpr DeclSpecifiers operator|(DeclSpecifiers a, DeclSpecifiers b)
    {
-      return static_cast<DeclSpecifiers>(
-         static_cast<uint32_t>(a) | static_cast<uint32_t>(b));
+      return DeclSpecifiers(uint32_t(a) | uint32_t(b));
    }
 
    constexpr DeclSpecifiers& operator|=(DeclSpecifiers& a, DeclSpecifiers b)
@@ -678,8 +677,7 @@ namespace ipr {
 
    constexpr DeclSpecifiers operator&(DeclSpecifiers a, DeclSpecifiers b)
    {
-      return static_cast<DeclSpecifiers>(
-         static_cast<uint32_t>(a) & static_cast<uint32_t>(b));
+      return DeclSpecifiers(uint32_t(a) & uint32_t(b));
    }
 
    constexpr DeclSpecifiers& operator&=(DeclSpecifiers& a, DeclSpecifiers b)
@@ -689,8 +687,7 @@ namespace ipr {
 
    constexpr DeclSpecifiers operator^(DeclSpecifiers a, DeclSpecifiers b)
    {
-      return static_cast<DeclSpecifiers>(
-         static_cast<uint32_t>(a) ^ static_cast<uint32_t>(b));
+      return DeclSpecifiers(uint32_t(a) ^ uint32_t(b));
    }
 
    constexpr DeclSpecifiers& operator^=(DeclSpecifiers& a, DeclSpecifiers b)
@@ -1033,8 +1030,7 @@ namespace ipr {
    constexpr Type_qualifier
    operator|(Type_qualifier a, Type_qualifier b)
    {
-      return static_cast<Type_qualifier>(
-         static_cast<uint8_t>(a) | static_cast<uint8_t>(b));
+      return Type_qualifier(uint8_t(a) | uint8_t(b));
    }
 
    inline Type_qualifier&
@@ -1046,8 +1042,7 @@ namespace ipr {
    constexpr Type_qualifier
    operator&(Type_qualifier a, Type_qualifier b)
    {
-      return static_cast<Type_qualifier>(
-         static_cast<uint8_t>(a) & static_cast<uint8_t>(b));
+      return Type_qualifier(uint8_t(a) & uint8_t(b));
 
    }
 
@@ -1060,8 +1055,7 @@ namespace ipr {
    constexpr Type_qualifier
    operator^(Type_qualifier a, Type_qualifier b)
    {
-      return static_cast<Type_qualifier>(
-         static_cast<uint8_t>(a) ^ static_cast<uint8_t>(b));
+      return Type_qualifier(uint8_t(a) ^ uint8_t(b));
    }
 
    inline Type_qualifier&

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -668,7 +668,7 @@ namespace ipr {
    constexpr DeclSpecifiers operator|(DeclSpecifiers a, DeclSpecifiers b)
    {
       return static_cast<DeclSpecifiers>(
-         std::underlying_type_t<DeclSpecifiers>(a) | std::underlying_type_t<DeclSpecifiers>(b));
+         static_cast<uint32_t>(a) | static_cast<uint32_t>(b));
    }
 
    constexpr DeclSpecifiers& operator|=(DeclSpecifiers& a, DeclSpecifiers b)
@@ -679,7 +679,7 @@ namespace ipr {
    constexpr DeclSpecifiers operator&(DeclSpecifiers a, DeclSpecifiers b)
    {
       return static_cast<DeclSpecifiers>(
-         std::underlying_type_t<DeclSpecifiers>(a) & std::underlying_type_t<DeclSpecifiers>(b));
+         static_cast<uint32_t>(a) & static_cast<uint32_t>(b));
    }
 
    constexpr DeclSpecifiers& operator&=(DeclSpecifiers& a, DeclSpecifiers b)
@@ -690,7 +690,7 @@ namespace ipr {
    constexpr DeclSpecifiers operator^(DeclSpecifiers a, DeclSpecifiers b)
    {
       return static_cast<DeclSpecifiers>(
-         std::underlying_type_t<DeclSpecifiers>(a) ^ std::underlying_type_t<DeclSpecifiers>(b));
+         static_cast<uint32_t>(a) ^ static_cast<uint32_t>(b));
    }
 
    constexpr DeclSpecifiers& operator^=(DeclSpecifiers& a, DeclSpecifiers b)
@@ -1034,7 +1034,7 @@ namespace ipr {
    operator|(Type_qualifier a, Type_qualifier b)
    {
       return static_cast<Type_qualifier>(
-         std::underlying_type_t<Type_qualifier>(a) | std::underlying_type_t<Type_qualifier>(b));
+         static_cast<uint8_t>(a) | static_cast<uint8_t>(b));
    }
 
    inline Type_qualifier&
@@ -1047,7 +1047,8 @@ namespace ipr {
    operator&(Type_qualifier a, Type_qualifier b)
    {
       return static_cast<Type_qualifier>(
-         std::underlying_type_t<Type_qualifier>(a) & std::underlying_type_t<Type_qualifier>(b));
+         static_cast<uint8_t>(a) & static_cast<uint8_t>(b));
+
    }
 
    inline Type_qualifier&
@@ -1060,7 +1061,7 @@ namespace ipr {
    operator^(Type_qualifier a, Type_qualifier b)
    {
       return static_cast<Type_qualifier>(
-         std::underlying_type_t<Type_qualifier>(a) ^ std::underlying_type_t<Type_qualifier>(b));
+         static_cast<uint8_t>(a) ^ static_cast<uint8_t>(b));
    }
 
    inline Type_qualifier&

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -2328,7 +2328,7 @@ namespace ipr {
       // A base-object is, by definition, unnamed.  However, it
       // is convenient to refer to it by the name of the corresponding
       // type -- in C++ tradition.
-      const Name& name() const override { return type().name(); }
+      const Name& name() const final { return type().name(); }
       virtual Decl_position position() const = 0;
    };
 

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -667,7 +667,8 @@ namespace ipr {
 
    constexpr DeclSpecifiers operator|(DeclSpecifiers a, DeclSpecifiers b)
    {
-      return DeclSpecifiers(uint32_t(a) | uint32_t(b));
+      return static_cast<DeclSpecifiers>(
+         std::underlying_type_t<DeclSpecifiers>(a) | std::underlying_type_t<DeclSpecifiers>(b));
    }
 
    constexpr DeclSpecifiers& operator|=(DeclSpecifiers& a, DeclSpecifiers b)
@@ -677,7 +678,8 @@ namespace ipr {
 
    constexpr DeclSpecifiers operator&(DeclSpecifiers a, DeclSpecifiers b)
    {
-      return DeclSpecifiers(uint32_t(a) & uint32_t(b));
+      return static_cast<DeclSpecifiers>(
+         std::underlying_type_t<DeclSpecifiers>(a) & std::underlying_type_t<DeclSpecifiers>(b));
    }
 
    constexpr DeclSpecifiers& operator&=(DeclSpecifiers& a, DeclSpecifiers b)
@@ -687,7 +689,8 @@ namespace ipr {
 
    constexpr DeclSpecifiers operator^(DeclSpecifiers a, DeclSpecifiers b)
    {
-      return DeclSpecifiers(uint32_t(a) ^ uint32_t(b));
+      return static_cast<DeclSpecifiers>(
+         std::underlying_type_t<DeclSpecifiers>(a) ^ std::underlying_type_t<DeclSpecifiers>(b));
    }
 
    constexpr DeclSpecifiers& operator^=(DeclSpecifiers& a, DeclSpecifiers b)
@@ -1030,7 +1033,8 @@ namespace ipr {
    constexpr Type_qualifier
    operator|(Type_qualifier a, Type_qualifier b)
    {
-      return Type_qualifier(uint8_t(a) | uint8_t(b));
+      return static_cast<Type_qualifier>(
+         std::underlying_type_t<Type_qualifier>(a) | std::underlying_type_t<Type_qualifier>(b));
    }
 
    inline Type_qualifier&
@@ -1042,7 +1046,8 @@ namespace ipr {
    constexpr Type_qualifier
    operator&(Type_qualifier a, Type_qualifier b)
    {
-      return Type_qualifier(uint8_t(a) & uint8_t(b));
+      return static_cast<Type_qualifier>(
+         std::underlying_type_t<Type_qualifier>(a) & std::underlying_type_t<Type_qualifier>(b));
    }
 
    inline Type_qualifier&
@@ -1054,7 +1059,8 @@ namespace ipr {
    constexpr Type_qualifier
    operator^(Type_qualifier a, Type_qualifier b)
    {
-      return Type_qualifier(uint8_t(a) ^ uint8_t(b));
+      return static_cast<Type_qualifier>(
+         std::underlying_type_t<Type_qualifier>(a) ^ std::underlying_type_t<Type_qualifier>(b));
    }
 
    inline Type_qualifier&
@@ -2168,7 +2174,7 @@ namespace ipr {
    // An alias is always initialized -- with what it is an alias for.
    // The type of an Alias expression is that of its initializer.
    struct Alias : Category<Category_code::Alias, Decl> {
-      const Type& type() const { return initializer().get().type(); }
+      const Type& type() const override { return initializer().get().type(); }
       const Region& lexical_region() const final { return home_region(); }
    };
 
@@ -2183,7 +2189,7 @@ namespace ipr {
       // A base-object is, by definition, unnamed.  However, it
       // is convenient to refer to it by the name of the corresponding
       // type -- in C++ tradition.
-      const Name& name() const { return type().name(); }
+      const Name& name() const override { return type().name(); }
    };
 
                                 // -- Parameter --

--- a/include/ipr/io
+++ b/include/ipr/io
@@ -45,7 +45,7 @@ namespace ipr
    }; // of struct disambiguation_map_type
 
    struct Printer {
-      enum Padding {
+      enum class Padding {
          None, Before, After
       };
 

--- a/include/ipr/utility
+++ b/include/ipr/utility
@@ -213,7 +213,7 @@ namespace ipr {
             bool found = false;
             Node* result = this->root;
             while (result != nullptr and not found) {
-               auto ordering = comp(*result, key) ;
+               const auto ordering = comp(*result, key) ;
                if (ordering < 0)
                   result = result->left();
                else if (ordering > 0)
@@ -235,7 +235,7 @@ namespace ipr {
 
             bool found = false;
             while (not found and *slot != nullptr) {
-               auto ordering = comp(**slot, *z);
+               const auto ordering = comp(**slot, *z);
                if (ordering < 0) {
                   up = *slot;
                   slot = &up->left();
@@ -308,7 +308,7 @@ namespace ipr {
          container<T>::find(const Key& key, Comp comp) const
          {
             for (node<T>* x = this->root; x != nullptr; ) {
-               auto ordering = comp(x->data, key);
+               const auto ordering = comp(x->data, key);
                if (ordering < 0)
                   x = x->left();
                else if (ordering > 0)
@@ -339,7 +339,7 @@ namespace ipr {
             bool found = false;
 
             for (where = this->root; where != nullptr and not found; where = *slot) {
-               auto ordering = comp(where->data, key);
+               const auto ordering = comp(where->data, key);
                if (ordering < 0) {
                   parent = where;
                   slot = &where->left();
@@ -400,7 +400,7 @@ namespace ipr {
          util::string* allocate(int);
          int remaining_header_count() const
          {
-            return (int)(next_header - &mem->storage[0]);
+            return static_cast<int>(next_header - &mem->storage[0]);
          }
 
          struct pool;
@@ -426,7 +426,7 @@ namespace ipr {
                         Compare compare) const
          {
             for (; first1 != last1 and first2 != last2; ++first1, ++first2)
-               if (int cmp = compare(*first1, *first2))
+               if (const auto cmp = compare(*first1, *first2))
                   return cmp;
 
             return first1 == last1 ? (first2 == last2 ? 0 : -1) : 1;

--- a/include/ipr/utility
+++ b/include/ipr/utility
@@ -213,7 +213,7 @@ namespace ipr {
             bool found = false;
             Node* result = this->root;
             while (result != nullptr and not found) {
-               const auto ordering = comp(*result, key) ;
+               auto ordering = comp(*result, key) ;
                if (ordering < 0)
                   result = result->left();
                else if (ordering > 0)
@@ -235,7 +235,7 @@ namespace ipr {
 
             bool found = false;
             while (not found and *slot != nullptr) {
-               const auto ordering = comp(**slot, *z);
+               auto ordering = comp(**slot, *z);
                if (ordering < 0) {
                   up = *slot;
                   slot = &up->left();
@@ -308,7 +308,7 @@ namespace ipr {
          container<T>::find(const Key& key, Comp comp) const
          {
             for (node<T>* x = this->root; x != nullptr; ) {
-               const auto ordering = comp(x->data, key);
+               auto ordering = comp(x->data, key);
                if (ordering < 0)
                   x = x->left();
                else if (ordering > 0)
@@ -339,7 +339,7 @@ namespace ipr {
             bool found = false;
 
             for (where = this->root; where != nullptr and not found; where = *slot) {
-               const auto ordering = comp(where->data, key);
+               auto ordering = comp(where->data, key);
                if (ordering < 0) {
                   parent = where;
                   slot = &where->left();
@@ -426,7 +426,7 @@ namespace ipr {
                         Compare compare) const
          {
             for (; first1 != last1 and first2 != last2; ++first1, ++first2)
-               if (const auto cmp = compare(*first1, *first2))
+               if (auto cmp = compare(*first1, *first2))
                   return cmp;
 
             return first1 == last1 ? (first2 == last2 ? 0 : -1) : 1;

--- a/infra/Analysis.ruleset
+++ b/infra/Analysis.ruleset
@@ -5,6 +5,7 @@
   <!-- Enforcement of the C++ Core Guidelines -->
   <Include Path="CppCoreCheckRules.ruleset" Action="Default" />
 
+  <!-- TODO: remove -->
   <Rules AnalyzerId="Microsoft.Analyzers.NativeCodeAnalysis" RuleNamespace="Microsoft.Rules.Native">
     <!-- Excluded warnings -->
     <Rule Id="C26440" Action="None" /> <!-- Declare noexcept -->

--- a/infra/Analysis.ruleset
+++ b/infra/Analysis.ruleset
@@ -15,7 +15,7 @@
     <!-- Memory management -->
     <Rule Id="C26409" Action="None" /> <!-- No new/delete -->
     <Rule Id="C26401" Action="None" /> <!-- Do not delete non-owner pointer -->
-    <Rule Id="C26482" Action="None" /> <!-- No allocation to non-owner pointer -->
+    <Rule Id="C26406" Action="None" /> <!-- No allocation to non-owner pointer -->
     <!-- Usage of GSL -->
     <Rule Id="C26429" Action="None" /> <!-- Use gsl::not_null -->
     <Rule Id="C26446" Action="None" /> <!-- Use gsl::at -->

--- a/infra/Analysis.ruleset
+++ b/infra/Analysis.ruleset
@@ -1,4 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RuleSet Name="IPR Ruleset" Description="This ruleset purposefully includes zero warnings to create a empty baseline for IPR repo." ToolsVersion="10.0">
-  <IncludeAll Action="None" />
+<RuleSet Name="IPR Ruleset" Description="Warnings to enable for the Microsoft C++ Code Analysis for IPR repository." ToolsVersion="10.0">
+   <!-- Default rules available in Visual Studio -->
+  <Include Path="NativeRecommendedRules.ruleset" Action="Default" />
+  <!-- Enforcement of the C++ Core Guidelines -->
+  <Include Path="CppCoreCheckRules.ruleset" Action="Default" />
+
+  <Rules AnalyzerId="Microsoft.Analyzers.NativeCodeAnalysis" RuleNamespace="Microsoft.Rules.Native">
+    <!-- Excluded warnings -->
+    <Rule Id="C26440" Action="None" /> <!-- Declare noexcept -->
+  </Rules>
 </RuleSet>

--- a/infra/Analysis.ruleset
+++ b/infra/Analysis.ruleset
@@ -12,6 +12,7 @@
     <Rule Id="C26436" Action="None" /> <!-- Virtual dtors -->
     <Rule Id="C26481" Action="None" /> <!-- No pointer arithmetic -->
     <Rule Id="C26485" Action="None" /> <!-- No pointer decay -->
+    <Rule Id="C26445" Action="None" /> <!-- No reference for views -->
     <!-- Memory management -->
     <Rule Id="C26409" Action="None" /> <!-- No new/delete -->
     <Rule Id="C26401" Action="None" /> <!-- Do not delete non-owner pointer -->

--- a/infra/Analysis.ruleset
+++ b/infra/Analysis.ruleset
@@ -5,7 +5,6 @@
   <!-- Enforcement of the C++ Core Guidelines -->
   <Include Path="CppCoreCheckRules.ruleset" Action="Default" />
 
-  <!-- TODO: remove -->
   <Rules AnalyzerId="Microsoft.Analyzers.NativeCodeAnalysis" RuleNamespace="Microsoft.Rules.Native">
     <!-- Excluded warnings -->
     <Rule Id="C26440" Action="None" /> <!-- Declare noexcept -->
@@ -14,6 +13,12 @@
     <Rule Id="C26481" Action="None" /> <!-- No pointer arithmetic -->
     <Rule Id="C26485" Action="None" /> <!-- No pointer decay -->
     <Rule Id="C26445" Action="None" /> <!-- No reference for views -->
+    <!-- Const -->
+    <Rule Id="C26496" Action="None" /> <!-- Mark var const -->
+    <Rule Id="C26462" Action="None" /> <!-- Mark pointer var const -->
+    <Rule Id="C26463" Action="None" /> <!-- Mark array const -->
+    <Rule Id="C26464" Action="None" /> <!-- Mark array of pointers const -->
+    <Rule Id="C26814" Action="None" /> <!-- Mark var constexpr -->
     <!-- Memory management -->
     <Rule Id="C26409" Action="None" /> <!-- No new/delete -->
     <Rule Id="C26401" Action="None" /> <!-- Do not delete non-owner pointer -->

--- a/infra/Analysis.ruleset
+++ b/infra/Analysis.ruleset
@@ -8,5 +8,19 @@
   <Rules AnalyzerId="Microsoft.Analyzers.NativeCodeAnalysis" RuleNamespace="Microsoft.Rules.Native">
     <!-- Excluded warnings -->
     <Rule Id="C26440" Action="None" /> <!-- Declare noexcept -->
+    <Rule Id="C26455" Action="None" /> <!-- Declare noexcept (ctor) -->
+    <Rule Id="C26436" Action="None" /> <!-- Virtual dtors -->
+    <Rule Id="C26481" Action="None" /> <!-- No pointer arithmetic -->
+    <Rule Id="C26485" Action="None" /> <!-- No pointer decay -->
+    <!-- Memory management -->
+    <Rule Id="C26409" Action="None" /> <!-- No new/delete -->
+    <Rule Id="C26401" Action="None" /> <!-- Do not delete non-owner pointer -->
+    <Rule Id="C26482" Action="None" /> <!-- No allocation to non-owner pointer -->
+    <!-- Usage of GSL -->
+    <Rule Id="C26429" Action="None" /> <!-- Use gsl::not_null -->
+    <Rule Id="C26446" Action="None" /> <!-- Use gsl::at -->
+    <Rule Id="C26482" Action="None" /> <!-- Only index with constant expr -->
+    <!-- False positives, re-enabled if fixed -->
+    <Rule Id="C26434" Action="None" /> <!-- Hides non-virtual -->
   </Rules>
 </RuleSet>

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -626,7 +626,7 @@ namespace ipr::impl {
 
       impl::Enumerator*
       Enum::add_member(const ipr::Name& n) {
-         const Decl_position pos { members().size() };
+         Decl_position pos { members().size() };
          impl::Enumerator* e = body.scope.push_back(n, *this, pos);
          e->where = &body;
          return e;
@@ -649,7 +649,7 @@ namespace ipr::impl {
 
       impl::Base_type*
       Class::declare_base(const ipr::Type& t) {
-         const Decl_position pos { bases().size() };
+         Decl_position pos { bases().size() };
          return base_subobjects.scope.push_back(t, base_subobjects, pos);
       }
 
@@ -762,7 +762,7 @@ namespace ipr::impl {
          int operator()(const Binary<T>& lhs,
                         const typename Binary<T>::Rep& rhs) const
          {
-            if (const auto cmp = compare(lhs.rep.first, rhs.first)) return cmp;
+            if (int cmp = compare(lhs.rep.first, rhs.first)) return cmp;
 
             return compare(lhs.rep.second, rhs.second);
          }
@@ -846,8 +846,8 @@ namespace ipr::impl {
          int operator()(const Ternary<T>& lhs,
                         const typename Ternary<T>::Rep& rhs) const
          {
-            if (const auto cmp = compare(lhs.rep.first, rhs.first)) return cmp;
-            if (const auto cmp = compare(lhs.rep.second, rhs.second)) return cmp;
+            if (int cmp = compare(lhs.rep.first, rhs.first)) return cmp;
+            if (int cmp = compare(lhs.rep.second, rhs.second)) return cmp;
 
             return compare(lhs.rep.third, rhs.third);
          }
@@ -856,8 +856,8 @@ namespace ipr::impl {
          int operator()(const typename Ternary<T>::Rep& lhs,
                         const Ternary<T>& rhs) const
          {
-            if (const auto cmp = compare(lhs.first, rhs.rep.first)) return cmp;
-            if (const auto cmp = compare(lhs.second, rhs.rep.second)) return cmp;
+            if (int cmp = compare(lhs.first, rhs.rep.first)) return cmp;
+            if (int cmp = compare(lhs.second, rhs.rep.second)) return cmp;
 
             return compare(lhs.third, rhs.rep.third);
          }
@@ -868,9 +868,9 @@ namespace ipr::impl {
          int operator()(const Quaternary<T>& lhs,
                         const typename Quaternary<T>::Rep& rhs) const
          {
-            if (const auto cmp = compare(lhs.rep.first, rhs.first)) return cmp;
-            if (const auto cmp = compare(lhs.rep.second, rhs.second)) return cmp;
-            if (const auto cmp = compare(lhs.rep.third, rhs.third)) return cmp;
+            if (int cmp = compare(lhs.rep.first, rhs.first)) return cmp;
+            if (int cmp = compare(lhs.rep.second, rhs.second)) return cmp;
+            if (int cmp = compare(lhs.rep.third, rhs.third)) return cmp;
 
             return compare(lhs.rep.fourth, rhs.fourth);
          }
@@ -879,9 +879,9 @@ namespace ipr::impl {
          int operator()(const typename Quaternary<T>::Rep& lhs,
                         const Quaternary<T>& rhs) const
          {
-            if (const auto cmp = compare(lhs.first, rhs.rep.first)) return cmp;
-            if (const auto cmp = compare(lhs.second, rhs.rep.second)) return cmp;
-            if (const auto cmp = compare(lhs.third, rhs.rep.third)) return cmp;
+            if (int cmp = compare(lhs.first, rhs.rep.first)) return cmp;
+            if (int cmp = compare(lhs.second, rhs.rep.second)) return cmp;
+            if (int cmp = compare(lhs.third, rhs.rep.third)) return cmp;
 
             return compare(lhs.fourth, rhs.rep.fourth);
          }
@@ -1045,7 +1045,7 @@ namespace ipr::impl {
 
       const ipr::Overload&
       Scope::operator[](const ipr::Name& n) const {
-         if (const impl::Overload* ovl = overloads.find(n, node_compare()))
+         if (impl::Overload* ovl = overloads.find(n, node_compare()))
             return *ovl;
          return missing;
       }
@@ -1240,7 +1240,7 @@ namespace ipr::impl {
       expr_factory::get_symbol(const ipr::Name& n, const ipr::Type& t)
       {
          const auto comparator = [&t](auto& x, auto& y) {
-            if (const auto cmp = compare(x.name(), y))
+            if (auto cmp = compare(x.name(), y))
                return cmp;
             return compare(x.type(), t);
          };
@@ -1832,8 +1832,8 @@ namespace ipr::impl {
       expr_factory::rname_for_next_param(const impl::Mapping& map,
                                          const ipr::Type& t) {
          using Rep = impl::Rname::Rep;
-         const Decl_position pos { map.parms.size() };
-         const auto lvl = map.parameters().level();
+         Decl_position pos { map.parms.size() };
+         auto lvl = map.parameters().level();
          return rnames.insert(Rep{ t, lvl, pos }, ternary_compare());
       }
 

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -20,9 +20,9 @@ namespace ipr {
    const String& String::empty_string()
    {
       struct Empty_string final : impl::Node<String> {
-         Index size() const { return 0; }
-         iterator begin() const { return ""; }
-         iterator end() const { return begin(); }
+         Index size() const final { return 0; }
+         iterator begin() const final { return ""; }
+         iterator end() const final { return begin(); }
       };
 
       static constexpr Empty_string empty { };
@@ -230,9 +230,8 @@ namespace ipr::impl {
 
       master_decl_data<ipr::Template>::
       master_decl_data(impl::Overload* ovl, const ipr::Type& t)
-            : Base(this), overload_entry(t),
-              primary(0),home(0),
-              overload(ovl)
+            : Base{this}, overload_entry{t},
+              primary{}, home{}, overload{ovl}
       { }
 
       // -------------------------
@@ -259,7 +258,7 @@ namespace ipr::impl {
       // --------------------
 
       Overload::Overload(const ipr::Name& n)
-            : name(n), where(0)
+            : name{n}, where{}
       { }
 
       Overload::Index Overload::size() const {
@@ -415,7 +414,7 @@ namespace ipr::impl {
       // ----------------------
 
       Enumerator::Enumerator(const ipr::Name& n, const ipr::Enum& t, Decl_position p)
-            : id(n), constraint(t), scope_pos(p), where(0), init(0)
+            : id{n}, constraint{t}, scope_pos{p}, where{}, init{}
       { }
 
       // -----------------
@@ -649,7 +648,7 @@ namespace ipr::impl {
 
       impl::Enumerator*
       Enum::add_member(const ipr::Name& n) {
-         Decl_position pos { members().size() };
+         const Decl_position pos { members().size() };
          impl::Enumerator* e = body.scope.push_back(n, *this, pos);
          e->where = &body;
          return e;
@@ -672,7 +671,7 @@ namespace ipr::impl {
 
       impl::Base_type*
       Class::declare_base(const ipr::Type& t) {
-         Decl_position pos { bases().size() };
+         const Decl_position pos { bases().size() };
          return base_subobjects.scope.push_back(t, base_subobjects, pos);
       }
 
@@ -785,7 +784,7 @@ namespace ipr::impl {
          int operator()(const Binary<T>& lhs,
                         const typename Binary<T>::Rep& rhs) const
          {
-            if (int cmp = compare(lhs.rep.first, rhs.first)) return cmp;
+            if (const auto cmp = compare(lhs.rep.first, rhs.first)) return cmp;
 
             return compare(lhs.rep.second, rhs.second);
          }
@@ -869,8 +868,8 @@ namespace ipr::impl {
          int operator()(const Ternary<T>& lhs,
                         const typename Ternary<T>::Rep& rhs) const
          {
-            if (int cmp = compare(lhs.rep.first, rhs.first)) return cmp;
-            if (int cmp = compare(lhs.rep.second, rhs.second)) return cmp;
+            if (const auto cmp = compare(lhs.rep.first, rhs.first)) return cmp;
+            if (const auto cmp = compare(lhs.rep.second, rhs.second)) return cmp;
 
             return compare(lhs.rep.third, rhs.third);
          }
@@ -879,8 +878,8 @@ namespace ipr::impl {
          int operator()(const typename Ternary<T>::Rep& lhs,
                         const Ternary<T>& rhs) const
          {
-            if (int cmp = compare(lhs.first, rhs.rep.first)) return cmp;
-            if (int cmp = compare(lhs.second, rhs.rep.second)) return cmp;
+            if (const auto cmp = compare(lhs.first, rhs.rep.first)) return cmp;
+            if (const auto cmp = compare(lhs.second, rhs.rep.second)) return cmp;
 
             return compare(lhs.third, rhs.rep.third);
          }
@@ -891,9 +890,9 @@ namespace ipr::impl {
          int operator()(const Quaternary<T>& lhs,
                         const typename Quaternary<T>::Rep& rhs) const
          {
-            if (int cmp = compare(lhs.rep.first, rhs.first)) return cmp;
-            if (int cmp = compare(lhs.rep.second, rhs.second)) return cmp;
-            if (int cmp = compare(lhs.rep.third, rhs.third)) return cmp;
+            if (const auto cmp = compare(lhs.rep.first, rhs.first)) return cmp;
+            if (const auto cmp = compare(lhs.rep.second, rhs.second)) return cmp;
+            if (const auto cmp = compare(lhs.rep.third, rhs.third)) return cmp;
 
             return compare(lhs.rep.fourth, rhs.fourth);
          }
@@ -902,9 +901,9 @@ namespace ipr::impl {
          int operator()(const typename Quaternary<T>::Rep& lhs,
                         const Quaternary<T>& rhs) const
          {
-            if (int cmp = compare(lhs.first, rhs.rep.first)) return cmp;
-            if (int cmp = compare(lhs.second, rhs.rep.second)) return cmp;
-            if (int cmp = compare(lhs.third, rhs.rep.third)) return cmp;
+            if (const auto cmp = compare(lhs.first, rhs.rep.first)) return cmp;
+            if (const auto cmp = compare(lhs.second, rhs.rep.second)) return cmp;
+            if (const auto cmp = compare(lhs.third, rhs.rep.third)) return cmp;
 
             return compare(lhs.fourth, rhs.rep.fourth);
          }
@@ -1051,7 +1050,7 @@ namespace ipr::impl {
       }
 
       // -- impl::Lambda
-      Lambda::Lambda(const ipr::Region& r, Mapping_level l) : parms{r, l}
+      Lambda::Lambda(const ipr::Region& r, Mapping_level l) : parms{r, l}, lam_spec{}
       { }
 
       // -------------------------------
@@ -1061,7 +1060,7 @@ namespace ipr::impl {
 
       const ipr::Overload&
       Scope::operator[](const ipr::Name& n) const {
-         if (impl::Overload* ovl = overloads.find(n, node_compare()))
+         if (const impl::Overload* ovl = overloads.find(n, node_compare()))
             return *ovl;
          return missing;
       }
@@ -1078,7 +1077,7 @@ namespace ipr::impl {
          impl::Overload* ovl = overloads.insert(n, node_compare());
          overload_entry* master = ovl->lookup(i.type());
 
-         if (master == 0) {
+         if (master == nullptr) {
             impl::Alias* decl = aliases.declare(ovl, i.type());
             decl->aliasee = &i;
             add_member(decl);
@@ -1097,7 +1096,7 @@ namespace ipr::impl {
          impl::Overload* ovl = overloads.insert(n, node_compare());
          overload_entry* master = ovl->lookup(t);
 
-         if (master == 0) {
+         if (master == nullptr) {
             impl::Var* var = vars.declare(ovl, t);
             add_member(var);
             return var;
@@ -1114,7 +1113,7 @@ namespace ipr::impl {
          impl::Overload* ovl = overloads.insert(n, node_compare());
          overload_entry* master = ovl->lookup(t);
 
-         if (master == 0) {
+         if (master == nullptr) {
             impl::Field* field = fields.declare(ovl, t);
             add_member(field);
             return field;
@@ -1131,7 +1130,7 @@ namespace ipr::impl {
          impl::Overload* ovl = overloads.insert(n, node_compare());
          overload_entry* master = ovl->lookup(t);
 
-         if (master == 0) {
+         if (master == nullptr) {
             impl::Bitfield* field = bitfields.declare(ovl, t);
             add_member(field);
             return field;
@@ -1152,11 +1151,9 @@ namespace ipr::impl {
 
          // Does the overload-set already contain a decl with that type?
          overload_entry* master = ovl->lookup(t);
-         impl::Typedecl* decl;
-         if (master == 0)       // no, this is the first declaration
-             decl = typedecls.declare(ovl, t);
-         else                   // just re-declare.
-            decl = typedecls.redeclare(master);
+         impl::Typedecl* decl = master == nullptr ?
+            typedecls.declare(ovl, t) : // no, this is the first declaration
+            typedecls.redeclare(master); // just re-declare.
          add_member(decl);      // remember we saw a declaration.
          return decl;
       }
@@ -1167,7 +1164,7 @@ namespace ipr::impl {
          impl::Overload* ovl = overloads.insert(n, node_compare());
          overload_entry* master = ovl->lookup(t);
 
-         if (master == 0) {
+         if (master == nullptr) {
             impl::Fundecl* decl = fundecls.declare(ovl, t);
             add_member(decl);
             return decl;
@@ -1185,7 +1182,7 @@ namespace ipr::impl {
          impl::Overload* ovl = overloads.insert(n, node_compare());
          overload_entry* master = ovl->lookup(t);
 
-         if (master == 0) {
+         if (master == nullptr) {
             impl::Template* decl = primary_maps.declare(ovl, t);
             decl->decl_data.master_data->primary = decl;
             add_member(decl);
@@ -1205,7 +1202,7 @@ namespace ipr::impl {
          impl::Overload* ovl = overloads.insert(n, node_compare());
          overload_entry* master = ovl->lookup(t);
 
-         if (master == 0) {
+         if (master == nullptr) {
             impl::Template* decl = secondary_maps.declare(ovl, t);
             // FXIME: record this a secondary map and set its primary.
             add_member(decl);
@@ -1257,7 +1254,7 @@ namespace ipr::impl {
       expr_factory::get_symbol(const ipr::Name& n, const ipr::Type& t)
       {
          const auto comparator = [&t](auto& x, auto& y) {
-            if (auto cmp = compare(x.name(), y))
+            if (const auto cmp = compare(x.name(), y))
                return cmp;
             return compare(x.type(), t);
          };
@@ -1827,8 +1824,8 @@ namespace ipr::impl {
       expr_factory::rname_for_next_param(const impl::Mapping& map,
                                          const ipr::Type& t) {
          using Rep = impl::Rname::Rep;
-         Decl_position pos { map.parms.size() };
-         auto lvl = map.parameters().level();
+         const Decl_position pos { map.parms.size() };
+         const auto lvl = map.parameters().level();
          return rnames.insert(Rep{ t, lvl, pos }, ternary_compare());
       }
 

--- a/src/io.cxx
+++ b/src/io.cxx
@@ -26,7 +26,7 @@ namespace ipr {
    template<typename F, typename T>
    static Printer& comma_separated(Printer& pp, const Sequence<T>& s)
    {
-      auto worker = [&pp, first = true](auto& x) mutable {
+      const auto worker = [&pp, first = true](auto& x) mutable {
          if (not first)
             pp << ", ";
          pp << F(x);
@@ -38,14 +38,14 @@ namespace ipr {
 
    Printer& operator<<(Printer& p, Mapping_level x)
    {
-      auto n = static_cast<std::size_t>(x);
+      const auto n = static_cast<std::size_t>(x);
       p.channel() << n;
       return p;
    }
 
    Printer& operator<<(Printer& p, Decl_position x)
    {
-      auto n = static_cast<std::size_t>(x);
+      const auto n = static_cast<std::size_t>(x);
       p.channel() << n;
       return p;
    }
@@ -61,7 +61,7 @@ namespace ipr {
    };
 
    Printer::Printer(std::ostream& os)
-         : stream(os), pad(None), emit_newline(false),
+         : stream(os), pad(Padding::None), emit_newline(false),
            pending_indentation(0) { }
 
    Printer&
@@ -94,13 +94,13 @@ namespace ipr {
    inline Printer&
    operator<<(Printer& printer, Token_helper<T> t)
    {
-      return printer << t.value << Printer::None;
+      return printer << t.value << Printer::Padding::None;
    }
 
    inline Printer&
    insert_xtoken(Printer& printer, const char* s)
    {
-      return printer << s << Printer::None;
+      return printer << s << Printer::Padding::None;
    }
 
    struct needs_newline { };
@@ -220,11 +220,11 @@ namespace ipr {
    static inline Printer&
    operator<<(Printer& printer, xpr_identifier id)
    {
-      if (printer.padding() == Printer::Before)
+      if (printer.padding() == Printer::Padding::Before)
          printer << ' ';
       printer.write(id.begin, id.last);
 
-      return printer <<  Printer::Before;
+      return printer <<  Printer::Padding::Before;
    }
 
    Printer&
@@ -277,7 +277,7 @@ namespace ipr {
             if (not std::isalpha(*s.begin()))
                {
                   pp.write(s.begin(), s.end());
-                  pp << Printer::None;
+                  pp << Printer::Padding::None;
                }
             else
                pp << xpr_identifier(s);
@@ -470,7 +470,7 @@ namespace ipr {
                case '\1':
                case '\2':
                case '\3':
-                  pp << "\\0" << std::oct << int(*cur);
+                  pp << "\\0" << std::oct << static_cast<int>(*cur);
                   break;
                }
       }
@@ -653,7 +653,7 @@ namespace ipr {
          void visit(const New& e) final
          {
             pp << xpr_identifier("new") << token(' ');
-            if (auto p = e.placement())
+            if (const auto p = e.placement())
                pp << token('(') << p.get() << token(") ");
             // Note: The following does not exactly conform to the ISO C++ grammar (because of ambiguity).
             pp << xpr_expr(e.initializer());
@@ -1718,9 +1718,10 @@ namespace ipr {
             auto& locus = stmt.source_location();
             if (locus.file != File_index{})
             {
-               *pp << token("F") << (int)locus.file << token(':') << (int)locus.line;
+               *pp << token("F") << static_cast<int>(locus.file) << token(':')
+                   << static_cast<int>(locus.line);
                if (locus.column != Column_number{})
-                  *pp << token(':') << (int)locus.column;
+                  *pp << token(':') << static_cast<int>(locus.column);
                *pp << token(' ');
             }
          }

--- a/src/io.cxx
+++ b/src/io.cxx
@@ -26,7 +26,7 @@ namespace ipr {
    template<typename F, typename T>
    static Printer& comma_separated(Printer& pp, const Sequence<T>& s)
    {
-      const auto worker = [&pp, first = true](auto& x) mutable {
+      auto worker = [&pp, first = true](auto& x) mutable {
          if (not first)
             pp << ", ";
          pp << F(x);
@@ -38,14 +38,14 @@ namespace ipr {
 
    Printer& operator<<(Printer& p, Mapping_level x)
    {
-      const auto n = static_cast<std::size_t>(x);
+      auto n = static_cast<std::size_t>(x);
       p.channel() << n;
       return p;
    }
 
    Printer& operator<<(Printer& p, Decl_position x)
    {
-      const auto n = static_cast<std::size_t>(x);
+      auto n = static_cast<std::size_t>(x);
       p.channel() << n;
       return p;
    }
@@ -653,7 +653,7 @@ namespace ipr {
          void visit(const New& e) final
          {
             pp << xpr_identifier("new") << token(' ');
-            if (const auto p = e.placement())
+            if (auto p = e.placement())
                pp << token('(') << p.get() << token(") ");
             // Note: The following does not exactly conform to the ISO C++ grammar (because of ambiguity).
             pp << xpr_expr(e.initializer());

--- a/src/utility.cxx
+++ b/src/utility.cxx
@@ -20,12 +20,12 @@ ipr::util::string::arena::arena()
       : mem(static_cast<pool*>(operator new(poolsz))),
         next_header(mem->storage)
 {
-   mem->previous = 0;
+   mem->previous = nullptr;
 }
 
 ipr::util::string::arena::~arena()
 {
-   while (mem != 0) {
+   while (mem != nullptr) {
       pool* cur = mem;
       mem = mem->previous;
       operator delete (cur);
@@ -38,7 +38,7 @@ ipr::util::string*
 ipr::util::string::arena::allocate(int n)
 {
    const int m = (n - string::padding_count + headersz - 1) / headersz + 1;
-   string* header;
+   string* header{};
 
    // If we have enough space left, juts grab it.
    if (m <= remaining_header_count()) {


### PR DESCRIPTION
Add analysis ruleset to be used by the Microsoft C++ Code Analysis action. Warnings should be visible in the PR so this can be used to determine the scope of rules that will be useful for the IPR.