### PR TITLE
Add `ipr::Rewrite`

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -1287,6 +1287,7 @@ namespace ipr {
       using Construction = Classic_unary_expr<ipr::Construction>;
       using Noexcept = Unary_expr<ipr::Noexcept>;
 
+      using Rewrite = Binary_node<ipr::Rewrite>;
       using And = Classic_binary_expr<ipr::And>;
       using Annotation = Binary_node<ipr::Annotation>;
       using Array_ref = Classic_binary_expr<ipr::Array_ref>;
@@ -1438,6 +1439,7 @@ namespace ipr {
          Construction* make_construction(const ipr::Type&, const ipr::Enclosure&);
          Noexcept* make_noexcept(const ipr::Expr&, Optional<ipr::Type> = { });
 
+         Rewrite* make_rewrite(const ipr::Expr&, const ipr::Expr&);
          And* make_and(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
          Array_ref* make_array_ref(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
          Arrow* make_arrow(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
@@ -1551,6 +1553,7 @@ namespace ipr {
          stable_farm<impl::Noexcept> noexcepts;
          stable_farm<impl::Args_cardinality> cardinalities;
 
+         stable_farm<impl::Rewrite> rewrites;
          stable_farm<impl::Scope_ref> scope_refs;
          stable_farm<impl::And> ands;
          stable_farm<impl::Array_ref> array_refs;

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -220,6 +220,7 @@ namespace ipr {
    struct Binary_fold;           // Primary expression of the form (a op ... op b)
 
    struct Mapping;               // function
+   struct Rewrite;               // Semantics by translation -- unwise, but the committee can't help it
 
    // --------------------------------------------------------
    // -- result of trinary expression constructor constants --
@@ -1554,6 +1555,17 @@ namespace ipr {
    // operator, but the general IPR model here allows it.
    struct Expansion : Unary<Category<Category_code::Expansion, Classic>> { };
 
+                                // -- Rewrite --
+   // Various ISO C++ syntactic constructs are defined - unwwisely -
+   // via translation to more elaborate sequences of tokens or parse trees.
+   // The `source()` is the construct as written in the input source code, and the
+   // `target()` is the internal expression giving meaning to the source.
+   struct Rewrite : Binary<Category<Category_code::Rewrite>> {
+      const Expr& source() const { return first(); }
+      const Expr& target() const { return second(); }
+      const Type& type() const final { return second().type(); }
+   };
+
                                 // -- Member_selection<> --
    // This class factorizes the commonalities of various object member
    // selection operation.
@@ -2386,6 +2398,7 @@ namespace ipr {
       virtual void visit(const Expansion&);
       virtual void visit(const Noexcept&);
 
+      virtual void visit(const Rewrite&);
       virtual void visit(const Scope_ref&);
       virtual void visit(const And&);
       virtual void visit(const Array_ref&);

--- a/include/ipr/node-category
+++ b/include/ipr/node-category
@@ -83,6 +83,7 @@ Expansion,                          // ipr::Expansion
 Noexcept,                           // ipr::Noexcept
 Args_cardinality,                   // ipr::Args_cardinality
 
+Rewrite,                            // ipr::Rewrite
 Scope_ref,                          // ipr::Scope_ref
 Plus,                               // ipr::Plus
 Plus_assign,                        // ipr::Plus_assign

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -1504,6 +1504,11 @@ namespace ipr::impl {
          return make(noexcepts, e).with_type(t);
       }
 
+      impl::Rewrite* expr_factory::make_rewrite(const ipr::Expr& s, const ipr::Expr& t)
+      {
+         return rewrites.make(s, t);
+      }
+
       impl::And*
       expr_factory::make_and(const ipr::Expr& l, const ipr::Expr& r, Optional<ipr::Type> t) 
       {

--- a/src/traversal.cxx
+++ b/src/traversal.cxx
@@ -460,6 +460,11 @@ ipr::Visitor::visit(const Noexcept& e)
    visit(as<Expr>(e));
 }
 
+void ipr::Visitor::visit(const Rewrite& e)
+{
+   visit(as<Expr>(e));
+}
+
 void
 ipr::Visitor::visit(const Scope_ref& n)
 {


### PR DESCRIPTION
Various places in the ISO C++ semantics require _semantics by translation_ -- an unwise specification technique for an evolutionary and complex language.  This expression node captures the structure of that process.