### PR TITLE
Add translation directives to IPR

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -429,7 +429,6 @@ namespace ipr {
          Arg_type rep;
 
          explicit Unary(Arg_type a) : rep{ a } { }
-
          Arg_type operand() const final { return rep; }
       };
 
@@ -456,7 +455,6 @@ namespace ipr {
 
          Binary(const Rep& r) : rep(r) { }
          Binary(Arg1_type f, Arg2_type s) : rep{ f, s } { }
-
          Arg1_type first() const final { return rep.first; }
          Arg2_type second() const final { return rep.second; }
       };
@@ -488,7 +486,6 @@ namespace ipr {
 
          Ternary(const Rep& r) : rep(r) { }
          Ternary(Arg1_type f, Arg2_type s, Arg3_type t) : rep{ f, s, t } { }
-
          Arg1_type first() const final { return rep.first; }
          Arg2_type second() const final { return rep.second; }
          Arg3_type third() const final { return rep.third; }
@@ -510,7 +507,6 @@ namespace ipr {
 
          Quaternary(const Rep& r) : rep(r) { }
          Quaternary(Arg1_type f, Arg2_type s, Arg3_type t, Arg4_type u) : rep{ f, s, t, u } { }
-
          Arg1_type first() const final { return rep.first; }
          Arg2_type second() const final { return rep.second; }
          Arg3_type third() const final { return rep.third; }
@@ -880,6 +876,11 @@ namespace ipr {
          // It was not strictly necessary to actually define this class
          // and the function type().  See the comments in <ipr/interface>.
          const ipr::Type& type() const;
+      };
+
+      template<typename T, Phases f>
+      struct Directive : impl::Expr<T> {
+         Phases phases() const final { return f; }
       };
 
       // Stmt<S> implements the common operations of statements.
@@ -1737,6 +1738,29 @@ namespace ipr {
          stable_farm<impl::Closure> closures;
       };
 
+      // -- Implementation of directives --
+      struct Asm : impl::Directive<ipr::Asm, Phases::Code_generation> {
+         explicit Asm(const ipr::String&);
+         const ipr::String& text() const final { return txt; }
+      private:
+         const ipr::String& txt;
+      };
+
+      struct Static_assert : impl::Directive<ipr::Static_assert, Phases::Elaboration> {
+         Static_assert(const ipr::Expr&, Optional<ipr::String>);
+         const ipr::Expr& condition() const final { return cond; }
+         Optional<ipr::String> message() const final { return txt; }
+      private:
+         const ipr::Expr& cond;
+         Optional<ipr::String> txt;
+      };
+
+      struct Using_directive : impl::Directive<ipr::Using_directive, Phases::Elaboration> {
+         explicit Using_directive(const ipr::Scope&);
+         const ipr::Scope& nominated_scope() const final { return scope; }
+      private:
+         const ipr::Scope& scope;
+      };
 
       // ----------------------------------
       // -- Implementation of statements --
@@ -1758,21 +1782,20 @@ namespace ipr {
       // recording the set of declarations appearing in that
       // block.  It also holds a sequence of handlers, when the
       // block actually represents a C++ try-block.
-
       struct Block : impl::Stmt<Expr<ipr::Block>> {
          impl::Region region;
-         impl::ref_sequence<ipr::Stmt> stmt_seq;
+         impl::ref_sequence<ipr::Expr> stmt_seq;
          impl::ref_sequence<ipr::Handler> handler_seq;
 
          explicit Block(const ipr::Region&);
          const ipr::Scope& elements() const final { return region.scope; }
-         const ipr::Sequence<ipr::Stmt>& body() const final { return stmt_seq; }
+         const ipr::Sequence<ipr::Expr>& body() const final { return stmt_seq; }
          const ipr::Sequence<ipr::Handler>& handlers() const final { return handler_seq; }
 
          // The scope of declarations in this block
          impl::Scope* scope() { return &region.scope; }
 
-         void add_stmt(const ipr::Stmt& s)
+         void add_stmt(const ipr::Expr& s)
          {
             stmt_seq.push_back(&s);
          }
@@ -2111,9 +2134,19 @@ namespace ipr {
          stable_farm<impl::Lambda> lambdas;
       };
 
+      struct dir_factory {
+         impl::Asm* make_asm(const ipr::String&, const ipr::Type&);
+         impl::Static_assert* make_static_assert(const ipr::Expr&, Optional<ipr::String> = { });
+         impl::Using_directive* make_using_directive(const ipr::Scope&, const ipr::Type&);
+      private:
+         stable_farm<impl::Asm> asms;
+         stable_farm<impl::Static_assert> asserts;
+         stable_farm<impl::Using_directive> dirs;
+      };
+
       // This factory class takes on the implementation burden of
       // allocating storage for statement nodes and their constructions.
-      struct stmt_factory : expr_factory {
+      struct stmt_factory : expr_factory, dir_factory {
          impl::Break* make_break(const ipr::Type&);
          impl::Continue* make_continue(const ipr::Type&);
          impl::Empty_stmt* make_empty_stmt(const ipr::Type&);

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -78,6 +78,7 @@ namespace ipr {
    struct Expr;                  // general expressions
    struct Name;                  // general names
    struct Type;                  // general types
+   struct Directive;             // general directives
    struct Stmt;                  // general statements
    struct Decl;                  // general declarations
 
@@ -249,11 +250,19 @@ namespace ipr {
    struct Switch;                // switch-statement
    struct While;                 // while-statement
 
+   // -----------------------------------------------
+   // -- result of directive constructor constants --
+   // -----------------------------------------------
+   struct Asm;                   // asm-declaration
+   struct Deduction_guide;       // deduction-guide declaration
+   struct Static_assert;         // static-assert declaration
+   struct Using_declaration;     // using-declaration
+   struct Using_directive;       // using-directive
+ 
    // -------------------------------------------------
    // -- result of declaration constructor constants --
    // -------------------------------------------------
    struct Alias;                 // alias-declaration
-   struct Asm;                   // asm-declaration
    struct Base_type;             // base-class in class inheritance
    struct Enumerator;            // enumerator in enumeration-declaration
    struct Field;                 // field in union or class declaration
@@ -263,7 +272,6 @@ namespace ipr {
    struct Parameter;             // function or template parameter
    struct Typedecl;              // declaration for a type
    struct Var;                   // variable declaration
-   struct Using_directive;       // using-directive
 
    // ------------------------
    // -- distinguished node --
@@ -280,6 +288,28 @@ namespace ipr {
    // -- built-ins, but not constants --
    // ----------------------------------
    struct Global_scope;          // global namespace -- "::"
+
+   // ---------------------------
+   // -- Phases of translation --
+   // ---------------------------
+   // A bitmask type for the various phases of C++ program translation.
+   enum class Phases {
+      Unknown              = 0x0000,   // Unknown translation phase
+      Reading              = 0x0001,   // Opening and reading an input source
+      Lexing               = 0x0002,   // Lexical decomposition of input source
+      Preprocessing        = 0x0004,   // Macro expansion and friends
+      Parsing              = 0x0008,   // Grammatical decomposition of the input source
+      Name_resolution      = 0x0010,   // Name lookup
+      Typing               = 0x0020,   // Type assignment of expressions
+      Evaluation           = 0x0040,   // Compile-time evaluation
+      Instantiation        = 0x0080,   // Template instantiation phase
+      Code_generation      = 0x0100,   // Code generation phase
+      Linking              = 0x0200,   // Linking phase
+      Loading              = 0x0400,   // Program loading phase
+      Execution            = 0x0800,   // Runtime execution
+
+      Elaboration          = Name_resolution | Typing | Evaluation | Instantiation
+   };
 
 
                                 // -- Category_node --
@@ -1911,6 +1941,50 @@ namespace ipr {
       auto size() const { return elements().size(); }
    };
 
+                                // -- Directive --
+   // Standard C++ has grammar hacks where certain constructs are
+   // classified as declarations, by they don't actually declare any name.
+   // Rather, the modify the behavior of the implementation in certain ways.
+   // For example, a using-declaration does not declare a name: it changes
+   // the usual name lookup rules to consider new scopes.  A static-assert
+   // does not declare anything: it halts translation when a certain condition
+   // does not hold; otherwise a no-op.
+   // These constructs are generally known as directives.  They were made
+   // declarations in Standard C++, so that they could appear at non-local 
+   // scopes -- where general declarations live. 
+   struct Directive : Expr {
+      virtual Phases phases() const = 0;
+   protected:
+      constexpr Directive(Category_code c) : Expr{ c } { }
+   };
+
+                                // -- Asm --
+   // An asm-declaration, a directive in IPR.
+   // This directive affects only code generation, where it might inject
+   // executable instructions or affect the linker behavior.
+   // Its type should be set to "void".
+   struct Asm : Category<Category_code::Asm, Directive> {
+      virtual const String& text() const = 0;
+   };
+
+                                // -- Static_assert --
+   // A static assertion: a directive that halts the elaboration phase.
+   // No runtime code is ever generated.
+   // Its type should be set to "bool". 
+   struct Static_assert : Category<Category_code::Static_assert, Directive> {
+      virtual const Expr& condition() const = 0;
+      virtual Optional<String> message() const = 0;
+   };
+
+                                // -- Using_directive --
+   // A standard C++ using-directive or a using-enum-declaration 
+   // (nominating additional scopes) for elaboration purposes.
+   // Its type should be "namespace" if it nominates a namespace,
+   // or "enum" or "enum class" if it nominates an enumeration.
+   struct Using_directive : Category<Category_code::Using_directive, Directive> {
+      virtual const Scope& nominated_scope() const = 0;
+   };
+
                                 // -- Stmt --
    // The view that a statement is kind of expression does not follow from
    // Standard C++ specification.  It is a design choice we made based on
@@ -1939,6 +2013,8 @@ namespace ipr {
    //              ,----> D.S. <----,
    //              |                |
    //         Declaration       Statement
+   //
+   //    3. In general, IPR is an expression-based language.
    //
    //
    // When combined, the two diagrams yield
@@ -1992,10 +2068,10 @@ namespace ipr {
    };
 
                                 // -- Block --
-   // A Block is any sequence of statements bracketed by curly braces.
+   // A Block is any sequence of general expressions bracketed by curly braces.
    struct Block : Category<Category_code::Block, Stmt> {
       virtual const Scope& elements() const = 0;
-      virtual const Sequence<Stmt>& body() const = 0;
+      virtual const Sequence<Expr>& body() const = 0;
       virtual const Sequence<Handler>& handlers() const = 0;
    };
 
@@ -2179,15 +2255,6 @@ namespace ipr {
                                 // -- Enumerator --
    // This represents a classic enumerator.
    struct Enumerator : Category<Category_code::Enumerator, Decl> {
-   };
-
-                                // -- Asm --
-   // An asm-declaration.  While this sort of declaration does not
-   // actually introduce any name, it was made a declaration in C++,
-   // so that it could appear at non-local scopes -- where general
-   // declarations live.  Its name is "asm" and its type is "void".
-   struct Asm : Category<Category_code::Asm, Decl> {
-      virtual const String& text() const = 0;
    };
 
                                 // - Alias --
@@ -2472,6 +2539,11 @@ namespace ipr {
       virtual void visit(const New&);
       virtual void visit(const Mapping&);
 
+      virtual void visit(const Directive&) = 0;
+      virtual void visit(const Asm&);
+      virtual void visit(const Static_assert&);
+      virtual void visit(const Using_directive&);
+
       virtual void visit(const Stmt&) = 0;
       virtual void visit(const Labeled_stmt&);
       virtual void visit(const Block&);
@@ -2500,7 +2572,6 @@ namespace ipr {
       virtual void visit(const Parameter_list&);
       virtual void visit(const Typedecl&);
       virtual void visit(const Var&);
-      virtual void visit(const Asm&);
 
       virtual void visit(const Global_scope&);
       virtual void visit(const Empty_stmt&);

--- a/include/ipr/node-category
+++ b/include/ipr/node-category
@@ -142,6 +142,12 @@ New,                                // ipr::New
 Conditional,                        // ipr::Conditional
 Scope,                              // ipr::Scope
 
+Asm,                                // ipr::Asm
+Deduction_guide,                    // ipr::Deduction_guide
+Static_assert,                      // ipr::Static_assert
+Using_declaration,                  // ipr::Using_declaration
+Using_directive,                    // ipr::Using_directive
+
 Block,                              // ipr::Block
 Break,                              // ipr::Break
 Continue,                           // ipr::Continue
@@ -159,7 +165,6 @@ Switch,                             // ipr::Switch
 While,                              // ipr::While
 
 Alias,                              // ipr::Alias
-Asm,                                // ipr::Asm
 Base_type,                          // ipr::Base_type
 Enumerator,                         // ipr::Enumerator
 Field,                              // ipr::Field
@@ -169,7 +174,6 @@ Template,                           // ipr::Template
 Parameter,                          // ipr::Parameter
 Typedecl,                           // ipr::Typedecl
 Var,                                // ipr::Var
-Using_directive,                    // ipr::Using_directive
 
 Unit,                               // ipr::Unit
 

--- a/include/ipr/traversal
+++ b/include/ipr/traversal
@@ -50,6 +50,7 @@ namespace ipr {
       void visit(const Name& n) override { (*this)(n); }
       void visit(const Expr& n) override { (*this)(n); }
       void visit(const Type& n) override { (*this)(n); }
+      void visit(const Directive& n) override { (*this)(n); }
       void visit(const Stmt& n) override { (*this)(n); }
       void visit(const Decl& n) override { (*this)(n); }
    };

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -355,6 +355,15 @@ namespace ipr::impl {
          return rep.first;
       }
 
+      // -- Directives --
+      Asm::Asm(const ipr::String& s) : txt{s} { }
+
+      Static_assert::Static_assert(const ipr::Expr& e, Optional<ipr::String> s)
+         : cond{e}, txt{s}
+      { }
+
+      Using_directive::Using_directive(const ipr::Scope& s) : scope{s} { }
+
       namespace {
          // Helper function for building expression nodes with type assignment.
          template<typename T, typename... Args>
@@ -533,6 +542,22 @@ namespace ipr::impl {
       // --------------------
 
       Continue::Continue() : stmt{} { }
+
+      // -- impl::dir_factory --
+      impl::Asm* dir_factory::make_asm(const ipr::String& s, const ipr::Type& t)
+      {
+         return make(asms, s).with_type(t);
+      }
+
+      impl::Static_assert* dir_factory::make_static_assert(const ipr::Expr& e, Optional<ipr::String> s)
+      {
+         return asserts.make(e, s);
+      }
+
+      impl::Using_directive* dir_factory::make_using_directive(const ipr::Scope& s, const ipr::Type& t)
+      {
+         return make(dirs, s).with_type(t);
+      }
 
       // ------------------------
       // -- impl::stmt_factory --

--- a/src/traversal.cxx
+++ b/src/traversal.cxx
@@ -793,6 +793,26 @@ ipr::Visitor::visit(const Mapping& s)
    visit(as<Expr>(s));
 }
 
+// -- Directives visiting hooks --
+
+void
+ipr::Visitor::visit(const Asm& d)
+{
+   visit(as<Directive>(d));
+}
+
+void
+ipr::Visitor::visit(const Static_assert& d)
+{
+   visit(as<Directive>(d));
+}
+
+void
+ipr::Visitor::visit(const Using_directive& d)
+{
+   visit(as<Directive>(d));
+}
+
 // -- Statements visiting hooks --
 
 void
@@ -891,12 +911,6 @@ ipr::Visitor::visit(const Handler& s)
 
 void
 ipr::Visitor::visit(const Alias& d)
-{
-   visit(as<Decl>(d));
-}
-
-void
-ipr::Visitor::visit(const Asm& d)
 {
    visit(as<Decl>(d));
 }


### PR DESCRIPTION
Certain Standard C++ constructs are described as declarations by the ISO spec, but they - in fact - do not declare any names.  They act more like directives (e.g. changing the compiler behavior) than introducing a name with a type (possibly with initializer) in a given scope.

Fixes #6
Fixes #17