### PR TITLE
Add Tor type for object constructors and destructors

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -839,6 +839,9 @@ namespace ipr {
       template<typename T>
       using Binary_type = Binary<Type<T>>;
 
+      template<typename T>
+      using Ternary_type = Ternary<Type<T>>;
+
       // Scopes, as expressions, have Product types.  Such types could
       // be implemented directly as a separate sequence of types.
       // However, it would require coordination from the various
@@ -1164,6 +1167,7 @@ namespace ipr {
       using Array = Binary_type<ipr::Array>;
       using Decltype = Unary_type<ipr::Decltype>;
       using As_type = Binary_type<ipr::As_type>;
+      using Tor = Ternary_type<ipr::Tor>;
       using Function = Quaternary<Type<ipr::Function>>;
       using Pointer = Unary_type<ipr::Pointer>;
       using Product = Unary_type<ipr::Product>;
@@ -1702,6 +1706,7 @@ namespace ipr {
          impl::Qualified* make_qualified(ipr::Type_qualifier,
                                          const ipr::Type&);
          impl::Decltype* make_decltype(const ipr::Expr&);
+         impl::Tor* make_tor(const ipr::Product&, const ipr::Sum&, const ipr::Linkage&);
          impl::Function* make_function(const ipr::Product&, const ipr::Type&,
                                        const ipr::Sum&, const ipr::Linkage&);
          impl::Pointer* make_pointer(const ipr::Type&);
@@ -1721,6 +1726,7 @@ namespace ipr {
       private:
          util::rb_tree::container<impl::Array> arrays;
          util::rb_tree::container<impl::As_type> type_refs;
+         util::rb_tree::container<impl::Tor> tors;
          util::rb_tree::container<impl::Function> functions;
          util::rb_tree::container<impl::Pointer> pointers;
          util::rb_tree::container<impl::Product> products;

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -94,6 +94,7 @@ namespace ipr {
    struct Class;                 // user-defined type - declared as "class" or "struct"
    struct Decltype;              // strict type of a declaration/expression
    struct Enum;                  // user-defined type - declared as "enum" or "class enum"
+   struct Tor;                   // types of constructors and destructors - not ISO C++ types
    struct Function;              // function type
    struct Namespace;             // user-defined type - declared as "namespace"
    struct Pointer;               // pointer type
@@ -1136,6 +1137,24 @@ namespace ipr {
    // of an expression.
    struct Decltype : Unary<Category<Category_code::Decltype, Type>, const Expr&> {
       Arg_type expr() const { return operand(); }
+   };
+
+                                // -- Tor --
+   // A node of this class represents a Type for either a constructor or a destructor.
+   // Formally, ISO C++ does not assign types to those special functions; however, a
+   // type-based representation of C++ semantics must assign types to such declarations.
+   // Although a low-level (e.g. ABI-level) representation of a contructor and a destructor
+   // may look at them as just some regular function, and assign them a Function type,
+   // the higher level semantics of C++ is best served by a dedicated type to abstract
+   // over ABI interpretation.
+   struct Tor : Ternary<Category<Category_code::Tor, Type>,
+                        const Expr&, const Type&, const Linkage&> {
+      // The parameter-list to a tor type.  Always empty for a Standard C++ destructor.
+      Arg1_type source() const { return first(); }
+      // The exception-specification for this tor type.
+      Arg2_type throws() const { return second(); }
+      // The language linkage for this to type.  Default is "C++".
+      Arg3_type lang_linkage() const { return third(); }
    };
 
                                 // -- Function --
@@ -2432,6 +2451,7 @@ namespace ipr {
       virtual void visit(const Decltype&);
       virtual void visit(const Enum&);
       virtual void visit(const As_type&);
+      virtual void visit(const Tor&);
       virtual void visit(const Function&);
       virtual void visit(const Namespace&);
       virtual void visit(const Pointer&);

--- a/include/ipr/node-category
+++ b/include/ipr/node-category
@@ -25,6 +25,7 @@ Class,                              // ipr::Class
 Decltype,                           // ipr::Decltype
 As_type,                            // ipr::As_type
 Enum,                               // ipr::Enum
+Tor,                                // ipr::Tor
 Function,                           // ipr::Function
 Namespace,                          // ipr::Namespace
 Pointer,                            // ipr::Pointer

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -935,6 +935,13 @@ namespace ipr::impl {
          }
       };
 
+      impl::Tor*
+      type_factory::make_tor(const ipr::Product& s, const ipr::Sum& e, const ipr::Linkage& l)
+      {
+         using rep = impl::Tor::Rep;
+         return tors.insert(rep{ s, e, l }, ternary_compare());
+      }
+
       impl::Function*
       type_factory::make_function(const ipr::Product& s, const ipr::Type& t,
                                   const ipr::Sum& e, const ipr::Linkage& l)

--- a/src/io.cxx
+++ b/src/io.cxx
@@ -1294,7 +1294,6 @@ namespace ipr {
    operator<<(Printer& pp, xpr_base_classes x)
    {
       const Sequence<Base_type>& bases = x.bases;
-      const int n = bases.size();
       if (not bases.empty()) {
          pp << token('(');
          comma_separated<xpr_decl>(pp, bases);

--- a/src/traversal.cxx
+++ b/src/traversal.cxx
@@ -191,6 +191,11 @@ ipr::Visitor::visit(const As_type& t)
    visit(as<Type>(t));
 }
 
+void ipr::Visitor::visit(const Tor& t)
+{
+   visit(as<Type>(t));
+}
+
 void
 ipr::Visitor::visit(const Function& t)
 {


### PR DESCRIPTION
Standard C++ does not assign types to constructor or destructor declarations.  The IPR, until now, has relied on platform ABI-dependent interpretations of those special functions as regular functions with some ABI-dependent return type.  A high level representation of C++ is expected to abstract over those differences.  This is the role of this new type `Tor` class.  It is essentially a `Function`, minus the `target()` type.