### PR TITLE
using-declaration as directive

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -150,13 +150,31 @@ namespace ipr {
          const T& get(Index p) const final { return *pointer(this->at(p)); }
       };
 
+      // -- When a class implements an interface, return that interface;
+      // -- otherwise, the type itself.
+      template<typename T>
+      concept Has_interface = requires { typename T::Interface; };
+
+      template<typename T>
+      struct abstraction {
+         using type = T;
+      };
+
+      template<Has_interface T>
+      struct abstraction<T> {
+         using type = typename T::Interface;
+      };
+
+      template<typename T>
+      using interface = typename abstraction<T>::type;
+
                                 // -- impl::val_sequence --
       // The class val_sequence<T> implements Sequence<T> by storing
       // the actual values, instead of references to values (as is
       // the case of ref_sequence<T>).
       template<typename T>
-      struct val_sequence : ipr::Sequence<typename T::Interface>, private stable_farm<T> {
-         using Seq = ipr::Sequence<typename T::Interface>;
+      struct val_sequence : ipr::Sequence<interface<T>>, private stable_farm<T> {
+         using Seq = ipr::Sequence<interface<T>>;
          using Impl = stable_farm<T>;
          using Iterator = typename Seq::Iterator;
          using Index = typename Seq::Index;
@@ -205,6 +223,25 @@ namespace ipr {
          {
             throw std::domain_error("empty_sequence::get");
          }
+      };
+
+      // A sequence implementation for the case of a collection consisting of exactly one element.  
+      template<typename T>
+      struct singleton : ipr::Sequence<T> {
+         using Index = typename Sequence<T>::Index;
+
+         template<typename... Args>
+         singleton(Args&&... args) : item{args...} { }
+
+         Index size() const final { return 1; }
+         const T& get(Index i) const final
+         {
+            if (i == 0)
+               return item;
+            throw std::domain_error("singleton_sequence::get");
+         }
+      private:
+         T item;
       };
 
       template<class T>
@@ -1761,6 +1798,20 @@ namespace ipr {
          Optional<ipr::String> txt;
       };
 
+      // Implementation of ipr::Using_declaration in case where using-declarator-list is a singleton.
+      struct single_using_declaration : impl::Directive<ipr::Using_declaration, Phases::Elaboration> {
+         single_using_declaration(const ipr::Scope_ref&, Designator::Mode);
+         const ipr::Sequence<Designator>& designators() const final { return what; }
+      private:
+         singleton<Designator> what;
+      };
+
+      struct Using_declaration : impl::Directive<ipr::Using_declaration, Phases::Elaboration> {
+         impl::val_sequence<Designator> seq;
+
+         const ipr::Sequence<Designator>& designators() const final { return seq; }
+      };
+
       struct Using_directive : impl::Directive<ipr::Using_directive, Phases::Elaboration> {
          explicit Using_directive(const ipr::Scope&);
          const ipr::Scope& nominated_scope() const final { return scope; }
@@ -2143,10 +2194,15 @@ namespace ipr {
       struct dir_factory {
          impl::Asm* make_asm(const ipr::String&, const ipr::Type&);
          impl::Static_assert* make_static_assert(const ipr::Expr&, Optional<ipr::String> = { });
+         impl::single_using_declaration* make_using_declaration(const ipr::Scope_ref&,
+                                                                ipr::Using_declaration::Designator::Mode);
+         impl::Using_declaration* make_using_declaration();
          impl::Using_directive* make_using_directive(const ipr::Scope&, const ipr::Type&);
       private:
          stable_farm<impl::Asm> asms;
          stable_farm<impl::Static_assert> asserts;
+         stable_farm<impl::single_using_declaration> singles;
+         stable_farm<impl::Using_declaration> usings;
          stable_farm<impl::Using_directive> dirs;
       };
 

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -1995,6 +1995,32 @@ namespace ipr {
       virtual Optional<String> message() const = 0;
    };
 
+
+                                // -- Using_declaration --
+   // A using-declaration is directive that instructs the C++ translator to look up
+   // a set of names ('designator'), and for each declaration in the qualified lookup 
+   // result of a designator create a synonymous declaration, subject to constraints.
+   struct Using_declaration : Category<Category_code::Using_declaration, Directive> {
+      struct Designator;
+      virtual const Sequence<Designator>& designators() const = 0;
+   };
+
+   // A using-declarator: a qualified name, along with a denomination mode.
+   struct Using_declaration::Designator {
+      enum class Mode {
+         Normal      = 0x00,              // Normal interpretation of qualified name lookup
+         Type        = 0x01,              // The qualified name is assumed to name a type
+         Expansion   = 0x02,              // The designator needs expansion
+      };
+
+      Designator(const Scope_ref& p, Mode m) : sr{&p}, md{m} { }
+      const Scope_ref& path() const { return *sr; }
+      Mode mode() const { return md; }
+   private:
+      const Scope_ref* sr;
+      Mode md;
+   };
+
                                 // -- Using_directive --
    // A standard C++ using-directive or a using-enum-declaration 
    // (nominating additional scopes) for elaboration purposes.
@@ -2562,6 +2588,7 @@ namespace ipr {
       virtual void visit(const Directive&) = 0;
       virtual void visit(const Asm&);
       virtual void visit(const Static_assert&);
+      virtual void visit(const Using_declaration&);
       virtual void visit(const Using_directive&);
 
       virtual void visit(const Stmt&) = 0;

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -362,6 +362,10 @@ namespace ipr::impl {
          : cond{e}, txt{s}
       { }
 
+      single_using_declaration::single_using_declaration(const ipr::Scope_ref& s, Designator::Mode m)
+         : what{s, m}
+      { }
+
       Using_directive::Using_directive(const ipr::Scope& s) : scope{s} { }
 
       namespace {
@@ -552,6 +556,17 @@ namespace ipr::impl {
       impl::Static_assert* dir_factory::make_static_assert(const ipr::Expr& e, Optional<ipr::String> s)
       {
          return asserts.make(e, s);
+      }
+
+      impl::single_using_declaration*
+      dir_factory::make_using_declaration(const ipr::Scope_ref& s, ipr::Using_declaration::Designator::Mode m)
+      {
+         return singles.make(s, m);
+      }
+
+      impl::Using_declaration* dir_factory::make_using_declaration()
+      {
+         return usings.make();
       }
 
       impl::Using_directive* dir_factory::make_using_directive(const ipr::Scope& s, const ipr::Type& t)

--- a/src/traversal.cxx
+++ b/src/traversal.cxx
@@ -812,6 +812,11 @@ ipr::Visitor::visit(const Static_assert& d)
    visit(as<Directive>(d));
 }
 
+void ipr::Visitor::visit(const Using_declaration& d)
+{
+   visit(as<Directive>(d));
+}
+
 void
 ipr::Visitor::visit(const Using_directive& d)
 {


### PR DESCRIPTION
This patch adds support for ISO C++ _using-declaration_, modeled in the IPR as belonging to the category `ipr::Directive`.

A _using-declaration_ is an directive to a C++ compiler for perform lookup on certain _qualified-id_ s and introduce _synonymous_ declarations, subject to certain constraints.  The common case of a single _using-declarator_ in a _using-declaration_ has a dedicated, more efficient implementation than the generic case of _using-declarator-list_ of cardinality more than 1.