### PR TITLE
Add missing node for `alignof`

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -1286,6 +1286,7 @@ namespace ipr {
 		 // <<<< Yuriy Solodkyy: 2007/02/02
       };
 
+      using Alignof = Unary_expr<ipr::Alignof>;
       using Sizeof = Unary_expr<ipr::Sizeof>;
       using Args_cardinality = Unary_expr<ipr::Args_cardinality>;
       using Typeid = Unary_expr<ipr::Typeid>;
@@ -1993,6 +1994,7 @@ namespace ipr {
          Deref* make_deref(const ipr::Expr&, Optional<ipr::Type> = {});
          Dtor_name* make_dtor_name(const ipr::Type&);
          Expr_list* make_expr_list();
+         Alignof* make_alignof(const ipr::Expr&, Optional<ipr::Type> = { });
          Sizeof* make_sizeof(const ipr::Expr&, Optional<ipr::Type> = { });
          Args_cardinality* make_args_cardinality(const ipr::Expr&, Optional<ipr::Type> = { });
          Typeid* make_typeid(const ipr::Expr&, Optional<ipr::Type> = { });
@@ -2103,6 +2105,7 @@ namespace ipr {
          stable_farm<impl::This> these;
 
          util::rb_tree::container<impl::Symbol> symbols;
+         stable_farm<impl::Alignof> alignofs;
          stable_farm<impl::Sizeof> sizeofs;
          stable_farm<impl::Typeid> xtypeids;
          stable_farm<impl::Address> addresses;

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -145,6 +145,7 @@ namespace ipr {
                                  // promotion -- implicit conversion
    struct Deref;                 // dereference expression              *p
    struct Expr_list;             // comma-separated expression list  x, y, z
+   struct Alignof;               // alignment query                  alignof(T)
    struct Sizeof;                // sizeof expression: sizeof *p or sizeof(int)
    struct Typeid;                // typeid expression, like sizeof expression
    struct Id_expr;               // use of a name as an expression
@@ -1502,6 +1503,10 @@ namespace ipr {
       auto size() const { return elements().size(); }
    };
 
+                                // -- Alignof --
+   //  Alignment query of a type, or any expression.
+   struct Alignof : Unary<Category<Category_code::Alignof>> { };
+
                                 // -- Sizeof --
    // sizeof-expression -- "sizeof expr" or "sizeof (int)"
    struct Sizeof : Unary<Category<Category_code::Sizeof>> { };
@@ -2507,6 +2512,7 @@ namespace ipr {
       virtual void visit(const Demotion&);
       virtual void visit(const Deref&);
       virtual void visit(const Enclosure&);
+      virtual void visit(const Alignof&);
       virtual void visit(const Sizeof&);
       virtual void visit(const Args_cardinality&);
       virtual void visit(const Expr_stmt&);

--- a/include/ipr/node-category
+++ b/include/ipr/node-category
@@ -64,6 +64,7 @@ Delete,                             // ipr::Delete
 Demotion,                           // ipr::Demotion
 Deref,                              // ipr::Deref
 Expr_list,                          // ipr::Expr_list
+Alignof,                            // ipr::Alignof
 Sizeof,                             // ipr::Sizeof
 Typeid,                             // ipr::Typeid
 Id_expr,                            // ipr::Id_expr

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -1504,6 +1504,11 @@ namespace ipr::impl {
          return type_ids.insert(t, unary_compare());
       }
 
+      impl::Alignof* expr_factory::make_alignof(const ipr::Expr& e, Optional<ipr::Type> t)
+      {
+         return make(alignofs, e).with_type(t);
+      }
+
       impl::Sizeof*
       expr_factory::make_sizeof(const ipr::Expr& e, Optional<ipr::Type> t)
       {

--- a/src/traversal.cxx
+++ b/src/traversal.cxx
@@ -357,6 +357,11 @@ ipr::Visitor::visit(const Enclosure& e)
    visit(as<Expr>(e));
 }
 
+void ipr::Visitor::visit(const Alignof& e)
+{
+   visit(as<Expr>(e));
+}
+
 void
 ipr::Visitor::visit(const Sizeof& e)
 {


### PR DESCRIPTION
Long forgotten IPR node.  Reported by @GorNishanov .