### PR TITLE
Simplify `ipr::Overload`

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -788,10 +788,7 @@ namespace ipr {
          std::vector<scope_datum*> masters;
 
          explicit Overload(const ipr::Name&);
-
-         const ipr::Sequence<ipr::Decl>& operator[](const ipr::Type&) const final;
-         Index size() const final;
-         const ipr::Decl& get(Index) const final;
+         Optional<ipr::Decl> operator[](const ipr::Type&) const final;
          overload_entry* lookup(const ipr::Type&) const;
 
          template<class T>
@@ -812,9 +809,7 @@ namespace ipr {
          explicit singleton_overload(const ipr::Decl&);
 
          const ipr::Type& type() const final;
-         Index size() const final;
-         const ipr::Decl& get(Index) const final;
-         const ipr::Sequence<ipr::Decl>& operator[](const ipr::Type&) const final;
+         Optional<ipr::Decl> operator[](const ipr::Type&) const final;
       };
 
 
@@ -826,9 +821,7 @@ namespace ipr {
 
       struct empty_overload : impl::Node<ipr::Overload> {
          const ipr::Type& type() const final;
-         Index size() const final;
-         const ipr::Decl& get(Index) const final;
-         const ipr::Sequence<ipr::Decl>& operator[](const ipr::Type&) const final;
+         Optional<ipr::Decl> operator[](const ipr::Type&) const final;
       };
 
       struct node_compare {

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -1003,10 +1003,10 @@ namespace ipr {
                                 // -- Overload --
    // An overload-set is an expression whose value is the set of all
    // declarations for a name in a given scope.  An overload-set supports
-   // look-up by type.  The result of such lookup is the sequence of
-   // declarations of that name with that type.
-   struct Overload : Sequence<Decl>, Category<Category_code::Overload> {
-      virtual const Sequence<Decl>& operator[](const Type&) const = 0;
+   // look-up by type.  The result of such lookup is the canonical declaration
+   // of all declarations with that given type, in that scope.
+   struct Overload : Category<Category_code::Overload> {
+      virtual Optional<Decl> operator[](const Type&) const = 0;
    };
 
                                 // -- Scope --

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -262,19 +262,12 @@ namespace ipr::impl {
             : name(n)
       { }
 
-      Overload::Index Overload::size() const {
-         return entries.size();
-      }
-
-      const ipr::Decl&
-      Overload::get(Index i) const {
-         return *masters.at(i)->decl;
-      }
-
-      const ipr::Sequence<ipr::Decl>&
-      Overload::operator[](const ipr::Type& t) const {
-         overload_entry* master = lookup(t);
-         return util::check(master)->declset;
+      Optional<ipr::Decl>
+      Overload::operator[](const ipr::Type& t) const
+      {
+         if (auto entry = lookup(t))
+            return { &entry->declset.get(0) };                    // Note: first decl is canonical
+         return { };
       }
 
       impl::overload_entry*
@@ -302,23 +295,12 @@ namespace ipr::impl {
          return seq.datum.type();
       }
 
-      singleton_overload::Index
-      singleton_overload::size() const {
-         return 1;
-      }
-
-      const ipr::Decl&
-      singleton_overload::get(Index i) const {
-         if (i != 1)
-            throw std::domain_error("singleton_overload::get: out-of-range ");
-         return seq.datum;
-      }
-
-      const ipr::Sequence<ipr::Decl>&
-      singleton_overload::operator[](const ipr::Type& t) const {
+      Optional<ipr::Decl>
+      singleton_overload::operator[](const ipr::Type& t) const
+      {
          if (&t != &seq.datum.type())
-            throw std::domain_error("invalid type subscription");
-         return seq;
+            return { };
+         return { &seq.datum };
       }
 
       // --------------------------
@@ -330,18 +312,10 @@ namespace ipr::impl {
          throw std::domain_error("empty_overload::type");
       }
 
-      empty_overload::Index empty_overload::size() const {
-         return 0;
-      }
-
-      const ipr::Decl&
-      empty_overload::get(Index) const {
-         throw std::domain_error("impl::empty_overload::get");
-      }
-
-      const ipr::Sequence<ipr::Decl>&
-      empty_overload::operator[](const ipr::Type&) const {
-         throw std::domain_error("impl::empty_overload::operator[]");
+      Optional<ipr::Decl>
+      empty_overload::operator[](const ipr::Type&) const
+      {
+         return { };
       }
 
       // -----------------


### PR DESCRIPTION
An overload set is a collection of all declarations for a given in name in a given scope.  That collection does not necessarily have an inherent ordering.  Consequently, this patch removes the presentation as `Sequence<Decl>`.

Furthermore, indexing an overload set by `Type` gives the canonical `Decl`.