### PR TITLE
Remove `ipr::Decl::position`

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -11,7 +11,6 @@
 #include <memory>
 #include <list>
 #include <vector>
-#include <deque>
 #include <map>
 #include <forward_list>
 #include <variant>
@@ -128,9 +127,9 @@ namespace ipr {
       // In general, it can be used to implement the notion of sub-sequence.
 
       template<typename T>
-      struct ref_sequence : ipr::Sequence<T>, private std::deque<const void*> {
+      struct ref_sequence : ipr::Sequence<T>, private std::vector<const void*> {
          using Seq = Sequence<T>;
-         using Rep = std::deque<const void*>;
+         using Rep = std::vector<const void*>;
          using pointer = const T*;
          using Iterator = typename Seq::Iterator;
          using Index = typename Seq::Index;
@@ -145,8 +144,6 @@ namespace ipr {
          //using Rep::reserve;
          using Rep::resize;
          using Rep::push_back;
-         using Rep::push_front;
-
          const T& get(Index p) const final { return *pointer(this->at(p)); }
       };
 
@@ -636,34 +633,18 @@ namespace ipr {
 
       using util::rb_tree::link;
       struct scope_datum : link<scope_datum> {
-         // The position of this Decl in its scope.  It shall be set
-         // at the actual declaration creation by the creating scope.
-         Decl_position scope_pos = { };
-
          // The specifiers for this declaration.  S
          ipr::DeclSpecifiers spec = { };
 
          // Back-pointer to this declaration.  It shall be set at
          // the declaration creation.
          const ipr::Decl* decl = { };
-
-         // A comparator object type, implements ordering on declaration
-         // position chaining declarations together, in scopes.
-         struct comp;
       };
 
                                 // -- impl::decl_sequence --
       // The chain of declarations in a scope.
 
-      struct decl_sequence : ipr::Sequence<ipr::Decl> {
-         Index size() const final;
-         const ipr::Decl& get(Index) const final;
-         // Inserts a declaration in this sequence.
-         void insert(scope_datum*);
-
-      private:
-         util::rb_tree::chain<scope_datum> decls;
-      };
+      struct decl_sequence : ref_sequence<ipr::Decl> { };
 
                                 // -- impl::singleton_declset --
       // A singleton_declset is a specialization of decl_sequence
@@ -1268,10 +1249,6 @@ namespace ipr {
          const ipr::Sequence<ipr::Expr>& operand() const final;
 
          void push_back(const ipr::Expr* e) { seq.seq.push_back(e); }
-		 // >>>> Yuriy Solodkyy: 2007/02/02
-		 // Front insertable sequence is more suitable for bottom-up parsing
-		 void push_front(const ipr::Expr* e) { seq.seq.push_front(e); }
-		 // <<<< Yuriy Solodkyy: 2007/02/02
       };
 
       using Alignof = Unary_expr<ipr::Alignof>;

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -2270,8 +2270,6 @@ namespace ipr {
 
       virtual Optional<Expr> initializer() const = 0;
 
-      virtual Decl_position position() const = 0;
-
       // This is the first seen declaration for name() in a given
       // translation unit.  The master declaration is therefore the
       // first element of the declaration-set.
@@ -2305,6 +2303,7 @@ namespace ipr {
                                 // -- Enumerator --
    // This represents a classic enumerator.
    struct Enumerator : Category<Category_code::Enumerator, Decl> {
+      virtual Decl_position position() const = 0;
    };
 
                                 // - Alias --
@@ -2329,12 +2328,14 @@ namespace ipr {
       // is convenient to refer to it by the name of the corresponding
       // type -- in C++ tradition.
       const Name& name() const { return type().name(); }
+      virtual Decl_position position() const = 0;
    };
 
                                 // -- Parameter --
    // A parameter is uniquely characterized by its position in
    // a parameter list.
    struct Parameter : Category<Category_code::Parameter, Decl> {
+      virtual Decl_position position() const = 0;
       const Region& lexical_region() const final { return home_region(); }
       Optional<Expr> default_value() const { return initializer(); }
    };

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -189,23 +189,6 @@ namespace ipr::impl {
          return components;
       }
 
-      struct scope_datum::comp {
-         int operator()(const scope_datum& lhs, const scope_datum& rhs) const
-         {
-            return compare(lhs.scope_pos, rhs.scope_pos);
-         }
-
-         int operator()(Decl_position pos, const scope_datum& s) const
-         {
-            return compare(pos, s.scope_pos);
-         }
-
-         int operator()(const scope_datum& s, Decl_position pos) const
-         {
-            return compare(s.scope_pos, pos);
-         }
-      };
-
       // -- impl::Symbol --
       Symbol::Symbol(const ipr::Name& n)
          : Unary_expr<ipr::Symbol>{ n }
@@ -234,25 +217,6 @@ namespace ipr::impl {
               primary(0),home(0),
               overload(ovl)
       { }
-
-      // -------------------------
-      // -- impl::decl_sequence --
-      // -------------------------
-
-      decl_sequence::Index decl_sequence::size() const {
-         return decls.size();
-      }
-
-      const ipr::Decl&
-      decl_sequence::get(Index i) const {
-         scope_datum* result = decls.find(Decl_position{ i }, scope_datum::comp());
-         return *util::check(result)->decl;
-      }
-
-      void
-      decl_sequence::insert(scope_datum* s) {
-         decls.insert(s, scope_datum::comp());
-      }
 
       // --------------------
       // -- impl::Overload --
@@ -1089,9 +1053,9 @@ namespace ipr::impl {
 
       template<class T>
       inline void
-      Scope::add_member(T* decl) {
-         decl->decl_data.scope_pos = Decl_position{ decls.seq.size() };
-         decls.seq.insert(&decl->decl_data);
+      Scope::add_member(T* decl)
+      {
+         decls.seq.push_back(decl);
       }
 
       impl::Alias*


### PR DESCRIPTION
The operation `Decl::position()` was to enable indexing into a scope based on position.  That model breaks down when a scope is made of pieces coming from various places (e.g. import of modules) in contemporary C++.  It does not seem to have lived up to its promises.  Removed thusly.