### PR TITLE
Support pragma as language construct

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -249,6 +249,7 @@ namespace ipr {
 
                                 // -- impl::Token --
       struct Token : ipr::Lexeme, ipr::Token {
+         using Interface = ipr::Token;
          Token(const ipr::String&, const Source_location&, TokenValue, TokenCategory);
          const ipr::String& spelling() const final { return text; }
          const Source_location& locus() const final { return location; }
@@ -1769,6 +1770,11 @@ namespace ipr {
          const ipr::Scope& scope;
       };
 
+      struct Pragma : impl::Directive<ipr::Pragma, Phases::All> {
+         val_sequence<impl::Token> tokens;
+         const ipr::Sequence<ipr::Token>& operand() const final { return tokens; }
+      };
+
       // ----------------------------------
       // -- Implementation of statements --
       // ----------------------------------
@@ -2150,12 +2156,14 @@ namespace ipr {
                                                                 ipr::Using_declaration::Designator::Mode);
          impl::Using_declaration* make_using_declaration();
          impl::Using_directive* make_using_directive(const ipr::Scope&, const ipr::Type&);
+         impl::Pragma* make_pragma();
       private:
          stable_farm<impl::Asm> asms;
          stable_farm<impl::Static_assert> asserts;
          stable_farm<impl::single_using_declaration> singles;
          stable_farm<impl::Using_declaration> usings;
          stable_farm<impl::Using_directive> dirs;
+         stable_farm<impl::Pragma> pragmas;
       };
 
       // This factory class takes on the implementation burden of

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -260,6 +260,7 @@ namespace ipr {
    struct Static_assert;         // static-assert declaration
    struct Using_declaration;     // using-declaration
    struct Using_directive;       // using-directive
+   struct Pragma;                // language-level pragma directive
  
    // -------------------------------------------------
    // -- result of declaration constructor constants --
@@ -310,7 +311,8 @@ namespace ipr {
       Loading              = 0x0400,   // Program loading phase
       Execution            = 0x0800,   // Runtime execution
 
-      Elaboration          = Name_resolution | Typing | Evaluation | Instantiation
+      Elaboration          = Name_resolution | Typing | Evaluation | Instantiation,
+      All                  = ~0x0,
    };
 
 
@@ -2035,6 +2037,12 @@ namespace ipr {
       virtual const Scope& nominated_scope() const = 0;
    };
 
+
+                                // -- Pragma --
+   struct Pragma : Unary<Category<Category_code::Pragma, Directive>, const Sequence<Token>&> {
+      const Sequence<Token>& incantation() const { return operand(); }
+   };
+
                                 // -- Stmt --
    // The view that a statement is kind of expression does not follow from
    // Standard C++ specification.  It is a design choice we made based on
@@ -2597,6 +2605,7 @@ namespace ipr {
       virtual void visit(const Static_assert&);
       virtual void visit(const Using_declaration&);
       virtual void visit(const Using_directive&);
+      virtual void visit(const Pragma&);
 
       virtual void visit(const Stmt&) = 0;
       virtual void visit(const Labeled_stmt&);

--- a/include/ipr/node-category
+++ b/include/ipr/node-category
@@ -149,6 +149,7 @@ Deduction_guide,                    // ipr::Deduction_guide
 Static_assert,                      // ipr::Static_assert
 Using_declaration,                  // ipr::Using_declaration
 Using_directive,                    // ipr::Using_directive
+Pragma,                             // ipr::Pragma
 
 Block,                              // ipr::Block
 Break,                              // ipr::Break

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -497,6 +497,11 @@ namespace ipr::impl {
          return make(dirs, s).with_type(t);
       }
 
+      impl::Pragma* dir_factory::make_pragma()
+      {
+         return pragmas.make();
+      }
+
       // ------------------------
       // -- impl::stmt_factory --
       // ------------------------

--- a/src/traversal.cxx
+++ b/src/traversal.cxx
@@ -828,6 +828,11 @@ ipr::Visitor::visit(const Using_directive& d)
    visit(as<Directive>(d));
 }
 
+void ipr::Visitor::visit(const Pragma& d)
+{
+   visit(as<Directive>(d));
+}
+
 // -- Statements visiting hooks --
 
 void


### PR DESCRIPTION
This patch represents `#`pragma` as a language construct, a directive.  This abstraction is to support pragma effects that persist beyond preprocessing stage.