### PR TITLE
Region has a body

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -1036,7 +1036,7 @@ namespace ipr {
       template<class Member>
       struct homogeneous_scope : impl::Node<ipr::Scope>,
                                  ipr::Sequence<ipr::Decl>,
-                                 std::allocator<void> {
+                                 ipr::Sequence<ipr::Expr> {
          using Index = typename ipr::Sequence<ipr::Decl>::Index;
          typed_sequence<val_sequence<Member>> decls;
 
@@ -1082,6 +1082,7 @@ namespace ipr {
          homogeneous_scope<Member> scope;
 
          const ipr::Region& enclosing() const final { return parent; }
+         const ipr::Sequence<ipr::Expr>& body() const final { return scope; }
          const ipr::Scope& bindings() const final { return scope; }
          const location_span& span() const final { return extent; }
          const ipr::Expr& owner() const final { return owned_by.get(); }
@@ -1513,8 +1514,10 @@ namespace ipr {
          location_span extent;
          util::ref<const ipr::Expr> owned_by;
          impl::Scope scope;
+         impl::ref_sequence<ipr::Expr> expr_seq;         // all the expressions making up the body.
 
          const ipr::Region& enclosing() const final { return parent.get(); }
+         const ipr::Sequence<ipr::Expr>& body() const final { return expr_seq; }
          const ipr::Scope& bindings() const final { return scope; }
          const location_span& span() const final { return extent; }
          const ipr::Expr& owner() const final { return owned_by.get(); }
@@ -1796,21 +1799,19 @@ namespace ipr {
       // block.  It also holds a sequence of handlers, when the
       // block actually represents a C++ try-block.
       struct Block : impl::Stmt<Expr<ipr::Block>> {
-         impl::Region region;
-         impl::ref_sequence<ipr::Expr> stmt_seq;
+         impl::Region lexical_region;
          impl::ref_sequence<ipr::Handler> handler_seq;
 
          explicit Block(const ipr::Region&);
-         const ipr::Scope& elements() const final { return region.scope; }
-         const ipr::Sequence<ipr::Expr>& body() const final { return stmt_seq; }
+         const ipr::Region& region() const final { return lexical_region; }
          const ipr::Sequence<ipr::Handler>& handlers() const final { return handler_seq; }
 
          // The scope of declarations in this block
-         impl::Scope* scope() { return &region.scope; }
+         impl::Scope* scope() { return &lexical_region.scope; }
 
          void add_stmt(const ipr::Expr& s)
          {
-            stmt_seq.push_back(&s);
+            lexical_region.expr_seq.push_back(&s);
          }
 
          void add_handler(const ipr::Handler& h)

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -822,19 +822,22 @@ namespace ipr {
    };
 
                                 // -- Region --
-   // A Region node represents a region of program text.  It is mostly
-   // useful for capturing the notion of scope (in Standard C++ sense).
+   // A Region node represents a region of program text processed into a sequence
+   // of expressions or directives.  It is mostly useful for capturing the notion 
+   // declarative region, and of scope (in Standard C++ sense).
    // In IPR, we're using a generalized notion of Scope (a sequence of
    // declarations).  The  notion of Region helps make precise when
    // some implicit actions like cleanup-ups happen, or nesting of scopes.
-   // The sequence of declarations appearing in a Region makes up the
-   // Scope of that region.
+   // The sequence of (generalized) expressions appearing in a Region makes up the
+   // (compile-time) body of that region.  Evaluating that body usually produces the
+   // bindings of that Region.
    struct Region : Category<Category_code::Region, Node> {
       using Location_span = std::pair<Unit_location, Unit_location>;
       virtual const Location_span& span() const = 0;
       virtual const Region& enclosing() const = 0;
-      virtual const Scope& bindings() const = 0;
       virtual const Expr& owner() const = 0;
+      virtual const Sequence<Expr>& body() const = 0;
+      virtual const Scope& bindings() const = 0;
       virtual bool global() const = 0;                   // is this region the global region?
    };
 
@@ -2128,8 +2131,8 @@ namespace ipr {
                                 // -- Block --
    // A Block is any sequence of general expressions bracketed by curly braces.
    struct Block : Category<Category_code::Block, Stmt> {
-      virtual const Scope& elements() const = 0;
-      virtual const Sequence<Expr>& body() const = 0;
+      virtual const Region& region() const = 0;
+      const Sequence<Expr>& body() const { return region().body(); }
       virtual const Sequence<Handler>& handlers() const = 0;
    };
 

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -440,9 +440,9 @@ namespace ipr::impl {
       // -----------------
 
       Block::Block(const ipr::Region& pr)
-            : region(&pr)
+            : lexical_region(&pr)
       {
-         region.owned_by = this;
+         lexical_region.owned_by = this;
       }
 
       // ---------------


### PR DESCRIPTION
This patch adds the `body()` operation to a `ipr::Region`: it returns the sequence of generalized expressions (classic expressions, statements, directives, declarations, etc.) that makes up a lexical region.

As a consequence, a function and user-defined types all have bodies: the sequence of expressions lexically written in their defining initializers.