### PR TITLE
Structured_binding as directive

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -360,12 +360,12 @@ namespace ipr {
       // -- implementation for ipr::Capture
       struct Capture : ipr::Capture {
          using Interface = ipr::Capture;
-         Capture(const ipr::Decl& d, ipr::Capture_mode m) : decl{d}, md{m} { }
-         ipr::Capture_mode mode() const final { return md; }
+         Capture(const ipr::Decl& d, ipr::Binding_mode m) : decl{d}, md{m} { }
+         ipr::Binding_mode mode() const final { return md; }
          const ipr::Decl& entity() const final { return decl; }
       private:
          const ipr::Decl& decl;
-         const ipr::Capture_mode md;
+         const ipr::Binding_mode md;
       };
 
       // -- Generic implementation of ipr::Capture_specification
@@ -376,41 +376,41 @@ namespace ipr {
 
       // -- implementation of ipr::Capture_specification::Default
       struct Default_capture_specification : Capture_specification<ipr::Capture_specification::Default> {
-         explicit Default_capture_specification(Capture_mode m) : md{m} { }
-         Capture_mode mode() const final { return md; }
+         explicit Default_capture_specification(Binding_mode m) : md{m} { }
+         Binding_mode mode() const final { return md; }
       private:
-         const Capture_mode md;
+         const Binding_mode md;
       };
 
       // -- implementation of ipr::Capture_specification::Implicit_object
       struct Implicit_object_capture_specification : Capture_specification<ipr::Capture_specification::Implicit_object> {
-         explicit Implicit_object_capture_specification(Capture_mode m) : md{m} { }
-         Capture_mode how() const final { return md; }
+         explicit Implicit_object_capture_specification(Binding_mode m) : md{m} { }
+         Binding_mode how() const final { return md; }
       private:
-         const Capture_mode md;
+         const Binding_mode md;
       };
 
       // -- implementation of ipr::Capture_specification::Enclosing_local
       struct Enclosing_local_capture_specification : Capture_specification<ipr::Capture_specification::Enclosing_local> {
-         Enclosing_local_capture_specification(const ipr::Decl& x, Capture_mode m) : decl{x}, md{m} { }
-         Capture_mode mode() const final { return md; }
+         Enclosing_local_capture_specification(const ipr::Decl& x, Binding_mode m) : decl{x}, md{m} { }
+         Binding_mode mode() const final { return md; }
          const ipr::Identifier& name() const final;
          const ipr::Decl& declaration() const final { return decl; }
       private:
          const ipr::Decl& decl;
-         const Capture_mode md;
+         const Binding_mode md;
       };
 
       // -- implementation of ipr::Capture_capture::Binding
       struct Binding_capture_specification : Capture_specification<ipr::Capture_specification::Binding> {
-         Binding_capture_specification(const ipr::Identifier& n, const ipr::Expr& x, Capture_mode m) : id{n}, init{x}, md{m} { }
-         Capture_mode mode() const final { return md; }
+         Binding_capture_specification(const ipr::Identifier& n, const ipr::Expr& x, Binding_mode m) : id{n}, init{x}, md{m} { }
+         Binding_mode mode() const final { return md; }
          const ipr::Identifier& name() const { return id; }
          const ipr::Expr& initializer() const { return init; }
       private:
          const ipr::Identifier& id;
          const ipr::Expr& init;
-         const Capture_mode md;
+         const Binding_mode md;
       };
 
       // -- implementation of ipr::Capture_specification::Expansion.
@@ -423,10 +423,10 @@ namespace ipr {
 
       // -- capture specification factory
       struct capture_spec_factory {
-         const ipr::Capture_specification::Default& default_capture(ipr::Capture_mode);
-         const ipr::Capture_specification::Implicit_object& implicit_object_capture(ipr::Capture_mode);
-         const ipr::Capture_specification::Enclosing_local& enclosing_local_capture(const ipr::Decl&, ipr::Capture_mode);
-         const ipr::Capture_specification::Binding& binding_capture(const ipr::Identifier&, const ipr::Expr&, ipr::Capture_mode);
+         const ipr::Capture_specification::Default& default_capture(Binding_mode);
+         const ipr::Capture_specification::Implicit_object& implicit_object_capture(Binding_mode);
+         const ipr::Capture_specification::Enclosing_local& enclosing_local_capture(const ipr::Decl&, Binding_mode);
+         const ipr::Capture_specification::Binding& binding_capture(const ipr::Identifier&, const ipr::Expr&, Binding_mode);
          const ipr::Capture_specification::Expansion& expansion_capture(const ipr::Capture_specification::Named&);
       private:
          stable_farm<impl::Default_capture_specification> defaults;
@@ -1752,6 +1752,22 @@ namespace ipr {
          Optional<ipr::String> txt;
       };
 
+      struct Structured_binding : impl::Directive<ipr::Structured_binding, Phases::Elaboration> {
+         impl::ref_sequence<ipr::Identifier> ids;           // names in this structured binding
+         util::ref<const ipr::Expr> init;                   // initializer of this structured binding
+         impl::ref_sequence<ipr::Decl> decl_seq;            // declarations resulting from this structured binding
+         ipr::DeclSpecifiers specs;                         // the non-type part of decl-specifier-seq in 
+                                                            // this structured binding.  Note: `type()` contains the
+                                                            // the type part of the decl-specifier-seq
+         ipr::Binding_mode binding_mode;                    // the binding mode of this structured binding
+
+         ipr::DeclSpecifiers specifiers() const final { return specs; }
+         ipr::Binding_mode mode() const final { return binding_mode; }
+         const ipr::Sequence<ipr::Identifier>& names() const final { return ids; }
+         const ipr::Expr& initializer() const final { return init.get(); }
+         const ipr::Sequence<ipr::Decl>& bindings() const final { return decl_seq; }
+      };
+
       // Implementation of ipr::Using_declaration in case where using-declarator-list is a singleton.
       struct single_using_declaration : impl::Directive<ipr::Using_declaration, Phases::Elaboration> {
          single_using_declaration(const ipr::Scope_ref&, Designator::Mode);
@@ -2153,6 +2169,7 @@ namespace ipr {
       struct dir_factory {
          impl::Asm* make_asm(const ipr::String&, const ipr::Type&);
          impl::Static_assert* make_static_assert(const ipr::Expr&, Optional<ipr::String> = { });
+         impl::Structured_binding* make_structured_binding();
          impl::single_using_declaration* make_using_declaration(const ipr::Scope_ref&,
                                                                 ipr::Using_declaration::Designator::Mode);
          impl::Using_declaration* make_using_declaration();
@@ -2161,6 +2178,7 @@ namespace ipr {
       private:
          stable_farm<impl::Asm> asms;
          stable_farm<impl::Static_assert> asserts;
+         stable_farm<impl::Structured_binding> bindings;
          stable_farm<impl::single_using_declaration> singles;
          stable_farm<impl::Using_declaration> usings;
          stable_farm<impl::Using_directive> dirs;

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -258,6 +258,7 @@ namespace ipr {
    struct Asm;                   // asm-declaration
    struct Deduction_guide;       // deduction-guide declaration
    struct Static_assert;         // static-assert declaration
+   struct Structured_binding;    // structured-binding declaration
    struct Using_declaration;     // using-declaration
    struct Using_directive;       // using-directive
    struct Pragma;                // language-level pragma directive
@@ -499,6 +500,16 @@ namespace ipr {
 
    // Position of a declaration in its declarative region
    enum class Decl_position : std::size_t { };
+
+
+                                // -- Binding_move --
+   // Mode of binding of a object value to a name (parameter, variable, alias, etc).
+   enum class Binding_mode : std::uint8_t {
+      Copy,                         // by copy operation; default binding mode of C and C++
+      Reference,                    // by ref; the parameter or varable has an lvalue reference type
+      Move,                         // by move operation; transfer of ownership
+      Default = Copy,
+   };
 
                                 // -- Optional<> --
    // Occasionally, a node has an optional property (e.g. a variable
@@ -743,12 +754,6 @@ namespace ipr {
       Mutable    = 1 << 0,
       Constexpr  = 1 << 1,
       Consteval  = 1 << 2,
-   };
-
-   // The available modes of lambda captures
-   enum class Capture_mode {
-      Value,                                    // Default capture by value ("=" squiggle)
-      Reference,                                // Default capture by reference ("&" squiggle)
    };
 
                                 // -- Module_name --
@@ -1326,14 +1331,14 @@ namespace ipr {
 
 
    // A capture is a description of how a local entity is referenced in a lambda expression.
-   // It is essentially a pair (Capture_mode, Decl) where the first component tells how the 
+   // It is essentially a pair (Binding_mode, Decl) where the first component tells how the 
    // entity is referenced (by value or by reference), and a declaration that specifies the 
    // declarative semantic properties of the captured entity.
    // Note: A Capture should not be confused with a Capture_specification: the specification
    //       is a prescription of how an entity should be captured (either explicitly or implicitly) 
    //       in a lambda, whereas a capture is a result of executing that prescription.
    struct Capture {
-      virtual Capture_mode mode() const = 0;
+      virtual Binding_mode mode() const = 0;
       virtual const Decl& entity() const = 0;
    };
 
@@ -1404,24 +1409,25 @@ namespace ipr {
 
    // Default lambda capture specification
    struct Capture_specification::Default : Capture_specification {
-      virtual Capture_mode mode() const = 0;
+      virtual Binding_mode mode() const = 0;
    };
 
    // Lambda capture specification of the implicit object in a non-static member context.
    // The designation of the capture is defined by how(), where:
-   //   - Capture_mode::Reference means 'this'
-   //   - Capture_mode::Value means '*this'
+   //   - Binding_mode::Reference means 'this'
+   //   - Binding_mode::Copy means '*this'
+   //   - anything else is invalid at this point.
    // Note: an alternative design is to introduced a distinct enum for representing the
    //       designation of the implicit object (say 'This' and 'Self), but that would
    //       have just obscured the fundamental semantics correspondence.
    struct Capture_specification::Implicit_object : Capture_specification {
-      virtual Capture_mode how() const = 0;
+      virtual Binding_mode how() const = 0;
    };
 
    // Base of lambda captures designated by an given name.
    struct Capture_specification::Named : Capture_specification {
       virtual const Identifier& name() const = 0;
-      virtual Capture_mode mode() const = 0;
+      virtual Binding_mode mode() const = 0;
    };
 
    // Lambda capture referencing a local entity from the enclosing context.
@@ -2005,6 +2011,17 @@ namespace ipr {
       virtual Optional<String> message() const = 0;
    };
 
+                                // -- Structured_binding --
+   // A structured binding is a directive to the compiler to introduce a set of names
+   // (either an Alias or a Var) in the current binding environment by taking apart
+   // the object value designated by the initializer.
+   struct Structured_binding : Category<Category_code::Structured_binding, Directive> {
+      virtual DeclSpecifiers specifiers() const = 0;
+      virtual Binding_mode mode() const = 0;
+      virtual const Sequence<Identifier>& names() const = 0;
+      virtual const Expr& initializer() const = 0;
+      virtual const Sequence<Decl>& bindings() const = 0;
+   };
 
                                 // -- Using_declaration --
    // A using-declaration is directive that instructs the C++ translator to look up
@@ -2319,7 +2336,7 @@ namespace ipr {
 
                                 // - Alias --
    // This represent a alias declaration (e.g. typedef, namespace-alias,
-   // template alias, ...).
+   // template alias, a binding in a structured binding, etc).
    // An alias is always initialized -- with what it is an alias for.
    // The type of an Alias expression is that of its initializer.
    struct Alias : Category<Category_code::Alias, Decl> {
@@ -2606,6 +2623,7 @@ namespace ipr {
       virtual void visit(const Directive&) = 0;
       virtual void visit(const Asm&);
       virtual void visit(const Static_assert&);
+      virtual void visit(const Structured_binding&);
       virtual void visit(const Using_declaration&);
       virtual void visit(const Using_directive&);
       virtual void visit(const Pragma&);

--- a/include/ipr/node-category
+++ b/include/ipr/node-category
@@ -147,6 +147,7 @@ Scope,                              // ipr::Scope
 Asm,                                // ipr::Asm
 Deduction_guide,                    // ipr::Deduction_guide
 Static_assert,                      // ipr::Static_assert
+Structured_binding,                 // ipr::Structured_binding
 Using_declaration,                  // ipr::Using_declaration
 Using_directive,                    // ipr::Using_directive
 Pragma,                             // ipr::Pragma

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -156,25 +156,25 @@ namespace ipr::impl {
 
       // -- impl::capture_spec_factory --
       const ipr::Capture_specification::Default&
-      capture_spec_factory::default_capture(ipr::Capture_mode m)
+      capture_spec_factory::default_capture(Binding_mode m)
       {
          return *defaults.make(m);
       }
 
       const ipr::Capture_specification::Implicit_object&
-      capture_spec_factory::implicit_object_capture(ipr::Capture_mode m)
+      capture_spec_factory::implicit_object_capture(Binding_mode m)
       {
          return *implicits.make(m);
       }
 
       const ipr::Capture_specification::Enclosing_local&
-      capture_spec_factory::enclosing_local_capture(const ipr::Decl& d, ipr::Capture_mode m)
+      capture_spec_factory::enclosing_local_capture(const ipr::Decl& d, Binding_mode m)
       {
          return *enclosings.make(d, m);
       }
 
       const ipr::Capture_specification::Binding&
-      capture_spec_factory::binding_capture(const ipr::Identifier& n, const ipr::Expr& x, ipr::Capture_mode m)
+      capture_spec_factory::binding_capture(const ipr::Identifier& n, const ipr::Expr& x, Binding_mode m)
       {
          return *bindings.make(n, x, m);
       }
@@ -479,6 +479,12 @@ namespace ipr::impl {
       impl::Static_assert* dir_factory::make_static_assert(const ipr::Expr& e, Optional<ipr::String> s)
       {
          return asserts.make(e, s);
+      }
+
+      impl::Structured_binding*
+      dir_factory::make_structured_binding()
+      {
+         return bindings.make();
       }
 
       impl::single_using_declaration*

--- a/src/traversal.cxx
+++ b/src/traversal.cxx
@@ -817,6 +817,11 @@ ipr::Visitor::visit(const Static_assert& d)
    visit(as<Directive>(d));
 }
 
+void ipr::Visitor::visit(const Structured_binding& d)
+{
+   visit(as<Directive>(d));
+}
+
 void ipr::Visitor::visit(const Using_declaration& d)
 {
    visit(as<Directive>(d));


### PR DESCRIPTION
A _structured binding_ is a directive to to decompose an object (designated by an _initializer_) into a collection of declarations (`Alias` or `Var`), following a given binding mode.

Fixes #9 .