### PR TITLE
Multiple declarators in single declaration as a directive

### DIFF
--- a/include/ipr/ancillary
+++ b/include/ipr/ancillary
@@ -1,0 +1,235 @@
+// -*- C++ -*-
+//
+// This file is part of The Pivot framework.
+// Written by Gabriel Dos Reis.
+// See LICENSE for copyright and license notices.
+//
+
+#ifndef IPR_ANCILLARY_INCLUDED
+#define IPR_ANCILLARY_INCLUDED
+
+#include <cstdint>
+#include <ipr/utility>
+
+namespace ipr {
+   // ---------------------------
+   // -- Phases of translation --
+   // ---------------------------
+   // A bitmask type for the various phases of C++ program translation.
+   enum class Phases {
+      Unknown              = 0x0000,   // Unknown translation phase
+      Reading              = 0x0001,   // Opening and reading an input source
+      Lexing               = 0x0002,   // Lexical decomposition of input source
+      Preprocessing        = 0x0004,   // Macro expansion and friends
+      Parsing              = 0x0008,   // Grammatical decomposition of the input source
+      Name_resolution      = 0x0010,   // Name lookup
+      Typing               = 0x0020,   // Type assignment of expressions
+      Evaluation           = 0x0040,   // Compile-time evaluation
+      Instantiation        = 0x0080,   // Template instantiation phase
+      Code_generation      = 0x0100,   // Code generation phase
+      Linking              = 0x0200,   // Linking phase
+      Loading              = 0x0400,   // Program loading phase
+      Execution            = 0x0800,   // Runtime execution
+
+      Elaboration          = Name_resolution | Typing | Evaluation | Instantiation,
+      All                  = ~0x0,
+   };
+
+                                // -- Type_qualifier --
+   // cv-qualifiers are actually type operators.  Much of these operators
+   // currently make sense only for classic type -- although it might
+   // be interesting to explore the notion of pointer to overload-set
+   // or reference to such an expression.
+   enum class Type_qualifiers : std::uint8_t {
+      None             = 0,
+      Const            = 1 << 0,
+      Volatile         = 1 << 1,
+      Restrict         = 1 << 2        // not standard C++
+   };
+
+   constexpr Type_qualifiers operator|(Type_qualifiers a, Type_qualifiers b)
+   {
+      return Type_qualifiers(uint8_t(a) | uint8_t(b));
+   }
+
+   constexpr Type_qualifiers& operator|=(Type_qualifiers& a, Type_qualifiers b)
+   {
+      return a = a | b;
+   }
+
+   constexpr Type_qualifiers operator&(Type_qualifiers a, Type_qualifiers b)
+   {
+      return Type_qualifiers(uint8_t(a) & uint8_t(b));
+   }
+
+   constexpr Type_qualifiers& operator&=(Type_qualifiers& a, Type_qualifiers b)
+   {
+      return a = a & b;
+   }
+
+   constexpr Type_qualifiers operator^(Type_qualifiers a, Type_qualifiers b)
+   {
+      return Type_qualifiers(uint8_t(a) ^ uint8_t(b));
+   }
+
+   constexpr Type_qualifiers& operator^=(Type_qualifiers& a, Type_qualifiers b)
+   {
+      return a = a ^ b;
+   }
+
+   constexpr bool implies(Type_qualifiers a, Type_qualifiers b)
+   {
+      return (a & b) == b;
+   }
+
+                                // -- Binding_mode --
+   // Mode of binding of a object value to a name (parameter, variable, alias, etc).
+   enum class Binding_mode : std::uint8_t {
+      Copy,                         // by copy operation; default binding mode of C and C++
+      Reference,                    // by ref; the parameter or varable has an lvalue reference type
+      Move,                         // by move operation; transfer of ownership
+      Default = Copy,
+   };
+
+                                 // -- Delimiter --
+   // Enclosure delimiters of expressions
+   enum class Delimiter {
+      Nothing,                   // no delimiter
+      Paren,                     // "()"
+      Brace,                     // "{}"
+      Bracket,                   // "[]"
+      Angle,                     // "<>"
+   };
+
+                                // -- Sequence<> --
+   // Often, we use a notion of sequence to represent intermediate
+   // abstractions like base-classes, enumerators, catch-clauses,
+   // parameter-type-list, etc.  A "Sequence" is a collection abstractly
+   // described by its "begin()" and "end()" iterators.  It is made
+   // abstract because it may admit different implementations depending
+   // on concrete constraints.  For example, a scope (a sequence of
+   // declarations, that additionally supports look-up by name) may
+   // implement this interface either as a associative-array that maps
+   // Names to Declarations (with no particular order) or as
+   // vector<Declaration*> (in order of their appearance in programs), or
+   // as a much more elaborated data structure.
+   template<class T>
+   struct Sequence  {
+      struct Iterator;          // An iterator is a pair of (sequence,
+                                // position).  The position indicates
+                                // the particular value referenced in
+                                // the sequence.
+
+      // Provide STL-style interface, for use with some STL algorithm
+      // helper classes.  Sequence<> is an immutable sequence.
+      using value_type = T;
+      using reference = const T&;
+      using pointer = const T*;
+      using Index = std::size_t;
+      using iterator = Iterator;
+
+      virtual Index size() const = 0;
+      bool empty() const { return not (size() > 0); }
+      Iterator begin() const;
+      Iterator end() const;
+      Iterator position(Index) const;
+
+   protected:
+      virtual const T& get(Index) const = 0;
+   };
+
+                                // -- Sequence<>::Iterator --
+   // This iterator class is as abstract as it could be, for useful
+   // purposes.  It forwards most operations to the "Sequence" class
+   // it provides a view for.
+   template<class T>
+   struct Sequence<T>::Iterator {
+      using self_type = Sequence<T>::Iterator;
+      using value_type = const T;
+      using reference = const T&;
+      using pointer = const T*;
+      using difference_type = ptrdiff_t;
+      using Index = typename Sequence<T>::Index;
+      using iterator_category = std::bidirectional_iterator_tag;
+
+      Iterator() {}
+      Iterator(const Sequence* s, Index i) : seq{ s }, index{ i } { }
+
+      const T& operator*() const
+      { return seq->get(index); }
+
+      const T* operator->() const
+      { return &seq->get(index); }
+
+      Iterator& operator++()
+      {
+         ++index;
+         return *this;
+      }
+
+      Iterator& operator--()
+      {
+        --index;
+        return *this;
+      }
+
+      Iterator operator++(int)
+      {
+         Iterator tmp = *this;
+         ++index;
+         return tmp;
+      }
+
+      Iterator operator--(int)
+      {
+        Iterator tmp = *this;
+        --index;
+        return tmp;
+      }
+
+      bool operator==(Iterator other) const
+      { return seq == other.seq and index == other.index; }
+
+      bool operator!=(Iterator other) const
+      { return not(*this == other); }
+
+   private:
+      const Sequence* seq { };
+      Index index { };
+   };
+
+   template<class T>
+   inline typename Sequence<T>::Iterator
+   Sequence<T>::position(Index i) const
+   { return { this, i }; }
+
+   template<class T>
+   inline typename Sequence<T>::Iterator
+   Sequence<T>::begin() const
+   { return { this, 0 }; }
+
+   template<class T>
+   inline typename Sequence<T>::Iterator
+   Sequence<T>::end() const
+   { return { this, size() }; }
+
+                                // -- Optional<> --
+   // Occasionally, a node has an optional property (e.g. a variable
+   // has an optional initializer).  This class template captures
+   // that commonality and provides a checked access.
+   template<typename T>
+   struct Optional {
+      Optional(const T* p = nullptr) : ptr { p } { }
+      const T& get() const { return *util::check(ptr); }
+      bool is_valid() const { return ptr != nullptr; }
+      explicit operator bool() const { return is_valid(); }
+      template<typename U, bool = std::is_base_of_v<T, U>>
+      operator Optional<U>() const { return { ptr }; }
+   private:
+      const T* ptr;
+   };
+
+}
+
+
+#endif // IPR_ANCILLARY_INCLUDED

--- a/include/ipr/attribute
+++ b/include/ipr/attribute
@@ -1,0 +1,101 @@
+// -*- C++ -*-
+//
+// This file is part of The Pivot framework.
+// Written by Gabriel Dos Reis.
+// See LICENSE for copyright and license notices.
+//
+
+#ifndef IPR_ATTRIBUTE_INCLUDED
+#define IPR_ATTRIBUTE_INCLUDED
+
+#include <cstdint>
+#include <ipr/synopsis>
+#include <ipr/location>
+
+namespace ipr {
+   // -----------------------------------
+   // -- Basic syntactic units: Tokens --
+   // -----------------------------------
+   // The IPR focuses primarily on semantic aspects of C++ constructs.
+   // Certain constructs, such as uninstantiated template definitions,
+   // are primarily syntactic with minimal semantic processing.  IPR nodes
+   // can fully represent those structurally well-defined syntactic entities.
+   // However, C++11 added attributes which are essentially token soups.  These
+   // attributes make the IPR interface less abstract than wanted.
+
+   // General classification of tokens, e.g. identifier, number, space, comment, etc.
+   enum class TokenCategory : std::uint8_t { };
+
+   // A numerical value associated with each token.
+   enum class TokenValue : std::uint16_t { };
+
+   struct Lexeme {
+      virtual const String& spelling() const = 0;
+      virtual const Source_location& locus() const = 0;
+   };
+
+   struct Token {
+      virtual const Lexeme& lexeme() const = 0;
+      virtual TokenValue value() const = 0;
+      virtual TokenCategory category() const = 0;
+   };
+
+   struct Attribute {
+      struct Visitor;
+      virtual void accept(Visitor&) const = 0;
+   };
+
+   // A simple token used as attribute.
+   struct BasicAttribute : Attribute {
+      virtual const Token& token() const = 0;
+   };
+
+   // An attribute of the form `token1 :: token2'
+   struct ScopedAttribute : Attribute {
+      virtual const Token& scope() const = 0;
+      virtual const Token& member() const = 0;
+   };
+
+   // An attribute of the form `token : attribute'.
+   struct LabeledAttribute : Attribute {
+      virtual const Token& label() const = 0;
+      virtual const Attribute& attribute() const = 0;
+   };
+
+   // An attribute of the form `f(args)'.
+   struct CalledAttribute : Attribute {
+      virtual const Attribute& function() const = 0;
+      virtual const Sequence<Attribute>& arguments() const = 0;
+   };
+
+   // An attribute of the form `attribute...'
+   struct ExpandedAttribute : Attribute {
+      virtual const Token& expander() const = 0;
+      virtual const Attribute& operand() const = 0;
+   };
+
+   // An attribute of the form `[[using check: memory(3), type(2)]]'
+   struct FactoredAttribute : Attribute {
+      virtual const Token& factor() const = 0;
+      virtual const Sequence<Attribute>& terms() const = 0;
+   };
+
+   // An attribute of the form `[[ expr ]]', where `expr' is the elaboration result
+   // of parsing and semantics analysis of the enclosed token sequence.  This is a 
+   // common non-standard form of attribute.
+   struct ElaboratedAttribute : Attribute {
+      virtual const Expr& elaboration() const = 0;
+   };
+
+   struct Attribute::Visitor {
+      virtual void visit(const BasicAttribute&) = 0;
+      virtual void visit(const ScopedAttribute&) = 0;
+      virtual void visit(const LabeledAttribute&) = 0;
+      virtual void visit(const CalledAttribute&) = 0;
+      virtual void visit(const ExpandedAttribute&) = 0;
+      virtual void visit(const FactoredAttribute&) = 0;
+      virtual void visit(const ElaboratedAttribute&) = 0;
+   };
+}
+
+#endif // IPR_ATTRIBUTE_INCLUDED

--- a/include/ipr/cxx-form
+++ b/include/ipr/cxx-form
@@ -1,0 +1,189 @@
+// -*- C++ -*-
+//
+// This file is part of The Pivot framework.
+// Written by Gabriel Dos Reis.
+// See LICENSE for copyright and license notices.
+//
+
+#ifndef IPR_FORM_INCLUDED
+#define IPR_FORM_INCLUDED
+
+#include <ipr/synopsis>
+#include <ipr/ancillary>
+
+// -- The IPR focuses primarily on capturing the semantics of C++, not mimic - with 
+// -- high fidelity - the ISO C++ source-level syntax minutiae, grammars, and other obscurities.
+// -- The IPR model of declaration reflects that semantics-oriented view.  Occasionally, it 
+// -- is necessary to bridge the gap between the generalized semantics model and the
+// -- irregularities and other grammatical hacks via IPR directives.  Some of those
+// -- directives need to refer to some form of input source level constructs, especially in 
+// -- cases of templated declarations involving non-ground types.
+// -- This file defines interfaces for some syntactic forms, i.e. abstractions of syntactic
+// -- input, to aid complete embedding of the ISO C++ specification.
+// -- Note: There is no effort in this file to reify the parse trees of the ISO C++ grammar.
+
+namespace ipr::cxx_form {
+    // -- Abstraction of ISO C++ Declarators:
+    // -- The C and C++ languages have tortuous grammars for declarations, whereby
+    // -- declarations are structured to mimic use (operator precedence).  A declaration
+    // -- is made of two essential pieces (decl-specifiers-seq and declarator), with an
+    // -- an optional component representing the initializer.  The decl-specifier-seq
+    // -- is a soup made of decl-specifier such as `static`, `extern`, etc. and simple-type
+    // -- names such as `int`, and type qualifiers.  Compound types are made with
+    // -- type-constructors such as `*` (pointer) or `&` (reference), etc.  
+    // -- The type-constructors (which really imply some form of data indirection) are specified
+    // -- along with the name being introduced, making up the declarator.
+    // -- Pointer-style type-constructors are modeled by `Indirector`.
+    // -- Mapping-style type constructors (functions, arrays) are modeled by `Species_declarator`.
+
+    struct Indirector_visitor;      // Base class of visitors for traversing `Indirector`s.
+
+    // Base class for objects representing ptr-operator (C++ grammar).
+    // While the source-level grammar of ISO C++ does not allow attributes on
+    // reference-style ptr-operator, the representation make room for that possibility.
+    // Hence all `Indirector` objects have an `attributes()` operation.
+    // At the input source level, `Indirector`s precede the name being declared in the declarator.
+    struct Indirector {
+        enum class Mode {
+            Deref,                  // "*" as ptr-operator in a declarator
+            Bind,                   // "&" as ptr-operator in a declarator
+            Move                    // "&&" as ptr-operator in a declarator
+        };
+        struct Simple;
+        struct Member;
+        virtual const Sequence<Attribute>& attributes() const = 0;
+        virtual void accept(Indirector_visitor&) const = 0;
+    };
+
+    // A simple `Indirector` object is a ptr-operator that specifies a simple indirection:
+    //     pointer, lvalue reference, or an rvalue reference
+    struct Indirector::Simple : Indirector {
+        virtual Mode mode() const = 0;
+    };
+
+    // A member `Indirector` object represents a ptr-operator that specifies a pointer to member.
+    struct Indirector::Member : Indirector {
+        virtual const Scope_ref& scope() const = 0;
+        virtual Type_qualifiers qualifiers() const = 0;
+    };
+
+    // Traversal of Indirector objects is facilitated by visitor classes deriving
+    // from this interface.
+    struct Indirector_visitor {
+        virtual void visit(const Indirector::Simple&) = 0;
+        virtual void visit(const Indirector::Member&) = 0;
+    };
+
+    // A species declarator indicates the typical usage of a named being declared.
+    //   - Id: an id-expression
+    //   - Callable: a callable expression
+    //   - Array: a table expression
+    //   - Parenthesized: requires parenthesis to obey operator precedence rules
+
+    struct Species_visitor;
+
+    struct Species_declarator {
+        struct Id;
+        struct Callable;
+        struct Array;
+        struct Parenthesized;
+        virtual void accept(Species_visitor&) const = 0;
+    };
+
+    // -- A declarator is either a term, or a species with a target type.
+    // -- A term is a sequence of indirectors followed by a species.
+    // -- A species indicates the typical usage syntactic structure of the named being declared.
+
+    struct Declarator_visitor;
+
+    // Almost all ISO C++ declarators have an optional attribute-specifier-seq.
+    // The modeling here allows (trailing) attribute sequence on all declarators,
+    // given by the `attributes()` operation.
+    struct Declarator {
+        struct Term;
+        struct Targeted;
+        virtual const Sequence<Attribute>& attributes() const = 0;
+        virtual void accept(Declarator_visitor&) const = 0;
+    };
+
+    // A term declarator is a sequence of `Indirector`s followed by a species declarator.
+    struct Declarator::Term : Declarator {
+        virtual const Sequence<Indirector>& indirectors() const = 0;
+        virtual const Species_declarator& species() const = 0;
+    };
+
+    // A targeted declarator is a species declarator with a trailing return type,
+    // given by the `target()` operation.
+    struct Declarator::Targeted : Declarator {
+        virtual const Species_declarator::Callable& species() const = 0;
+        virtual const Type& target() const = 0;
+    };
+
+    // Traversal of declarator objects is facilitated by visitor classes deriving
+    // from this interface.
+    struct Declarator_visitor {
+        virtual void visit(const Declarator::Term&) = 0;
+        virtual void visit(const Declarator::Targeted&) = 0;
+    };
+
+    // An id-expression in the species declarator.  That name may be further subject to pack expansion
+    struct Species_declarator::Id : Species_declarator {
+        virtual const Expr& name() const = 0;
+    };
+
+    // A species declarator indicating something that can be called.  That something
+    // is described by the species in the `prefix()` sequence of species.
+    struct Species_declarator::Callable : Species_declarator {
+        virtual const Sequence<Species_declarator>& prefix() const = 0;
+        virtual const Parameter_list& parameters() const = 0;
+        virtual Type_qualifiers qualifiers() const = 0;
+        virtual Binding_mode binding_mode() const = 0;
+        virtual Optional<Expr> throws() const = 0;
+    };
+
+    // A species declarator indicating something that can be indexed.  That something
+    // is described by the species in the `prefix()` sequence of species.
+    struct Species_declarator::Array : Species_declarator {
+        virtual const Sequence<Species_declarator>& prefix() const = 0;
+        virtual Optional<Expr> bound() const = 0;
+    };
+
+    // A term declarator requiring parenthesis to obey operator precedence rules.
+    struct Species_declarator::Parenthesized : Species_declarator {
+        virtual const Declarator::Term& term() const = 0;
+    };
+
+    // Traversal of species objects is facilitated by visitor classes deriving
+    // from this interface.
+    struct Species_visitor {
+        virtual void visit(const Species_declarator::Id&) = 0;
+        virtual void visit(const Species_declarator::Callable&) = 0;
+        virtual void visit(const Species_declarator::Array&) = 0;
+        virtual void visit(const Species_declarator::Parenthesized&) = 0;
+    };
+
+    struct Proclamator_visitor;
+
+    struct Proclamator {
+        struct Initialized;
+        struct Constrained;
+        virtual const Declarator& declarator() const = 0;
+        virtual Decl& result() const = 0;
+        virtual void accept(Proclamator_visitor&) const = 0;
+    };
+
+    struct Proclamator::Initialized : Proclamator {
+        virtual Optional<Expr> initializer() const = 0;
+    };
+
+    struct Proclamator::Constrained : Proclamator {
+        virtual const Expr& constraint() const = 0;
+    };
+
+    struct Proclamator_visitor {
+        virtual void visit(const Proclamator::Initialized&) = 0;
+        virtual void visit(const Proclamator::Constrained&) = 0;
+    };
+}
+
+#endif // IPR_FORM_INCLUDED

--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -58,6 +58,84 @@ namespace ipr::impl {
       using Interface = T;
       void accept(ipr::Visitor& v) const final { v.visit(*this); }
    };
+
+                             // -- impl::Unary --
+   template<class Interface>
+   struct Unary : Interface {
+      using typename Interface::Arg_type;
+      Arg_type rep;
+
+      explicit Unary(Arg_type a) : rep{ a } { }
+      Arg_type operand() const final { return rep; }
+   };
+
+   // -- impl::Unary_node: Shorthand for the implementation of generic unary nodes.
+   template<typename T>
+   using Unary_node = Unary<Node<T>>;
+
+                             // -- impl::Binary --
+   template<class Interface>
+   struct Binary : Interface {
+      using typename Interface::Arg1_type;
+      using typename Interface::Arg2_type;
+      struct Rep {
+         Arg1_type first;
+         Arg2_type second;
+      };
+      Rep rep;
+
+      Binary(const Rep& r) : rep(r) { }
+      Binary(Arg1_type f, Arg2_type s) : rep{ f, s } { }
+      Arg1_type first() const final { return rep.first; }
+      Arg2_type second() const final { return rep.second; }
+   };
+
+   // -- impl::Binary_node: Short hand for implementation of generic binary nodes.
+   template<typename T>
+   using Binary_node = Binary<Node<T>>;
+
+                           // -- impl::Ternary --
+   template<class Interface>
+   struct Ternary : Interface {
+      using typename Interface::Arg1_type;
+      using typename Interface::Arg2_type;
+      using typename Interface::Arg3_type;
+      struct Rep {
+         Arg1_type first;
+         Arg2_type second;
+         Arg3_type third;
+      };
+      Rep rep;
+
+      Ternary(const Rep& r) : rep(r) { }
+      Ternary(Arg1_type f, Arg2_type s, Arg3_type t) : rep{ f, s, t } { }
+      Arg1_type first() const final { return rep.first; }
+      Arg2_type second() const final { return rep.second; }
+      Arg3_type third() const final { return rep.third; }
+   };
+
+                           // -- impl::Quaternary --
+   template<class Interface>
+   struct Quaternary : Interface {
+      using typename Interface::Arg1_type;
+      using typename Interface::Arg2_type;
+      using typename Interface::Arg3_type;
+      using typename Interface::Arg4_type;
+      struct Rep {
+         Arg1_type first;
+         Arg2_type second;
+         Arg3_type third;
+         Arg4_type fourth;
+      };
+      Rep rep;
+
+      Quaternary(const Rep& r) : rep(r) { }
+      Quaternary(Arg1_type f, Arg2_type s, Arg3_type t, Arg4_type u) : rep{ f, s, t, u } { }
+      Arg1_type first() const final { return rep.first; }
+      Arg2_type second() const final { return rep.second; }
+      Arg3_type third() const final { return rep.third; }
+      Arg4_type fourth() const final { return rep.fourth; }
+   };
 }
 
 namespace ipr::util {
@@ -92,2372 +170,2356 @@ namespace ipr::util {
    };
 }
 
-namespace ipr {
-   namespace impl {
-      struct Lexicon;
+namespace ipr::impl {
+   // --------------------------------------
+   // -- Implementations of ipr::Sequence --
+   // --------------------------------------
+   // The Sequence<> interface admits various implementations.
+   // Here is the list of the implementations currently in use:
+   //   (a) ref_sequence<>;
+   //   (b) val_sequence<>;
+   //   (c) empty_sequence<T>.
+   // Variants exist in form of
+   //   (i) decl_sequence;
+   //  (ii) singleton_declset<T>.
 
-      template<typename T>
-      struct stable_farm : std::forward_list<T> {
-         using std::forward_list<T>::forward_list;
+   // -- When a class implements an interface, return that interface;
+   // -- otherwise, the type itself.
+   template<typename T>
+   concept Has_interface = requires { typename T::Interface; };
 
-         template<typename... Args>
-         T* make(Args&&... args) {
-            this->emplace_front(std::forward<Args>(args)...);
-            return &this->front();
-         }
-      };
+   template<typename T>
+   struct abstraction {
+      using type = T;
+   };
 
-      // --------------------------------------
-      // -- Implementations of ipr::Sequence --
-      // --------------------------------------
-      // The Sequence<> interface admits various implementations.
-      // Here is the list of the implementations currently in use:
-      //   (a) ref_sequence<>;
-      //   (b) val_sequence<>;
-      //   (c) empty_sequence<T>.
-      // Variants exist in form of
-      //   (i) decl_sequence;
-      //  (ii) singleton_declset<T>.
+   template<Has_interface T>
+   struct abstraction<T> {
+      using type = typename T::Interface;
+   };
 
-                                // -- impl::ref_sequence --
-      // The class ref_sequence<T> implements Sequence<T> by storing
-      // references (e.g. pointers) to data of type T, allocated
-      // somewhere else.  That for example if useful when keeping track
-      // of redeclarations in decl-sets.
-      // In general, it can be used to implement the notion of sub-sequence.
+   template<typename T>
+   using interface = typename abstraction<T>::type;
 
-      template<typename T>
-      struct ref_sequence : ipr::Sequence<T>, private std::vector<const void*> {
-         using Seq = Sequence<T>;
-         using Rep = std::vector<const void*>;
-         using pointer = const T*;
-         using Iterator = typename Seq::Iterator;
-         using Index = typename Seq::Index;
+                          // -- impl::ref_sequence --
+   // The class ref_sequence<T> implements Sequence<T> by storing
+   // references (e.g. pointers) to data of type T, allocated
+   // somewhere else.  That for example if useful when keeping track
+   // of redeclarations in decl-sets.
+   // In general, it can be used to implement the notion of sub-sequence.
+   template<typename T>
+   struct ref_sequence : ipr::Sequence<T>, private std::vector<const void*> {
+      using Seq = Sequence<T>;
+      using Rep = std::vector<const void*>;
+      using pointer = const T*;
+      using Iterator = typename Seq::Iterator;
+      using Index = typename Seq::Index;
+      explicit ref_sequence(std::size_t n = 0) : Rep(n) { }
+      Index size() const final { return Rep::size(); }
 
-         explicit ref_sequence(std::size_t n = 0) : Rep(n) { }
+      using Seq::begin;
+      using Seq::end;
+      using Rep::resize;
+      using Rep::push_back;
+      const T& get(Index p) const final { return *pointer(this->at(p)); }
+   };
 
-         Index size() const final { return Rep::size(); }
-
-         using Seq::begin;
-         using Seq::end;
-
-         //using Rep::reserve;
-         using Rep::resize;
-         using Rep::push_back;
-         const T& get(Index p) const final { return *pointer(this->at(p)); }
-      };
-
-      // -- When a class implements an interface, return that interface;
-      // -- otherwise, the type itself.
-      template<typename T>
-      concept Has_interface = requires { typename T::Interface; };
-
-      template<typename T>
-      struct abstraction {
-         using type = T;
-      };
-
-      template<Has_interface T>
-      struct abstraction<T> {
-         using type = typename T::Interface;
-      };
-
-      template<typename T>
-      using interface = typename abstraction<T>::type;
-
-                                // -- impl::val_sequence --
-      // The class val_sequence<T> implements Sequence<T> by storing
-      // the actual values, instead of references to values (as is
-      // the case of ref_sequence<T>).
-      template<typename T>
-      struct val_sequence : ipr::Sequence<interface<T>>, private stable_farm<T> {
-         using Seq = ipr::Sequence<interface<T>>;
-         using Impl = stable_farm<T>;
-         using Iterator = typename Seq::Iterator;
-         using Index = typename Seq::Index;
-
-         using Seq::begin;
-         using Seq::end;
-
-         val_sequence() : mark(this->before_begin()) { }
-
-         Index size() const final
-         {
-            return std::distance(Impl::begin(), Impl::end());
-         }
-
-         template<typename... Args>
-         T* push_back(Args&&... args)
-         {
-            mark = this->emplace_after(mark, std::forward<Args>(args)...);
-            return &*mark;
-         }
-
-         const T& get(Index p) const final
-         {
-            if (p < 0 or p >= size())
-               throw std::domain_error("val_sequence::get");
-
-            auto b = Impl::begin();
-            std::advance(b, p);
-            return *b;
-         }
-      private:
-         typename Impl::iterator mark;
-      };
-                                // -- impl::empty_sequence --
-      // There are various situations where the general notion of
-      // sequence leads to consider empty sequence in implementations.
-      // We could just use the generic ref_sequence<> or val_sequence<>;
-      // however, this specialization will help control data size
-      // inflation, as the general sequences need at least two words
-      // to keep track of their elements (even when they are empty).
-      template<class T>
-      struct empty_sequence : ipr::Sequence<T> {
-         int size() const final { return 0; }
-
-         const T& get(int) const final
-         {
-            throw std::domain_error("empty_sequence::get");
-         }
-      };
-
-      // A sequence implementation for the case of a collection consisting of exactly one element.  
-      template<typename T>
-      struct singleton : ipr::Sequence<T> {
-         using Index = typename Sequence<T>::Index;
-
-         template<typename... Args>
-         singleton(Args&&... args) : item{args...} { }
-
-         Index size() const final { return 1; }
-         const T& get(Index i) const final
-         {
-            if (i == 0)
-               return item;
-            throw std::domain_error("singleton_sequence::get");
-         }
-      private:
-         T item;
-      };
-
-      template<class T>
-      struct node_ref {
-         const T& node;
-         explicit node_ref(const T& t) : node(t) { }
-      };
-
-                                // -- impl::Token --
-      struct Token : ipr::Lexeme, ipr::Token {
-         using Interface = ipr::Token;
-         Token(const ipr::String&, const Source_location&, TokenValue, TokenCategory);
-         const ipr::String& spelling() const final { return text; }
-         const Source_location& locus() const final { return location; }
-         const ipr::Lexeme& lexeme() const final { return *this; }
-         TokenValue value() const final { return token_value; }
-         TokenCategory category() const final { return token_category; }
-
-      private:
-         const ipr::String& text;
-         Source_location location;
-         TokenValue token_value;
-         TokenCategory token_category;
-      };
-
-      // -- Parameterized implementation of ipr::Attribute.
-      // -- The type parameter is used here as a device to implement an overrider
-      // -- for ipr::Attribute::visit(), for all T implementation classes of attribute.
-      template<typename T>
-      struct Attribute : T {
-         void accept(typename T::Visitor& v) const final { v.visit(*this); }
-      };
-
-      // -- implementation of ipr::BasicAttribute
-      struct BasicAttribute : impl::Attribute<ipr::BasicAttribute> {
-         explicit BasicAttribute(const ipr::Token& t) : tok{ t } { }
-         const ipr::Token& token() const final { return tok; }
-      private:
-         const ipr::Token& tok;
-      };
-
-      // -- implementation of ipr::ScopedAttribute
-      struct ScopedAttribute : impl::Attribute<ipr::ScopedAttribute> {
-         ScopedAttribute(const ipr::Token& s, const ipr::Token& m) : first{ s }, second{ m } { }
-         const ipr::Token& scope() const final { return first; }
-         const ipr::Token& member() const final { return second; }
-      private:
-         const ipr::Token& first;
-         const ipr::Token& second;
-      };
-
-      // -- implementation of ipr::LabeledAttribute
-      struct LabeledAttribute : impl::Attribute<ipr::LabeledAttribute> {
-         LabeledAttribute(const ipr::Token& l, const ipr::Attribute& a) : lbl{ l }, attr{ a } { }
-         const ipr::Token& label() const final { return lbl; }
-         const ipr::Attribute& attribute() const final { return attr; }
-      private:
-         const ipr::Token& lbl;
-         const ipr::Attribute& attr;
-      };
-
-      // -- implementation of ipr::CalledAttribute
-      struct CalledAttribute : impl::Attribute<ipr::CalledAttribute> {
-         CalledAttribute(const ipr::Attribute& f, const ipr::Sequence<ipr::Attribute>& s) : fun{ f }, args{ s } { }
-         const ipr::Attribute& function() const final { return fun; }
-         const ipr::Sequence<ipr::Attribute>& arguments() const final { return args; }
-      private:
-         const ipr::Attribute& fun;
-         const ipr::Sequence<ipr::Attribute>& args;
-      };
-
-      // -- implementation of ipr::ExpandedAttribute
-      struct ExpandedAttribute : impl::Attribute<ipr::ExpandedAttribute> {
-         ExpandedAttribute(const ipr::Token& t, const ipr::Attribute& a) : tok{ t }, attr{ a } { }
-         const ipr::Token& expander() const final { return tok; }
-         const ipr::Attribute& operand() const final { return attr; }
-      private:
-         const ipr::Token& tok;
-         const ipr::Attribute& attr;
-      };
-
-      // -- implementation of ipr::FactoredAttribute
-      struct FactoredAttribute : impl::Attribute<ipr::FactoredAttribute> {
-         FactoredAttribute(const ipr::Token& t, const ipr::Sequence<ipr::Attribute>& s) : tok{ t }, seq{ s } { }
-         const ipr::Token& factor() const final { return tok; }
-         const ipr::Sequence<ipr::Attribute>& terms() const final { return seq; }
-      private:
-         const ipr::Token& tok;
-         const ipr::Sequence<ipr::Attribute>& seq;
-      };
-
-      // -- implementation of ipr::ElaboratedAttribute
-      struct ElaboratedAttribute : impl::Attribute<ipr::ElaboratedAttribute> {
-         explicit ElaboratedAttribute(const ipr::Expr& x) : expr{ x } { }
-         const ipr::Expr& elaboration() const final { return expr; }
-      private:
-         const ipr::Expr& expr;
-      };
-
-      // -- Attributes factory --
-      struct attr_factory {
-         const ipr::BasicAttribute& make_basic_attribute(const ipr::Token&);
-         const ipr::ScopedAttribute& make_scoped_attribute(const ipr::Token&, const ipr::Token&);
-         const ipr::LabeledAttribute& make_labeled_attribute(const ipr::Token&, const ipr::Attribute&);
-         const ipr::CalledAttribute& make_called_attribute(const ipr::Attribute&, const ipr::Sequence<ipr::Attribute>&);
-         const ipr::ExpandedAttribute& make_expanded_attribute(const ipr::Token&, const ipr::Attribute&);
-         const ipr::FactoredAttribute& make_factored_attribute(const ipr::Token&, const ipr::Sequence<ipr::Attribute>&);
-         const ipr::ElaboratedAttribute& make_elaborated_attribute(const ipr::Expr&);
-      private:
-         stable_farm<impl::BasicAttribute> basics;
-         stable_farm<impl::ScopedAttribute> scopeds;
-         stable_farm<impl::LabeledAttribute> labeleds;
-         stable_farm<impl::CalledAttribute> calleds;
-         stable_farm<impl::ExpandedAttribute> expandeds;
-         stable_farm<impl::FactoredAttribute> factoreds;
-         stable_farm<impl::ElaboratedAttribute> elaborateds;
-      };
-
-      // -- implementation for ipr::Capture
-      struct Capture : ipr::Capture {
-         using Interface = ipr::Capture;
-         Capture(const ipr::Decl& d, ipr::Binding_mode m) : decl{d}, md{m} { }
-         ipr::Binding_mode mode() const final { return md; }
-         const ipr::Decl& entity() const final { return decl; }
-      private:
-         const ipr::Decl& decl;
-         const ipr::Binding_mode md;
-      };
-
-      // -- Generic implementation of ipr::Capture_specification
-      template<typename T>
-      struct Capture_specification : T {
-         void accept(typename T::Visitor& v) const final { v.visit(*this); }
-      };
-
-      // -- implementation of ipr::Capture_specification::Default
-      struct Default_capture_specification : Capture_specification<ipr::Capture_specification::Default> {
-         explicit Default_capture_specification(Binding_mode m) : md{m} { }
-         Binding_mode mode() const final { return md; }
-      private:
-         const Binding_mode md;
-      };
-
-      // -- implementation of ipr::Capture_specification::Implicit_object
-      struct Implicit_object_capture_specification : Capture_specification<ipr::Capture_specification::Implicit_object> {
-         explicit Implicit_object_capture_specification(Binding_mode m) : md{m} { }
-         Binding_mode how() const final { return md; }
-      private:
-         const Binding_mode md;
-      };
-
-      // -- implementation of ipr::Capture_specification::Enclosing_local
-      struct Enclosing_local_capture_specification : Capture_specification<ipr::Capture_specification::Enclosing_local> {
-         Enclosing_local_capture_specification(const ipr::Decl& x, Binding_mode m) : decl{x}, md{m} { }
-         Binding_mode mode() const final { return md; }
-         const ipr::Identifier& name() const final;
-         const ipr::Decl& declaration() const final { return decl; }
-      private:
-         const ipr::Decl& decl;
-         const Binding_mode md;
-      };
-
-      // -- implementation of ipr::Capture_capture::Binding
-      struct Binding_capture_specification : Capture_specification<ipr::Capture_specification::Binding> {
-         Binding_capture_specification(const ipr::Identifier& n, const ipr::Expr& x, Binding_mode m) : id{n}, init{x}, md{m} { }
-         Binding_mode mode() const final { return md; }
-         const ipr::Identifier& name() const { return id; }
-         const ipr::Expr& initializer() const { return init; }
-      private:
-         const ipr::Identifier& id;
-         const ipr::Expr& init;
-         const Binding_mode md;
-      };
-
-      // -- implementation of ipr::Capture_specification::Expansion.
-      struct Expansion_capture_specification : Capture_specification<ipr::Capture_specification::Expansion> {
-         explicit Expansion_capture_specification(const Named& x) : cap{x} { }
-         const Named& what() const final { return cap; }
-      private:
-         const Named& cap;
-      };
-
-      // -- capture specification factory
-      struct capture_spec_factory {
-         const ipr::Capture_specification::Default& default_capture(Binding_mode);
-         const ipr::Capture_specification::Implicit_object& implicit_object_capture(Binding_mode);
-         const ipr::Capture_specification::Enclosing_local& enclosing_local_capture(const ipr::Decl&, Binding_mode);
-         const ipr::Capture_specification::Binding& binding_capture(const ipr::Identifier&, const ipr::Expr&, Binding_mode);
-         const ipr::Capture_specification::Expansion& expansion_capture(const ipr::Capture_specification::Named&);
-      private:
-         stable_farm<impl::Default_capture_specification> defaults;
-         stable_farm<impl::Implicit_object_capture_specification> implicits;
-         stable_farm<impl::Enclosing_local_capture_specification> enclosings;
-         stable_farm<impl::Binding_capture_specification> bindings;
-         stable_farm<impl::Expansion_capture_specification> expansions;
-      };
-
-                                // -- impl::Module_name --
-      struct Module_name : ipr::Module_name {
-         ref_sequence<ipr::Identifier> components;
-
-         const ipr::Sequence<ipr::Identifier>& stems() const final;
-      };
-
-
-      template<typename T,
-          typename std::enable_if_t<std::is_scalar_v<T>, int> = 0>
-      constexpr int compare(T lhs, T rhs)
+   // -- stable_farm --
+   // Backing store for stable reference-producing factories.
+   template<typename T>
+   struct stable_farm : std::forward_list<T> {
+      using std::forward_list<T>::forward_list;
+      template<typename... Args>
+      T* make(Args&&... args)
       {
-         constexpr std::less<> lt { };
-         return lt(lhs, rhs) ? -1 : (lt(rhs, lhs) ? 1 : 0);
+         this->emplace_front(std::forward<Args>(args)...);
+         return &this->front();
+      }
+   };
+
+                             // -- impl::val_sequence --
+   // The class val_sequence<T> implements Sequence<T> by storing
+   // the actual values, instead of references to values (as is
+   // the case of ref_sequence<T>).
+   template<typename T>
+   struct val_sequence : ipr::Sequence<interface<T>>, private stable_farm<T> {
+      using Seq = ipr::Sequence<interface<T>>;
+      using Impl = stable_farm<T>;
+      using Iterator = typename Seq::Iterator;
+      using Index = typename Seq::Index;
+      using Seq::begin;
+      using Seq::end;
+
+      val_sequence() : mark(this->before_begin()) { }
+
+      Index size() const final
+      {
+         return std::distance(Impl::begin(), Impl::end());
       }
 
-      constexpr int compare(const ipr::Node& lhs, const ipr::Node& rhs)
+      template<typename... Args>
+      T* push_back(Args&&... args)
       {
-         return compare(&lhs, &rhs);
+         mark = this->emplace_after(mark, std::forward<Args>(args)...);
+         return &*mark;
       }
 
-      // Helper class
-      template<class Interface>
-      struct Unary : Interface {
-         using typename Interface::Arg_type;
-         Arg_type rep;
-
-         explicit Unary(Arg_type a) : rep{ a } { }
-         Arg_type operand() const final { return rep; }
-      };
-
-      // Shorthand for the implementation of generic unary nodes.
-      template<typename T>
-      using Unary_node = Unary<Node<T>>;
-
-      template<class Base>
-      struct type_from_operand : Unary_node<Base> {
-         using typename Base::Arg_type;
-         explicit type_from_operand(Arg_type a) : Unary_node<Base>{a} { }
-         const ipr::Type& type() const final { return this->operand().type(); }
-      };
-
-      template<class Interface>
-      struct Binary : Interface {
-         using typename Interface::Arg1_type;
-         using typename Interface::Arg2_type;
-         struct Rep {
-            Arg1_type first;
-            Arg2_type second;
-         };
-         Rep rep;
-
-         Binary(const Rep& r) : rep(r) { }
-         Binary(Arg1_type f, Arg2_type s) : rep{ f, s } { }
-         Arg1_type first() const final { return rep.first; }
-         Arg2_type second() const final { return rep.second; }
-      };
-
-      // Short hand for implementation of generic binary nodes.
-      template<typename T>
-      using Binary_node = Binary<Node<T>>;
-
-      template<class Base>
-      struct type_from_second : Binary_node<Base> {
-         using typename Base::Arg1_type;
-         using typename Base::Arg2_type;
-         type_from_second(Arg1_type f, Arg2_type s) : Binary_node<Base>{ f, s } { }
-         const ipr::Type& type() const final { return this->second().type(); }
-      };
-
-
-      template<class Interface>
-      struct Ternary : Interface {
-         using typename Interface::Arg1_type;
-         using typename Interface::Arg2_type;
-         using typename Interface::Arg3_type;
-         struct Rep {
-            Arg1_type first;
-            Arg2_type second;
-            Arg3_type third;
-         };
-         Rep rep;
-
-         Ternary(const Rep& r) : rep(r) { }
-         Ternary(Arg1_type f, Arg2_type s, Arg3_type t) : rep{ f, s, t } { }
-         Arg1_type first() const final { return rep.first; }
-         Arg2_type second() const final { return rep.second; }
-         Arg3_type third() const final { return rep.third; }
-      };
-
-      template<class Interface>
-      struct Quaternary : Interface {
-         using typename Interface::Arg1_type;
-         using typename Interface::Arg2_type;
-         using typename Interface::Arg3_type;
-         using typename Interface::Arg4_type;
-         struct Rep {
-            Arg1_type first;
-            Arg2_type second;
-            Arg3_type third;
-            Arg4_type fourth;
-         };
-         Rep rep;
-
-         Quaternary(const Rep& r) : rep(r) { }
-         Quaternary(Arg1_type f, Arg2_type s, Arg3_type t, Arg4_type u) : rep{ f, s, t, u } { }
-         Arg1_type first() const final { return rep.first; }
-         Arg2_type second() const final { return rep.second; }
-         Arg3_type third() const final { return rep.third; }
-         Arg4_type fourth() const final { return rep.fourth; }
-      };
-
-
-      // -------------------------
-      // -- Classic expressions --
-      // -------------------------
-
-      template<class Operation>
-      struct Classic : Operation {
-         Optional<ipr::Expr> op_impl { };
-         using Operation::Operation;
-
-         Optional<ipr::Expr> implementation() const final { return op_impl; }
-      };
-
-                                // -- Conversion_expr --
-      template<class Interface>
-      struct Conversion_expr : impl::Classic<Binary_node<Interface>> {
-         using Base = impl::Classic<Binary_node<Interface>>;
-         using Base::Base;
-
-         const ipr::Type& type() const { return this->rep.first; }
-      };
-
-                                // -- Linkage --
-      using Linkage = Unary_node<ipr::Linkage>;
-
-      // -------------------------
-      // -- General expressions --
-      // -------------------------
-      // Various generalized expressions are the result of a unary
-      // operator applied to an expression.  Their structure is captured
-      // by ipr::Unary<>.  The class unary_expr<T> implements that
-      // interface.
-
-      template<class Interface>
-      struct Expr : impl::Node<Interface> {
-         Optional<ipr::Type> constraint;
-
-         Expr(Optional<ipr::Type> t = { }) : constraint{ t } { }
-         const ipr::Type& type() const final { return constraint.get(); }
-      };
-
-      // Short hand for the implementation of generic expression nodes.
-      template<typename T>
-      using Unary_expr = Unary<Expr<T>>;
-
-      template<typename T>
-      using Classic_unary_expr = Classic<Unary_expr<T>>;
-
-      template<typename T>
-      using Binary_expr = Binary<Expr<T>>;
-
-      template<typename T>
-      using Classic_binary_expr = Classic<Binary_expr<T>>;
-
-      // ----------------------------------------------------
-      // -- Scopes, sequence of declarations and overloads --
-      // ----------------------------------------------------
-      //
-      // A scope is defined to be a sequence of declarations.
-      // There may be multiple instances of a declaration in
-      // a scope.  All declarations sharing the same name
-      // form an overload set.  Consequently a scope is partitioned
-      // into overload sets, each of which is uniquely identified
-      // by its name.
-      // An overload set, in turn, is partitioned in sub-sets of
-      // (multiple) declarations with same type.  So, each decl-set
-      // within its overload set, is uniquely determined by its
-      // type.  Each decl-set has a "standard" representative,
-      // called the "master declaration".  A master declaration is
-      // the first seen declaration of a decl-set.
-      //
-      // There are few special cases of the above general description.
-      // Parameters, base-classes and enumerators cannot be multiply
-      // declared.  Therefore within a parameter-lits, a base-class
-      // list or an enumeration definition, each decl-set is
-      // singleton whose sole element is the master declaration.
-      //
-      // A scope chains declaration together.  A declaration in a
-      // Scope has a "position", that uniquely identifies it as a member
-      // of a sequence.  To provide a relatively fast "subscription by position"
-      // operation on a scope, the chain of declaration is
-      // organized as a red-back tree where the position is used as key.
-      // And alternative is a hash table, when we get there.
-
-      struct scope_datum : util::rb_tree::link<scope_datum> {
-         // The specifiers for this declaration.  S
-         ipr::DeclSpecifiers spec = { };
-
-         // Back-pointer to this declaration.  It shall be set at
-         // the declaration creation.
-         const ipr::Decl* decl = { };
-      };
-
-                                // -- impl::decl_sequence --
-      // The chain of declarations in a scope.
-
-      struct decl_sequence : ref_sequence<ipr::Decl> { };
-
-                                // -- impl::singleton_declset --
-      // A singleton_declset is a specialization of decl_sequence
-      // that contains only a single declaration.  It is mostly used
-      // to support the general interface of ipr::Scope as inherited
-      // in parameter-list or enumerator definitions.
-
-      template<class T>
-      struct singleton_declset : ipr::Sequence<ipr::Decl> {
-         using Index = typename Sequence<ipr::Decl>::Index;
-         const T& datum;
-
-         explicit singleton_declset(const T& t) : datum(t) { }
-
-         Index size() const final { return 1; }
-         const T& get(Index i) const final
-         {
-            if (i == 0)
-               return datum;
-            throw std::domain_error("singleton_declset::get");
-         }
-      };
-
-
-      // All declarations (except parameters, base-classes, enumerations)
-      // maintain data about their position and master declaration.  Since
-      // all declarations in a given decl-set have the same type, only
-      // the master declaration has the "type" information.
-      // Similarly, only the master declaration maintains the home
-      // region information.
-      //
-      // In a given decl-set, only one of the declarations is a definition.
-      // The master declaration keeps track of that definition, so all
-      // other redeclarations can refer to it through the master
-      // declaration data.
-
-      template<class> struct master_decl_data;
-      struct Overload;
-
-      // An entry in an overload set.  Part of the data that a
-      // master declaration manages.  It is determined, within
-      // an overload set, by its type.  All redeclarations must
-      // register themselves before the master declaration, at
-      // the creation time.
-
-      struct overload_entry : util::rb_tree::link<overload_entry> {
-         const ipr::Type& type;
-         ref_sequence<ipr::Decl> declset;
-         explicit overload_entry(const ipr::Type& t) : type(t) { }
-      };
-
-
-      template<class Interface>
-      struct basic_decl_data : scope_datum {
-         // Information about the master declaration.  This pointer
-         // shall be set at actual declaration creation time.
-         master_decl_data<Interface>* master_data;
-
-         explicit basic_decl_data(master_decl_data<Interface>* mdd)
-               : master_data(mdd)
-         { }
-      };
-
-
-      // A master declaration is the first seen introduction of
-      // a name with a given type.  Further redeclarations
-      // are represented by basic_decl_data<> and are linked to the
-      // master declaration.  That forms the declaration-set of
-      // that declaration.
-
-      template<class Interface>
-      struct master_decl_data : basic_decl_data<Interface>, overload_entry {
-         // The declaration that is considered to be the definition.
-         Optional<Interface> def { };
-         util::ref<const ipr::Linkage> langlinkage { };
-
-         // The overload set that contains this master declaration.  It
-         // shall be set at the time the node for the master declaration
-         // is created.
-         impl::Overload* overload;
-         const ipr::Region* home;
-         master_decl_data(impl::Overload* ovl, const ipr::Type& t)
-               : basic_decl_data<Interface>(this),
-                 overload_entry(t),
-                 overload(ovl),home(0)
-         { }
-      };
-
-      template<>
-      struct master_decl_data<ipr::Template>
-         : basic_decl_data<ipr::Template>, overload_entry {
-         using Base = basic_decl_data<ipr::Template>;
-         // The declaration that is considered to be the definition.
-         Optional<ipr::Template> def { };
-         util::ref<const ipr::Linkage> langlinkage { };
-         const ipr::Template* primary;
-         const ipr::Region* home;
-
-         // The overload set that contains this master declaration.  It
-         // shall be set at the time the node for the master declaration
-         // is created.
-         impl::Overload* overload;
-
-         // Sequence of specializations
-         decl_sequence specs;
-
-         master_decl_data(impl::Overload*, const ipr::Type&);
-      };
-
-
-      struct Overload : impl::Expr<ipr::Overload> {
-         // The name of this overload set.
-         const ipr::Name& name;
-
-         // All entries in this overload set, chained together in a
-         // red-back tree to permit fast retrieval based on type (as key).
-         // They are all master declarations.
-         util::rb_tree::chain<overload_entry> entries;
-
-         // A sequence of master declarations.  They are added as they
-         // appear in their enclosing scope.
-         std::vector<scope_datum*> masters;
-
-         explicit Overload(const ipr::Name&);
-         Optional<ipr::Decl> operator[](const ipr::Type&) const final;
-         overload_entry* lookup(const ipr::Type&) const;
-
-         template<class T>
-         void push_back(master_decl_data<T>*);
-      };
-
-      // Parameters, base-subobjects and enumerations cannot be
-      // multiply declared in a given region.  Therefore such a
-      // declaration is the sole member in its own decl-set.
-      // Furthermore, there cannot be other declaration with
-      // different type but same name.  Therefore the name for
-      // such a declaration defines an overload set with a single
-      // member.  This class implements such a special overload set.
-
-      struct singleton_overload : impl::Node<ipr::Overload> {
-         singleton_declset<ipr::Decl> seq;
-
-         explicit singleton_overload(const ipr::Decl&);
-
-         const ipr::Type& type() const final;
-         Optional<ipr::Decl> operator[](const ipr::Type&) const final;
-      };
-
-      struct node_compare {
-         int operator()(const ipr::Node& lhs, const ipr::Node& rhs) const
-         {
-            return compare(lhs, rhs);
-         }
-
-         int
-         operator()(const overload_entry& e, const ipr::Type& t) const
-         {
-            return (*this)(e.type, t);
-         }
-
-         int
-         operator()(const overload_entry& l, const overload_entry& r) const
-         {
-            return (*this)(l.type, r.type);
-         }
-      };
-
-      // -----------------------
-      // -- Generalized types --
-      // -----------------------
-
-      // impl::Type<T> implements the common operations supported
-      // by all operations.  In particular, it implements only
-      // main-variant types; qualified types are handled elsewhere.
-
-      template<class T>
-      struct Type : impl::Expr<T> {
-         Optional<ipr::Name> id { };
-
-         const ipr::Name& name() const final { return id.get(); }
-      };
-
-      template<typename T>
-      using Unary_type = Unary<Type<T>>;
-
-      template<typename T>
-      using Binary_type = Binary<Type<T>>;
-
-      template<typename T>
-      using Ternary_type = Ternary<Type<T>>;
-
-      // Scopes, as expressions, have Product types.  Such types could
-      // be implemented directly as a separate sequence of types.
-      // However, it would require coordination from the various
-      // scope updaters to keep the types in sync.  An alternative,
-      // implemented by typed_sequence<Seq>, is to wrap sequences
-      // in "type envelop" and return the nth type as being the
-      // type of the nth declaration in the sequence.
-
-      template<class Seq>
-      struct typed_sequence : impl::Type<ipr::Product>,
-                              ipr::Sequence<ipr::Type> {
-         using Index = typename Sequence<ipr::Type>::Index;
-         Seq seq;
-
-         typed_sequence() { }
-         explicit typed_sequence(const Seq& s) : seq(s) { }
-
-         const ipr::Sequence<ipr::Type>& operand() const final
-         {
-            return *this;
-         }
-         Index size() const final { return seq.size(); }
-         const ipr::Type& get(Index i) const final
-         {
-            return seq.get(i).type();
-         }
-      };
-
-                                // -----------------
-                                // -- impl::Rname --
-                                // -----------------
-      struct Rname : Ternary<Node<ipr::Rname>> {
-         explicit Rname(Rep);
-
-         // It was not strictly necessary to actually define this class
-         // and the function type().  See the comments in <ipr/interface>.
-         const ipr::Type& type() const;
-      };
-
-      template<typename T, Phases f>
-      struct Directive : impl::Expr<T> {
-         Phases phases() const final { return f; }
-      };
-
-      // Stmt<S> implements the common operations of statements.
-
-      struct Stmt_common {
-         ipr::Unit_location unit_locus;
-         ipr::Source_location src_locus;
-         ref_sequence<ipr::Annotation> notes;
-         ref_sequence<ipr::Attribute> attrs;
-      };
-
-      template<class S>
-      struct Stmt : S, Stmt_common {
-         const ipr::Unit_location& unit_location() const final
-         {
-            return unit_locus;
-         }
-
-         const ipr::Source_location& source_location() const final
-         {
-            return src_locus;
-         }
-
-         const ipr::Sequence<ipr::Annotation>& annotation() const final
-         {
-            return notes;
-         }
-
-         const ipr::Sequence<ipr::Attribute>& attributes() const final
-         {
-            return attrs;
-         }
-      };
-
-      // Capture the commonality of controlled statements such as `do-statement',
-      // `while-statement', and `switch-statement'.  This special class is introduced
-      // instead of reusing `type_from_second' because otherwise the contruction of
-      // nodes of such classes would require constructing the control expression and
-      // the body statement first, which can be awkward.
-      template<typename Base>
-      struct Controlled_stmt : Stmt<Node<Base>> {
-         using typename Base::Arg1_type;
-         using typename Base::Arg2_type;
-         util::ref<std::remove_reference_t<Arg1_type>> control;
-         util::ref<std::remove_reference_t<Arg2_type>> stmt;
-         Arg1_type first() const final { return control.get(); }
-         Arg2_type second() const final { return stmt.get(); }
-         const ipr::Type& type() const final { return second().type(); }
-      };
-
-      // The class template Decl<> implements common operations
-      // for most declarations nodes.  The exception cases are
-      // handled by the class template unique_decl<>.
-
-      template<class D>
-      struct Decl : Stmt<Node<D>> {
-         basic_decl_data<D> decl_data;
-
-         Decl() : decl_data{ nullptr } { }
-
-         const ipr::Linkage& lang_linkage() const final
-         {
-            return util::check(decl_data.master_data)->langlinkage.get();
-         }
-
-         const ipr::Region& home_region() const final {
-            return *util::check(util::check(decl_data.master_data)->home);
-         }
-
-         // Set declaration specifiers for this decl.
-         using D::specifiers;
-         void specifiers(ipr::DeclSpecifiers s) {
-            decl_data.spec = s;
-         }
-      };
-
-
-      // Some declarations (e.g. parameters, base-classes, enumerators)
-      // cannot be redeclared in their declarative regions.  Consequently
-      // their decl-sets and overload sets are singleton, containing
-      // only the mater declarations.  Consequently, it seems
-      // heavyweight space wasteful to deploy the general representation
-      // machinery for them.  The class unique_decl<> implements the
-      // specialization of Decl<> in those cases.
-
-      template<class Interface>
-      struct unique_decl : impl::Stmt<Node<Interface>> {
-         ipr::DeclSpecifiers spec;
-         util::ref<const ipr::Linkage> langlinkage { };
-         singleton_overload overload;
-
-         unique_decl() : spec(ipr::DeclSpecifiers::None),
-                         overload(*this)
-         { }
-
-         ipr::DeclSpecifiers specifiers() const final { return spec; }
-         const ipr::Decl& master() const final { return *this; }
-         const ipr::Linkage& lang_linkage() const final
-         {
-            return langlinkage.get();
-         }
-         const ipr::Sequence<ipr::Decl>& decl_set() const final { return overload.seq; }
-      };
-
-      struct Parameter final : unique_decl<ipr::Parameter> {
-         const ipr::Name& id;
-         const impl::Rname& abstract_name;
-         util::ref<const ipr::Parameter_list> where;
-         Optional<ipr::Expr> init;
-
-         Parameter(const ipr::Name&, const impl::Rname&);
-         const ipr::Name& name() const final { return id; }
-         const ipr::Type& type() const final;
-         const ipr::Region& home_region() const final { return where.get().region(); }
-         Decl_position position() const final;
-         Optional<ipr::Expr> initializer() const final { return init; }
-      };
-
-      struct Base_type final : unique_decl<ipr::Base_type> {
-         const ipr::Type& base;
-         const ipr::Region& where;
-         const Decl_position scope_pos;
-
-         Base_type(const ipr::Type&, const ipr::Region&, Decl_position);
-         const ipr::Type& type() const final { return base; }
-         // FIXME: for a base-class subobject, the home region and lexical
-         //        region are slightly different.  The home region should be that
-         //        of the class this is a base class, whereas the lexical region
-         //        should be the actual lexical region where the base type was specified.
-         const ipr::Region& lexical_region() const final { return where; }
-         const ipr::Region& home_region() const final { return where; }
-         Decl_position position() const final { return scope_pos; }
-         Optional<ipr::Expr> initializer() const final;
-      };
-
-      struct Enumerator final : unique_decl<ipr::Enumerator> {
-         const ipr::Name& id;
-         const ipr::Enum& constraint;
-         const Decl_position scope_pos;
-         util::ref<const ipr::Region> where;
-         Optional<ipr::Expr> init;
-
-         Enumerator(const ipr::Name&, const ipr::Enum&, Decl_position);
-         const ipr::Name& name() const final { return id; }
-         const ipr::Type& type() const final { return constraint; }
-         const ipr::Region& lexical_region() const final { return where.get(); }
-         const ipr::Region& home_region() const final { return where.get(); }
-         Decl_position position() const final { return scope_pos; }
-         Optional<ipr::Expr> initializer() const final { return init; }
-      };
-
-      // A sequence of homogenous node can be represented directly as a container
-      // of the concrete implementations classes instead of pointers to the 
-      // interface nodes.  This is the case, in particular, for enumerators of 
-      // an enumeration or parameters in a parameter list.
-      template<class Member>
-      struct homogeneous_scope : impl::Node<ipr::Scope>,
-                                 ipr::Sequence<ipr::Decl>,
-                                 ipr::Sequence<ipr::Expr> {
-         using Index = typename ipr::Sequence<ipr::Decl>::Index;
-         typed_sequence<val_sequence<Member>> decls;
-
-         Index size() const final { return decls.size(); }
-         const Member& get(Index i) const final { return decls.seq.get(i); }
-
-         const ipr::Product& type() const final { return decls; }
-
-         const ipr::Sequence<ipr::Decl>& elements() const final { return *this; }
-
-         Optional<ipr::Overload> operator[](const Name&) const final;
-
-         template<typename... Args>
-         Member* push_back(const Args&... args)
-         {
-            return decls.seq.push_back(args...);
-         }
-      };
-
-      // FIXME: Remove this linear search.
-      template<class Member>
-      Optional<ipr::Overload>
-      homogeneous_scope<Member>::operator[](const ipr::Name& n) const
+      const T& get(Index p) const final
       {
-         const auto s = decls.size();
-         for (Index i = 0; i < s; ++i) {
-            const auto& decl = decls.seq.get(i);
-            if (&decl.name() == &n)
-               return { &decl.overload };
-         }
+         if (p < 0 or p >= size())
+            throw std::domain_error("val_sequence::get");
 
-         return { };
+         auto b = Impl::begin();
+         std::advance(b, p);
+         return *b;
+      }
+   private:
+      typename Impl::iterator mark;
+   };
+
+                              // -- impl::empty_sequence --
+   // There are various situations where the general notion of
+   // sequence leads to consider empty sequence in implementations.
+   // We could just use the generic ref_sequence<> or val_sequence<>;
+   // however, this specialization will help control data size
+   // inflation, as the general sequences need at least two words
+   // to keep track of their elements (even when they are empty).
+   template<class T>
+   struct empty_sequence : ipr::Sequence<T> {
+      int size() const final { return 0; }
+
+      const T& get(int) const final
+      {
+         throw std::domain_error("empty_sequence::get");
+      }
+   };
+
+   // A sequence implementation for the case of a collection consisting of exactly one element.  
+   template<typename T>
+   struct singleton : ipr::Sequence<T> {
+      using Index = typename Sequence<T>::Index;
+
+      template<typename... Args>
+      singleton(Args&&... args) : item{args...} { }
+
+      Index size() const final { return 1; }
+      const T& get(Index i) const final
+      {
+         if (i == 0)
+            return item;
+         throw std::domain_error("singleton_sequence::get");
+      }
+   private:
+      T item;
+   };
+}
+
+namespace ipr::impl {
+   // -- impl::Classic
+   template<class Operation>
+   struct Classic : Operation {
+      Optional<ipr::Expr> op_impl { };
+      using Operation::Operation;
+
+      Optional<ipr::Expr> implementation() const final { return op_impl; }
+   };
+
+   // -- impl::Expr
+   template<class Interface>
+   struct Expr : impl::Node<Interface> {
+      Optional<ipr::Type> constraint;
+
+      Expr(Optional<ipr::Type> t = { }) : constraint{ t } { }
+      const ipr::Type& type() const final { return constraint.get(); }
+   };
+
+   // -- impl::Unary_expr: Short hand for the implementation of generic unary expression nodes.
+   template<typename T>
+   using Unary_expr = Unary<Expr<T>>;
+
+   // -- impl::Classic_unary_expr
+   template<typename T>
+   using Classic_unary_expr = Classic<Unary_expr<T>>;
+
+   // -- impl::Binary_expr
+   template<typename T>
+   using Binary_expr = Binary<Expr<T>>;
+
+   // -- impl::Classic_binary_expr
+   template<typename T>
+   using Classic_binary_expr = Classic<Binary_expr<T>>;
+
+   // -----------------------
+   // -- Generalized types --
+   // -----------------------
+   // impl::Type<T> implements the common operations supported
+   // by all type node objects.  In particular, it implements only
+   // main-variant types; qualified types are handled elsewhere.
+   template<class T>
+   struct Type : impl::Expr<T> {
+      Optional<ipr::Name> id { };
+
+      const ipr::Name& name() const final { return id.get(); }
+   };
+
+   // -- impl::Unary_type
+   template<typename T>
+   using Unary_type = Unary<Type<T>>;
+
+   // -- impl::Binary_type
+   template<typename T>
+   using Binary_type = Binary<Type<T>>;
+
+   // -- impl::Ternary_type
+   template<typename T>
+   using Ternary_type = Ternary<Type<T>>;
+}
+
+namespace ipr::impl{
+   // ----------------------------------------------------
+   // -- Scopes, sequence of declarations and overloads --
+   // ----------------------------------------------------
+   //
+   // A scope is defined to be a sequence of declarations.
+   // There may be multiple instances of a declaration in
+   // a scope.  All declarations sharing the same name
+   // form an overload set.  Consequently a scope is partitioned
+   // into overload sets, each of which is uniquely identified
+   // by its name.
+   // An overload set, in turn, is partitioned in sub-sets of
+   // (multiple) declarations with same type.  So, each decl-set
+   // within its overload set, is uniquely determined by its
+   // type.  Each decl-set has a "standard" representative,
+   // called the "master declaration".  A master declaration is
+   // the first seen declaration of a decl-set.
+   //
+   // There are few special cases of the above general description.
+   // Parameters, base-classes and enumerators cannot be multiply
+   // declared.  Therefore within a parameter-lits, a base-class
+   // list or an enumeration definition, each decl-set is
+   // singleton whose sole element is the master declaration.
+   //
+   // A scope chains declaration together.  A declaration in a
+   // Scope has a "position", that uniquely identifies it as a member
+   // of a sequence.  To provide a relatively fast "subscription by position"
+   // operation on a scope, the chain of declaration is
+   // organized as a red-back tree where the position is used as key.
+   // And alternative is a hash table, when we get there.
+
+   // The chain of declarations in a scope.
+   struct scope_datum : util::rb_tree::link<scope_datum> {
+      // The specifiers for this declaration.  S
+      ipr::DeclSpecifiers spec = { };
+
+      // Back-pointer to this declaration.  It shall be set at
+      // the declaration creation.
+      const ipr::Decl* decl = { };
+   };
+
+                              // -- impl::decl_sequence --
+   struct decl_sequence : ref_sequence<ipr::Decl> { };
+
+                              // -- impl::singleton_declset --
+   // A singleton_declset is a specialization of decl_sequence
+   // that contains only a single declaration.  It is mostly used
+   // to support the general interface of ipr::Scope as inherited
+   // in parameter-list or enumerator definitions.
+
+   template<class T>
+   struct singleton_declset : ipr::Sequence<ipr::Decl> {
+      using Index = typename Sequence<ipr::Decl>::Index;
+      const T& datum;
+
+      explicit singleton_declset(const T& t) : datum(t) { }
+
+      Index size() const final { return 1; }
+      const T& get(Index i) const final
+      {
+         if (i == 0)
+            return datum;
+         throw std::domain_error("singleton_declset::get");
+      }
+   };
+
+   // Parameters, base-subobjects and enumerations cannot be
+   // multiply declared in a given region.  Therefore such a
+   // declaration is the sole member in its own decl-set.
+   // Furthermore, there cannot be other declaration with
+   // different type but same name.  Therefore the name for
+   // such a declaration defines an overload set with a single
+   // member.  This class implements such a special overload set.
+   struct singleton_overload : impl::Node<ipr::Overload> {
+      singleton_declset<ipr::Decl> seq;
+
+      explicit singleton_overload(const ipr::Decl&);
+
+      const ipr::Type& type() const final;
+      Optional<ipr::Decl> operator[](const ipr::Type&) const final;
+   };
+}
+
+namespace ipr::impl {
+   // Scopes, as expressions, have Product types.  Such types could
+   // be implemented directly as a separate sequence of types.
+   // However, it would require coordination from the various
+   // scope updaters to keep the types in sync.  An alternative,
+   // implemented by typed_sequence<Seq>, is to wrap sequences
+   // in "type envelop" and return the nth type as being the
+   // type of the nth declaration in the sequence.
+   template<class Seq>
+   struct typed_sequence : impl::Type<ipr::Product>,
+                           ipr::Sequence<ipr::Type> {
+      using Index = typename Sequence<ipr::Type>::Index;
+      Seq seq;
+
+      typed_sequence() { }
+      explicit typed_sequence(const Seq& s) : seq(s) { }
+      const ipr::Sequence<ipr::Type>& operand() const final
+      {
+         return *this;
+      }
+      Index size() const final { return seq.size(); }
+      const ipr::Type& get(Index i) const final
+      {
+         return seq.get(i).type();
+      }
+   };
+}
+
+namespace ipr::impl {
+   // -- homogeneous_scope
+   // A sequence of homogenous node can be represented directly as a container
+   // of the concrete implementations classes instead of pointers to the 
+   // interface nodes.  This is the case, in particular, for enumerators of 
+   // an enumeration or parameters in a parameter list.
+   template<typename Member>
+   struct homogeneous_scope : impl::Node<ipr::Scope>,
+                              ipr::Sequence<ipr::Decl>,
+                              ipr::Sequence<ipr::Expr> {
+      using Index = typename ipr::Sequence<ipr::Decl>::Index;
+      typed_sequence<val_sequence<Member>> decls;
+
+      Index size() const final { return decls.size(); }
+      const Member& get(Index i) const final { return decls.seq.get(i); }
+      const ipr::Product& type() const final { return decls; }
+      const ipr::Sequence<ipr::Decl>& elements() const final { return *this; }
+      Optional<ipr::Overload> operator[](const Name&) const final;
+      template<typename... Args>
+      Member* push_back(const Args&... args)
+      {
+         return decls.seq.push_back(args...);
+      }
+   };
+
+   // FIXME: Remove this linear search.
+   template<class Member>
+   Optional<ipr::Overload>
+   homogeneous_scope<Member>::operator[](const ipr::Name& n) const
+   {
+      const auto s = decls.size();
+      for (Index i = 0; i < s; ++i) {
+         const auto& decl = decls.seq.get(i);
+         if (&decl.name() == &n)
+            return { &decl.overload };
       }
 
-      template<class Member,
-               class RegionKind = Node<ipr::Region>>
-      struct homogeneous_region : RegionKind {
-         using location_span = ipr::Region::Location_span;
-         using Index = typename Sequence<Member>::Index;
-         const ipr::Region& parent;
-         location_span extent;
-         Optional<ipr::Expr> owned_by { };
-         homogeneous_scope<Member> scope;
-
-         const ipr::Region& enclosing() const final { return parent; }
-         const ipr::Sequence<ipr::Expr>& body() const final { return scope; }
-         const ipr::Scope& bindings() const final { return scope; }
-         const location_span& span() const final { return extent; }
-         const ipr::Expr& owner() const final { return owned_by.get(); }
-         bool global() const final { return false; }
-
-         explicit homogeneous_region(const ipr::Region& p)
-               : parent(p)
-         { }
-      };
-
-      struct Parameter_list : impl::Node<ipr::Parameter_list> {
-         homogeneous_region<impl::Parameter> parms;
-         const Mapping_level nesting;
-
-         Parameter_list(const ipr::Region&, Mapping_level);
-         const ipr::Product& type() const final;
-         const ipr::Region& region() const final;
-         Mapping_level level() const final { return nesting; }
-         const ipr::Sequence<ipr::Parameter>& elements() const final;
-
-         impl::Parameter* add_member(const ipr::Name&, const impl::Rname&);
-      };
-
-      template<typename T>
-      struct decl_rep : T {
-         using Interface = typename T::Interface;
-         decl_rep(master_decl_data<Interface>* mdd)
-         {
-            this->decl_data.master_data = mdd;
-            this->decl_data.decl = this;
-            mdd->declset.push_back(this);
-         }
-
-         const ipr::Name& name() const final
-         {
-            return this->decl_data.master_data->overload->name;
-         }
-
-         ipr::DeclSpecifiers specifiers() const final
-         {
-            return this->decl_data.spec;
-         }
-
-         const ipr::Type& type() const final
-         {
-            return this->decl_data.master_data->type;
-         }
-
-         const ipr::Scope& scope() const
-         {
-            return this->decl_data.master_data->overload->where;
-         }
-
-         Decl_position position() const
-         {
-            return this->decl_data.scope_pos;
-         }
-
-         const ipr::Decl& master() const
-         {
-            return *util::check(this->decl_data.master_data->decl);
-         }
-
-         const ipr::Sequence<ipr::Decl>& decl_set() const
-         {
-            return this->decl_data.master_data->declset;
-         }
-
-         Optional<Interface> definition() const
-         {
-            return this->decl_data.master_data->def;
-         }
-      };
-
-
-      using Array = Binary_type<ipr::Array>;
-      using Decltype = Unary_type<ipr::Decltype>;
-      using As_type = Binary_type<ipr::As_type>;
-      using Tor = Ternary_type<ipr::Tor>;
-      using Function = Quaternary<Type<ipr::Function>>;
-      using Pointer = Unary_type<ipr::Pointer>;
-      using Product = Unary_type<ipr::Product>;
-      using Ptr_to_member = Binary_type<ipr::Ptr_to_member>;
-      using Qualified = Binary_type<ipr::Qualified>;
-      using Reference = Unary_type<ipr::Reference>;
-      using Rvalue_reference = Unary_type<ipr::Rvalue_reference>;
-      using Sum = Unary_type<ipr::Sum>;
-      using Forall = Binary_type<ipr::Forall>;
-
-      using Comment = Unary_node<Comment>;
-
-      using Identifier = Unary_node<ipr::Identifier>;
-      using Suffix = Unary_node<ipr::Suffix>;
-      using Operator = Unary_node<ipr::Operator>;
-      using Conversion = Unary_node<ipr::Conversion>;
-      using Ctor_name = Unary_node<ipr::Ctor_name>;
-      using Dtor_name = Unary_node<ipr::Dtor_name>;
-      using Guide_name = Unary_node<ipr::Guide_name>;
-      using Type_id = Unary_node<ipr::Type_id>;
-
-      using Phantom = Expr<ipr::Phantom>;
-      using Eclipsis = Expr<ipr::Eclipsis>;
-
-      struct This : impl::Expr<ipr::This> {
-         Optional<ipr::Decl> owner;
-         Optional<ipr::Decl> context() const final { return owner; }
-      };
-
-      struct Symbol final : Unary_expr<ipr::Symbol> {
-         explicit Symbol(const ipr::Name&);
-         Symbol(const ipr::Name&, const ipr::Type&);
-      };
-
-      struct Lambda : impl::Node<ipr::Lambda> {
-         util::ref<const ipr::Closure> constraint;
-         Optional<ipr::Type> value_type;
-         impl::Parameter_list parms;
-         util::ref<const ipr::Expr> body;
-         Optional<ipr::Expr> decl_constraint;
-         impl::ref_sequence<ipr::Attribute> attrs;
-         impl::ref_sequence<ipr::Capture_specification> env_spec;
-         Optional<ipr::Expr> eh;
-         Lambda_specifiers lam_spec;
-
-         Lambda(const ipr::Region&, Mapping_level);
-         const ipr::Closure& type() const final { return constraint.get(); }
-         Optional<ipr::Type> target() const final { return value_type; }
-         const ipr::Parameter_list& parameters() const final { return parms; }
-         Optional<ipr::Expr> requirement() const final { return decl_constraint; }
-         const ipr::Expr& result() const final { return body.get(); }
-         const ipr::Sequence<ipr::Attribute>& attributes() const final { return attrs; }
-         Optional<ipr::Expr> eh_specification() const final { return eh; }
-         Lambda_specifiers specifiers() const final { return lam_spec; }
-         const ipr::Sequence<ipr::Capture_specification>& captures() const final { return env_spec; }
-      };
-
-      using Address = Classic_unary_expr<ipr::Address>;
-      using Array_delete = Classic_unary_expr<ipr::Array_delete>;
-      using Complement = Classic_unary_expr<ipr::Complement>;
-      using Delete = Classic_unary_expr<ipr::Delete>;
-      using Demotion = Unary_expr<ipr::Demotion>;
-      using Deref = Classic_unary_expr<ipr::Deref>;
-
-      struct Expr_list : impl::Node<ipr::Expr_list> {
-         typed_sequence<ref_sequence<ipr::Expr>> seq;
-
-         Expr_list();
-         explicit Expr_list(const ref_sequence<ipr::Expr>&);
-
-         const ipr::Product& type() const final;
-
-         const ipr::Sequence<ipr::Expr>& operand() const final;
-
-         void push_back(const ipr::Expr* e) { seq.seq.push_back(e); }
-      };
-
-      using Alignof = Unary_expr<ipr::Alignof>;
-      using Sizeof = Unary_expr<ipr::Sizeof>;
-      using Args_cardinality = Unary_expr<ipr::Args_cardinality>;
-      using Typeid = Unary_expr<ipr::Typeid>;
-      using Label = Unary_expr<ipr::Label>;
-
-      struct Id_expr : Unary_expr<ipr::Id_expr> {
-         Optional<ipr::Expr> decls { };
-
-         explicit Id_expr(const ipr::Name&);
-         Optional<ipr::Expr> resolution() const final;
-      };
-
-      using Materialization = Unary_expr<ipr::Materialization>;
-      using Not = Classic_unary_expr<ipr::Not>;
-
-      struct Enclosure : impl::Unary_expr<ipr::Enclosure> {
-         Enclosure(ipr::Delimiter, const ipr::Expr&);
-         Delimiter delimiters() const final { return delim; }
-      private:
-         Delimiter delim;
-      };
-
-      using Pre_decrement = Classic_unary_expr<ipr::Pre_decrement>;
-      using Pre_increment = Classic_unary_expr<ipr::Pre_increment>;
-      using Post_decrement = Classic_unary_expr<ipr::Post_decrement>;
-      using Post_increment = Classic_unary_expr<ipr::Post_increment>;
-      using Promotion = Unary_expr<ipr::Promotion>;
-      using Read = Unary_expr<ipr::Read>;
-      using Throw = Classic_unary_expr<ipr::Throw>;
-
-      using Unary_minus = Classic_unary_expr<ipr::Unary_minus>;
-      using Unary_plus = Classic_unary_expr<ipr::Unary_plus>;
-      using Expansion = Classic_unary_expr<ipr::Expansion>;
-      using Construction = Classic_unary_expr<ipr::Construction>;
-      using Noexcept = Unary_expr<ipr::Noexcept>;
-
-      using Rewrite = Binary_node<ipr::Rewrite>;
-      using And = Classic_binary_expr<ipr::And>;
-      using Annotation = Binary_node<ipr::Annotation>;
-      using Array_ref = Classic_binary_expr<ipr::Array_ref>;
-      using Arrow = Classic_binary_expr<ipr::Arrow>;
-      using Arrow_star = Classic_binary_expr<ipr::Arrow_star>;
-      using Assign = Classic_binary_expr<ipr::Assign>;
-      using Bitand = Classic_binary_expr<ipr::Bitand>;
-      using Bitand_assign = Classic_binary_expr<ipr::Bitand_assign>;
-      using Bitor = Classic_binary_expr<ipr::Bitor>;
-      using Bitor_assign = Classic_binary_expr<ipr::Bitor_assign>;
-      using Bitxor = Classic_binary_expr<ipr::Bitxor>;
-      using Bitxor_assign = Classic_binary_expr<ipr::Bitxor_assign>;
-      using Call = Classic_binary_expr<ipr::Call>;
-      using Cast = Conversion_expr<ipr::Cast>;
-      using Coercion = Classic_binary_expr<ipr::Coercion>;
-      using Comma = Classic_binary_expr<ipr::Comma>;
-      using Const_cast = Conversion_expr<ipr::Const_cast>;
-      using Div = Classic_binary_expr<ipr::Div>;
-      using Div_assign = Classic_binary_expr<ipr::Div_assign>;
-      using Dot = Classic_binary_expr<ipr::Dot>;
-      using Dot_star = Classic_binary_expr<ipr::Dot_star>;
-      using Dynamic_cast = Conversion_expr<ipr::Dynamic_cast>;
-      using Equal = Classic_binary_expr<ipr::Equal>;
-      using Greater = Classic_binary_expr<ipr::Greater>;
-      using Greater_equal = Classic_binary_expr<ipr::Greater_equal>;
-      using Less = Classic_binary_expr<ipr::Less>;
-      using Less_equal = Classic_binary_expr<ipr::Less_equal>;
-      using Literal = Conversion_expr<ipr::Literal>;
-      using Lshift = Classic_binary_expr<ipr::Lshift>;
-      using Lshift_assign = Classic_binary_expr<ipr::Lshift_assign>;
-
-      struct Mapping : impl::Expr<ipr::Mapping> {
-         impl::Parameter_list parms;
-         util::ref<const ipr::Type> value_type;
-         util::ref<const ipr::Expr> body;
-
-         Mapping(const ipr::Region&, Mapping_level);
-         const ipr::Parameter_list& parameters() const final { return parms; }
-         const ipr::Type& target() const final { return value_type.get(); }
-         const ipr::Expr& result() const final { return body.get(); }
-         impl::Parameter* param(const ipr::Name&, const impl::Rname&);
-      };
-
-      using Member_init = Binary_expr<ipr::Member_init>;
-      using Minus = Classic_binary_expr<ipr::Minus>;
-      using Minus_assign = Classic_binary_expr<ipr::Minus_assign>;
-      using Modulo = Classic_binary_expr<ipr::Modulo>;
-      using Modulo_assign = Classic_binary_expr<ipr::Modulo_assign>;
-      using Mul = Classic_binary_expr<ipr::Mul>;
-      using Mul_assign = Classic_binary_expr<ipr::Mul_assign>;
-      using Narrow = Binary_expr<ipr::Narrow>;
-      using Not_equal = Classic_binary_expr<ipr::Not_equal>;
-      using Or = Classic_binary_expr<ipr::Or>;
-      using Plus = Classic_binary_expr<ipr::Plus>;
-      using Plus_assign = Classic_binary_expr<ipr::Plus_assign>;
-      using Pretend = Binary_expr<ipr::Pretend>;
-      using Qualification = Binary_expr<ipr::Qualification>;
-      using Reinterpret_cast = Conversion_expr<ipr::Reinterpret_cast>;
-      using Rshift = Classic_binary_expr<ipr::Rshift>;
-      using Rshift_assign = Classic_binary_expr<ipr::Rshift_assign>;
-      using Scope_ref = Classic_binary_expr<ipr::Scope_ref>;
-      using Static_cast = Conversion_expr<ipr::Static_cast>;
-      using Template_id = Binary_node<ipr::Template_id>;
-      using Widen = Binary_expr<ipr::Widen>;
-      // A Where node where the attendant() is not a scope.
-      using Where_no_decl = Binary_node<ipr::Where>;
-
-      struct Binary_fold : Classic_binary_expr<ipr::Binary_fold> {
-         Category_code fold_op;
-
-         Binary_fold(Category_code, const ipr::Expr&, const ipr::Expr&);
-         Category_code operation() const final;
-      };
-
-      struct New : impl::Classic_binary_expr<ipr::New> {
-         bool global = false;
-
-         New(Optional<ipr::Expr_list>, const ipr::Construction&);
-         bool global_requested() const final;
-      };
-
-      using Conditional = Ternary<Classic<Expr<ipr::Conditional>>>;
-
-      struct Template : impl::Decl<ipr::Template> {
-         util::ref<impl::Mapping> init;
-         util::ref<const ipr::Region> lexreg;
-         impl::Expr_list args;
-
-         Template();
-         const ipr::Template& primary_template() const final;
-         const ipr::Sequence<ipr::Decl>& specializations() const final;
-         const ipr::Mapping& mapping() const final { return init.get(); }
-         // FIXME: The initializer should actually be the mapping, since a Template is a
-         //        *named* mapping.  In Classic IPR, and in the current incarnation, the initializer 
-         //        is the initializer of the current instantiation.
-         Optional<ipr::Expr> initializer() const final { return { &mapping().result() }; }
-         const ipr::Region& lexical_region() const final { return lexreg.get(); }
-      };
-
-      template<typename T>
-      struct decl_factory {
-         using Interface = typename T::Interface;
-         stable_farm<decl_rep<T>> decls;
-         stable_farm<master_decl_data<Interface>> master_info;
-
-         // We have gotten an overload-set for a name, and we are about
-         // to enter the first declaration for that name with the type T.
-         decl_rep<T>* declare(Overload* ovl, const ipr::Type& t)
-         {
-            // Grab bookkeeping memory for this master declaration.
-            master_decl_data<Interface>* data = master_info.make(ovl, t);
-            // The actual representation for the declaration points back
-            // to the master declaration bookkeeping store.
-            decl_rep<T>* master = decls.make(data);
-            // Inform the overload-set that we have a new master declaration.
-            ovl->push_back(data);
-
-            return master;
-         }
-
-         decl_rep<T>* redeclare(overload_entry* decl)
-         {
-            return decls.make
-               (static_cast<master_decl_data<Interface>*>(decl));
-         }
-      };
-
-
-      struct Alias : impl::Decl<ipr::Alias> {
-         const ipr::Expr* aliasee;
-
-         Alias();
-         Optional<ipr::Expr> initializer() const final { return aliasee; }
-      };
-
-      struct Var : impl::Decl<ipr::Var> {
-         Optional<ipr::Expr> init;
-         util::ref<const ipr::Region> lexreg;
-
-         Var();
-         Optional<ipr::Expr> initializer() const final { return init; }
-         const ipr::Region& lexical_region() const final { return lexreg.get(); }
-      };
-
-      // FIXME: Field should use unique_decl, not impl::Decl.
-      struct Field : impl::Decl<ipr::Field> {
-         Optional<ipr::Expr> init;
-
-         Field();
-         Optional<ipr::Expr> initializer() const final { return init; }
-      };
-
-      // FIXME: Bitfield should use unique_decl, not impl::Decl
-      struct Bitfield : impl::Decl<ipr::Bitfield> {
-         util::ref<const ipr::Expr> length;
-         Optional<ipr::Expr> init;
-
-         Bitfield();
-         const ipr::Expr& precision() const final { return length.get(); }
-         Optional<ipr::Expr> initializer() const final { return init; }
-      };
-
-      struct Typedecl : impl::Decl<ipr::Typedecl> {
-         Optional<ipr::Type> init;
-         util::ref<const ipr::Region> lexreg;
-
-         Typedecl();
-         Optional<ipr::Expr> initializer() const final { return init; }
-         const ipr::Region& lexical_region() const final { return lexreg.get(); }
-      };
-
-      // For a non-defining function declaration, the parameters - if any is named
-      // or has a default argument - are stored with that particular declaration.
-      // A function definition is one that specifies the initializer (Mapping) which
-      // already has room for the named parameters or the default arguments.
-      struct fundecl_data : std::variant<impl::Parameter_list*, impl::Mapping*> {
-         impl::Parameter_list* parameters() const { return std::get<0>(*this); }
-         impl::Mapping* mapping() const { return std::get<1>(*this); }
-      };
-
-      struct Fundecl : impl::Decl<ipr::Fundecl> {
-         fundecl_data data;
-         util::ref<const ipr::Region> lexreg;
-
-         Fundecl();
-
-         const ipr::Parameter_list& parameters() const final;
-         Optional<ipr::Mapping> mapping() const final;
-         Optional<ipr::Expr> initializer() const final;
-         const ipr::Region& lexical_region() const final { return lexreg.get(); }
-      };
-
-      // A heterogeneous scope is a sequence of declarations of
-      // almost of kinds.  The omitted kinds being parameters,
-      // base-class subobjects and enumerators.   Those form
-      // a homogeneous scope, implemented by homogeneous_scope.
-
-      struct Scope : impl::Node<ipr::Scope> {
-         Scope();
-         const ipr::Type& type() const final { return decls; }
-         const ipr::Sequence<ipr::Decl>& elements() const final { return decls.seq; }
-         Optional<ipr::Overload> operator[](const ipr::Name&) const final;
-
-         impl::Alias* make_alias(const ipr::Name&, const ipr::Expr&);
-         impl::Var* make_var(const ipr::Name&, const ipr::Type&);
-         impl::Field* make_field(const ipr::Name&, const ipr::Type&);
-         impl::Bitfield* make_bitfield(const ipr::Name&, const ipr::Type&);
-         impl::Typedecl* make_typedecl(const ipr::Name&, const ipr::Type&);
-         impl::Fundecl* make_fundecl(const ipr::Name&, const ipr::Function&);
-         impl::Template* make_primary_template(const ipr::Name&, const ipr::Forall&);
-         impl::Template* make_secondary_template(const ipr::Name&, const ipr::Forall&);
-
-      private:
-         util::rb_tree::container<impl::Overload> overloads;
-         typed_sequence<decl_sequence> decls;
-         decl_factory<impl::Alias> aliases;
-         decl_factory<impl::Var> vars;
-         decl_factory<impl::Field> fields;
-         decl_factory<impl::Bitfield> bitfields;
-         decl_factory<impl::Fundecl> fundecls;
-         decl_factory<impl::Typedecl> typedecls;
-         decl_factory<impl::Template> primary_maps;
-         decl_factory<impl::Template> secondary_maps;
-
-         template<class T> inline void add_member(T*);
-      };
-
-
-      // A heterogeneous region is a region of program text that
-      // contains heterogeneous scope (as defined above).
-
-      struct Region : impl::Node<ipr::Region> {
-         using location_span = ipr::Region::Location_span;
-         Optional<ipr::Region> parent;
-         location_span extent;
-         util::ref<const ipr::Expr> owned_by;
-         impl::Scope scope;
-         impl::ref_sequence<ipr::Expr> expr_seq;         // all the expressions making up the body.
-
-         const ipr::Region& enclosing() const final { return parent.get(); }
-         const ipr::Sequence<ipr::Expr>& body() const final { return expr_seq; }
-         const ipr::Scope& bindings() const final { return scope; }
-         const location_span& span() const final { return extent; }
-         const ipr::Expr& owner() const final { return owned_by.get(); }
-         bool global() const final { return not parent.is_valid(); }
-
-         impl::Region* make_subregion();
-
-         // Convenient functions, forwarding to those of SCOPE.
-         impl::Alias* declare_alias(const ipr::Name& n, const ipr::Type& t)
-         {
-            return scope.make_alias(n, t);
-         }
-
-         impl::Var* declare_var(const ipr::Name& n, const ipr::Type& t)
-         {
-            return scope.make_var(n, t);
-         }
-
-         impl::Field* declare_field(const ipr::Name& n, const ipr::Type& t)
-         {
-            return scope.make_field(n, t);
-         }
-
-         impl::Bitfield* declare_bitfield(const ipr::Name& n,
-                                          const ipr::Type& t)
-         {
-            return scope.make_bitfield(n, t);
-         }
-
-         Typedecl* declare_type(const ipr::Name& n, const ipr::Type& t)
-         {
-            return scope.make_typedecl(n, t);
-         }
-
-         Fundecl* declare_fun(const ipr::Name& n, const ipr::Function& t)
-         {
-            return scope.make_fundecl(n, t);
-         }
-
-         Template* declare_primary_template(const ipr::Name& n, const ipr::Forall& t)
-         {
-            return scope.make_primary_template(n, t);
-         }
-
-         Template* declare_secondary_template(const ipr::Name& n, const ipr::Forall& t)
-         {
-            return scope.make_secondary_template(n, t);
-         }
-
-         explicit Region(Optional<ipr::Region>);
-
-      private:
-         stable_farm<Region> subregions;
-      };
-
-
-      // Implement common operations for user-defined types.  The case
-      // of enums is handled separately because its body is a
-      // homogeneous region.
-
-      template<class Interface>
-      struct Udt : impl::Type<Interface> {
-         Region body;
-         Udt(const ipr::Region* pr, const ipr::Type& t) : body(pr)
-         {
-            this->constraint = &t;
-            body.owned_by = this;
-         }
-
-         const ipr::Region& region() const final { return body; }
-
-         impl::Alias*
-         declare_alias(const ipr::Name& n, const ipr::Type& t)
-         {
-            impl::Alias* alias = body.declare_alias(n, t);
-            return alias;
-         }
-
-         impl::Field*
-         declare_field(const ipr::Name& n, const ipr::Type& t)
-         {
-            impl::Field* field = body.declare_field(n, t);
-            return field;
-         }
-
-         impl::Bitfield*
-         declare_bitfield(const ipr::Name& n, const ipr::Type& t)
-         {
-            impl::Bitfield* field = body.declare_bitfield(n, t);
-            return field;
-         }
-
-         impl::Var*
-         declare_var(const ipr::Name& n, const ipr::Type& t)
-         {
-            impl::Var* var = body.declare_var(n, t);
-            return var;
-         }
-
-         impl::Typedecl*
-         declare_type(const ipr::Name& n, const ipr::Type& t)
-         {
-            impl::Typedecl* typedecl = body.declare_type(n, t);
-            return typedecl;
-         }
-
-         impl::Fundecl*
-         declare_fun(const ipr::Name& n, const ipr::Function& t)
-         {
-            impl::Fundecl* fundecl = body.declare_fun(n, t);
-            return fundecl;
-         }
-
-         impl::Template*
-         declare_primary_template(const ipr::Name& n, const ipr::Forall& t)
-         {
-            impl::Template* map = body.declare_primary_template(n, t);
-            return map;
-         }
-
-         impl::Template*
-         declare_secondary_template(const ipr::Name& n, const ipr::Forall& t)
-         {
-            impl::Template* map = body.declare_secondary_template(n, t);
-            return map;
-         }
-      };
-
-      struct Enum : impl::Type<ipr::Enum> {
-         homogeneous_region<impl::Enumerator> body;
-         const Kind enum_kind;
-
-         const ipr::Region& region() const final;
-         const Sequence<ipr::Enumerator>& members() const final;
-         Kind kind() const final;
-         impl::Enumerator* add_member(const ipr::Name&);
-
-         Enum(const ipr::Region&, Kind);
-      };
-
-      using Union = Udt<ipr::Union>;
-      using Namespace = Udt<ipr::Namespace>;
-
-      struct Class : impl::Udt<ipr::Class> {
-         homogeneous_region<impl::Base_type> base_subobjects;
-
-         Class(const ipr::Region&, const ipr::Type&);
-
-         const ipr::Sequence<ipr::Base_type>& bases() const final;
-         impl::Base_type* declare_base(const ipr::Type&);
-
-      };
-
-      struct Auto : impl::Type<ipr::Auto> {
-      };
-
-      struct Closure : impl::Udt<ipr::Closure> {
-         impl::val_sequence<impl::Capture> captures;
-
-         Closure(const ipr::Region&, const ipr::Type&);
-         const ipr::Sequence<ipr::Capture>& members() const final { return captures; }
-      };
-
-      // This class is responsible for creating nodes that
-      // represent types.  It is responsible for the storage
-      // management that is implied.  Notice that the type nodes
-      // created by this class may need additional processing such
-      // as setting their types (as expressions) and their names.
-
-      struct type_factory {
-         // Build an IPR node for an expression that denotes a type.
-         // The linkage, if not specified, is assumed to be C++.
-         impl::As_type* make_as_type(const ipr::Expr&);
-         impl::As_type* make_as_type(const ipr::Expr&, const ipr::Linkage&);
-
-         impl::Array* make_array(const ipr::Type&, const ipr::Expr&);
-         impl::Qualified* make_qualified(ipr::Type_qualifier,
-                                         const ipr::Type&);
-         impl::Decltype* make_decltype(const ipr::Expr&);
-         impl::Tor* make_tor(const ipr::Product&, const ipr::Sum&, const ipr::Linkage&);
-         impl::Function* make_function(const ipr::Product&, const ipr::Type&,
-                                       const ipr::Sum&, const ipr::Linkage&);
-         impl::Pointer* make_pointer(const ipr::Type&);
-         impl::Product* make_product(const ipr::Sequence<ipr::Type>&);
-         impl::Ptr_to_member* make_ptr_to_member(const ipr::Type&,
-                                                 const ipr::Type&);
-         impl::Reference* make_reference(const ipr::Type&);
-         impl::Rvalue_reference* make_rvalue_reference(const ipr::Type&);
-         impl::Sum* make_sum(const ipr::Sequence<ipr::Type>&);
-         impl::Forall* make_forall(const ipr::Product&, const ipr::Type&);
-
-         impl::Enum* make_enum(const ipr::Region&, Enum::Kind);
-         impl::Class* make_class(const ipr::Region&, const ipr::Type&);
-         impl::Union* make_union(const ipr::Region&, const ipr::Type&);
-         impl::Namespace* make_namespace(const ipr::Region*, const ipr::Type&);
-         impl::Closure* make_closure(const ipr::Region&, const ipr::Type&);
-      private:
-         util::rb_tree::container<impl::Array> arrays;
-         util::rb_tree::container<impl::As_type> type_refs;
-         util::rb_tree::container<impl::Tor> tors;
-         util::rb_tree::container<impl::Function> functions;
-         util::rb_tree::container<impl::Pointer> pointers;
-         util::rb_tree::container<impl::Product> products;
-         util::rb_tree::container<impl::Ptr_to_member> member_ptrs;
-         util::rb_tree::container<impl::Qualified> qualifieds;
-         util::rb_tree::container<impl::Reference> references;
-         util::rb_tree::container<impl::Rvalue_reference> refrefs;
-         util::rb_tree::container<impl::Sum> sums;
-         util::rb_tree::container<impl::Forall> foralls;
-         stable_farm<impl::Decltype> decltypes;
-         stable_farm<impl::Enum> enums;
-         stable_farm<impl::Class> classes;
-         stable_farm<impl::Union> unions;
-         stable_farm<impl::Namespace> namespaces;
-         stable_farm<impl::Closure> closures;
-      };
-
-      // -- Implementation of directives --
-      struct Asm : impl::Directive<ipr::Asm, Phases::Code_generation> {
-         explicit Asm(const ipr::String&);
-         const ipr::String& text() const final { return txt; }
-      private:
-         const ipr::String& txt;
-      };
-
-      struct Static_assert : impl::Directive<ipr::Static_assert, Phases::Elaboration> {
-         Static_assert(const ipr::Expr&, Optional<ipr::String>);
-         const ipr::Expr& condition() const final { return cond; }
-         Optional<ipr::String> message() const final { return txt; }
-      private:
-         const ipr::Expr& cond;
-         Optional<ipr::String> txt;
-      };
-
-      struct Structured_binding : impl::Directive<ipr::Structured_binding, Phases::Elaboration> {
-         impl::ref_sequence<ipr::Identifier> ids;           // names in this structured binding
-         util::ref<const ipr::Expr> init;                   // initializer of this structured binding
-         impl::ref_sequence<ipr::Decl> decl_seq;            // declarations resulting from this structured binding
-         ipr::DeclSpecifiers specs;                         // the non-type part of decl-specifier-seq in 
-                                                            // this structured binding.  Note: `type()` contains the
-                                                            // the type part of the decl-specifier-seq
-         ipr::Binding_mode binding_mode;                    // the binding mode of this structured binding
-
-         ipr::DeclSpecifiers specifiers() const final { return specs; }
-         ipr::Binding_mode mode() const final { return binding_mode; }
-         const ipr::Sequence<ipr::Identifier>& names() const final { return ids; }
-         const ipr::Expr& initializer() const final { return init.get(); }
-         const ipr::Sequence<ipr::Decl>& bindings() const final { return decl_seq; }
-      };
-
-      // Implementation of ipr::Using_declaration in case where using-declarator-list is a singleton.
-      struct single_using_declaration : impl::Directive<ipr::Using_declaration, Phases::Elaboration> {
-         single_using_declaration(const ipr::Scope_ref&, Designator::Mode);
-         const ipr::Sequence<Designator>& designators() const final { return what; }
-      private:
-         singleton<Designator> what;
-      };
-
-      struct Using_declaration : impl::Directive<ipr::Using_declaration, Phases::Elaboration> {
-         impl::val_sequence<Designator> seq;
-
-         const ipr::Sequence<Designator>& designators() const final { return seq; }
-      };
-
-      struct Using_directive : impl::Directive<ipr::Using_directive, Phases::Elaboration> {
-         explicit Using_directive(const ipr::Scope&);
-         const ipr::Scope& nominated_scope() const final { return scope; }
-      private:
-         const ipr::Scope& scope;
-      };
-
-      struct Pragma : impl::Directive<ipr::Pragma, Phases::All> {
-         val_sequence<impl::Token> tokens;
-         const ipr::Sequence<ipr::Token>& operand() const final { return tokens; }
-      };
-
-      // ----------------------------------
-      // -- Implementation of statements --
-      // ----------------------------------
-
-      using Ctor_body = Binary<Stmt<Expr<ipr::Ctor_body>>>;
-      using Do = Controlled_stmt<ipr::Do>;
-      using Expr_stmt = type_from_operand<Stmt<ipr::Expr_stmt>>;
-      using Empty_stmt = type_from_operand<Stmt<ipr::Empty_stmt>>;
-      using Goto = type_from_operand<Stmt<ipr::Goto>>;
-      using Handler = type_from_second<Stmt<ipr::Handler>>;
-      using If = Ternary<Stmt<Expr<ipr::If>>>;
-      using Labeled_stmt = type_from_second<Stmt<ipr::Labeled_stmt>>;
-      using Return = type_from_operand<Stmt<ipr::Return>>;
-      using Switch = Controlled_stmt<ipr::Switch>;
-      using While = Controlled_stmt<ipr::While>;
-
-      // A Block holds a heterogeneous region, suitable for
-      // recording the set of declarations appearing in that
-      // block.  It also holds a sequence of handlers, when the
-      // block actually represents a C++ try-block.
-      struct Block : impl::Stmt<Expr<ipr::Block>> {
-         impl::Region lexical_region;
-         impl::ref_sequence<ipr::Handler> handler_seq;
-
-         explicit Block(const ipr::Region&);
-         const ipr::Region& region() const final { return lexical_region; }
-         const ipr::Sequence<ipr::Handler>& handlers() const final { return handler_seq; }
-
-         // The scope of declarations in this block
-         impl::Scope* scope() { return &lexical_region.scope; }
-
-         void add_stmt(const ipr::Expr& s)
-         {
-            lexical_region.expr_seq.push_back(&s);
-         }
-
-         void add_handler(const ipr::Handler& h)
-         {
-            handler_seq.push_back(&h);
-         }
-      };
-
-
-      // A for-statement node in its most general form is a quaternry
-      // expresion; for flexibility, it is made in a way that
-      // supports settings of its components after construction.
-
-      struct For : impl::Stmt<impl::Node<ipr::For>> {
-         util::ref<const ipr::Expr> init;
-         util::ref<const ipr::Expr> cond;
-         util::ref<const ipr::Expr> inc;
-         util::ref<const ipr::Stmt> stmt;
-
-         For();
-         const ipr::Type& type() const final { return body().type(); }
-         const ipr::Expr& initializer() const final { return init.get(); }
-         const ipr::Expr& condition() const final { return cond.get(); }
-         const ipr::Expr& increment() const final { return inc.get(); }
-         const ipr::Stmt& body() const final { return stmt.get(); }
-      };
-
-      struct For_in : impl::Stmt<impl::Node<ipr::For_in>> {
-         util::ref<const ipr::Var> var;
-         util::ref<const ipr::Expr> seq;
-         util::ref<const ipr::Stmt> stmt;
-
-         For_in();
-         const ipr::Type& type() const final { return body().type(); }
-         const ipr::Var& variable() const final { return var.get(); }
-         const ipr::Expr& sequence() const final { return seq.get(); }
-         const ipr::Stmt& body() const final { return stmt.get(); }
-      };
-
-
-      // A Break node can record the selction- of iteration-statement it
-      // transfers control out of.
-
-      struct Break : Stmt<Expr<ipr::Break>> {
-         util::ref<const ipr::Stmt> stmt;
-
-         Break();
-         const ipr::Stmt& from() const final { return stmt.get(); }
-      };
-
-      // Like a Break, a Continue node can refer back to the
-      // iteration-statement containing it.
-      struct Continue : Stmt<Expr<ipr::Continue>> {
-         util::ref<const ipr::Stmt> stmt;
-
-         Continue();
-         const ipr::Stmt& iteration() const final { return stmt.get(); }
-      };
-
-      // This template will be instantiated to implementations
-      // of several builtin type singletons.  It does not reuse
-      // implementations of Type, and Binary, to save space since
-      // most data needed by those implementations are shared.
-      template<class T>
-      struct Builtin : impl::Expr<T> {
-         using Arg1_type = typename T::Arg1_type;
-         using Arg2_type = typename T::Arg2_type;
-         Builtin(const ipr::Name& n, Arg2_type l, const ipr::Type& t)
-               : impl::Expr<T>(&t), id(n), link(l) { }
-
-         const ipr::Name& name() const final { return id; }
-         Arg1_type first() const final { return *this; }
-         Arg2_type second() const final { return link; }
-
-      private:
-         const ipr::Name& id;
-         Arg2_type link;
-      };
-
-      // Type of `Where`-nodes introducing declarations in their `attendant()` expressions.
-      // Note: See impl::Where_no_decls for the degenerated case where the `attendant()`
-      //       is just a classic expression, with no declaration introduced.
-      struct Where : impl::Node<ipr::Where> {
-         impl::Region region;                            // hosts the declarations in the `attendant()`.
-         util::ref<const ipr::Expr> result;              // the `main()` expression.
-
-         explicit Where(const ipr::Region&);
-         const ipr::Expr& first() const final { return result.get(); }
-         const ipr::Scope& second() const final { return region.bindings(); }
-      };
-
-      struct expr_factory {
-         // Returns an IPR node for unified string literals.
-         const ipr::String& get_string(util::word_view);
-
-         // Returns an IPR node a language linkage.
-         const ipr::Linkage& get_linkage(util::word_view);
-         const ipr::Linkage& get_linkage(const ipr::String&);
-
-         // Return a symbol with a given name and type.
-         const ipr::Symbol& get_symbol(const ipr::Name&, const ipr::Type&);
-
-         Annotation* make_annotation(const ipr::String&, const ipr::Literal&);
-
-         // Build a node for a missing expression of an unspecified type.
-         Phantom* make_phantom();
-         // Build an unspecified expression node of a given type.
-         const ipr::Phantom* make_phantom(const ipr::Type&);
-
-         Eclipsis* make_eclipsis(const ipr::Type&);
-         This* make_this();
-
-         // Returns an IPR node for a typed literal expression.
-         Literal* make_literal(const ipr::Type&, const ipr::String&);
-         Literal* make_literal(const ipr::Type&, util::word_view);
-
-         // Builds an IPR object for an identifier.
-         Identifier* make_identifier(const ipr::String&);
-         Identifier* make_identifier(util::word_view);
-
-         Suffix* make_suffix(const ipr::Identifier&);
-
-         // Builds an IPR object for an operator name.
-         Operator* make_operator(const ipr::String&);
-         Operator* make_operator(util::word_view);
-
-         Guide_name* make_guide_name(const ipr::Template&);
-
-         Address* make_address(const ipr::Expr&, Optional<ipr::Type> = {});
-         Array_delete* make_array_delete(const ipr::Expr&);
-         Complement* make_complement(const ipr::Expr&, Optional<ipr::Type> = {});
-         Conversion* make_conversion(const ipr::Type&);
-         Ctor_name* make_ctor_name(const ipr::Type&);
-         Delete* make_delete(const ipr::Expr&);
-         Demotion* make_demotion(const ipr::Expr&, const ipr::Type&);
-         Deref* make_deref(const ipr::Expr&, Optional<ipr::Type> = {});
-         Dtor_name* make_dtor_name(const ipr::Type&);
-         Expr_list* make_expr_list();
-         Alignof* make_alignof(const ipr::Expr&, Optional<ipr::Type> = { });
-         Sizeof* make_sizeof(const ipr::Expr&, Optional<ipr::Type> = { });
-         Args_cardinality* make_args_cardinality(const ipr::Expr&, Optional<ipr::Type> = { });
-         Typeid* make_typeid(const ipr::Expr&, Optional<ipr::Type> = { });
-         impl::Id_expr* make_id_expr(const ipr::Name&, Optional<ipr::Type> = {});
-         Id_expr* make_id_expr(const ipr::Decl&);
-         Label* make_label(const ipr::Identifier&, Optional<ipr::Type> = {});
-         Materialization* make_materialization(const ipr::Expr&, const ipr::Type&);
-         Not* make_not(const ipr::Expr&, Optional<ipr::Type> = {});
-         Enclosure* make_enclosure(ipr::Delimiter, const ipr::Expr&, Optional<ipr::Type> = { });
-         Post_increment* make_post_increment(const ipr::Expr&, Optional<ipr::Type> = {});
-         Post_decrement* make_post_decrement(const ipr::Expr&, Optional<ipr::Type> = {});
-         Pre_increment* make_pre_increment(const ipr::Expr&, Optional<ipr::Type> = {});
-         Pre_decrement* make_pre_decrement(const ipr::Expr&, Optional<ipr::Type> = {});
-         Promotion* make_promotion(const ipr::Expr&, const ipr::Type&);
-         Read* make_read(const ipr::Expr&, const ipr::Type&);
-         Throw* make_throw(const ipr::Expr&, Optional<ipr::Type> = {});
-         Type_id* make_type_id(const ipr::Type&);
-         Unary_minus* make_unary_minus(const ipr::Expr&, Optional<ipr::Type> = {});
-         Unary_plus* make_unary_plus(const ipr::Expr&, Optional<ipr::Type> = {});
-         Expansion* make_expansion(const ipr::Expr&, Optional<ipr::Type> = {});
-         Construction* make_construction(const ipr::Type&, const ipr::Enclosure&);
-         Noexcept* make_noexcept(const ipr::Expr&, Optional<ipr::Type> = { });
-
-         Rewrite* make_rewrite(const ipr::Expr&, const ipr::Expr&);
-         And* make_and(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
-         Array_ref* make_array_ref(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
-         Arrow* make_arrow(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
-         Arrow_star* make_arrow_star(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
-         Assign* make_assign(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
-         Bitand* make_bitand(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
-         Bitand_assign* make_bitand_assign(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
-         Bitor* make_bitor(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
-         Bitor_assign* make_bitor_assign(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
-         Bitxor* make_bitxor(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
-         Bitxor_assign* make_bitxor_assign(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
-         Cast* make_cast(const ipr::Type&, const ipr::Expr&);
-         Call* make_call(const ipr::Expr&, const ipr::Expr_list&, Optional<ipr::Type> = {});
-         Coercion* make_coercion(const ipr::Expr&, const ipr::Type&, const ipr::Type&);
-         Comma* make_comma(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
-         Const_cast* make_const_cast(const ipr::Type&, const ipr::Expr&);
-         Div* make_div(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
-         Div_assign* make_div_assign(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
-         Dot* make_dot(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
-         Dot_star* make_dot_star(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
-         Dynamic_cast* make_dynamic_cast(const ipr::Type&, const ipr::Expr&);
-         Equal* make_equal(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
-         Greater* make_greater(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
-         Greater_equal* make_greater_equal(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
-         Less* make_less(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
-         Less_equal* make_less_equal(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
-         Lshift* make_lshift(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
-         Lshift_assign* make_lshift_assign(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
-         Member_init* make_member_init(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
-         Minus* make_minus(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
-         Minus_assign* make_minus_assign(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
-         Modulo* make_modulo(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
-         Modulo_assign* make_modulo_assign(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
-         Mul* make_mul(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
-         Mul_assign* make_mul_assign(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
-         Narrow* make_narrow(const ipr::Expr&, const ipr::Type&, const ipr::Type&);
-         Not_equal* make_not_equal(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
-         Or* make_or(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
-         Plus* make_plus(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
-         Plus_assign* make_plus_assign(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
-         Pretend* make_pretend(const ipr::Expr&, const ipr::Type&, const ipr::Type&);
-         Qualification* make_qualification(const ipr::Expr&, ipr::Type_qualifier, const ipr::Type&);
-         Reinterpret_cast* make_reinterpret_cast(const ipr::Type&,
-                                                 const ipr::Expr&);
-         Scope_ref* make_scope_ref(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
-         Rshift* make_rshift(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
-         Rshift_assign* make_rshift_assign(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
-         Template_id* make_template_id(const ipr::Name&,
-                                       const ipr::Expr_list&);
-         Static_cast* make_static_cast(const ipr::Type&, const ipr::Expr&);
-         Widen* make_widen(const ipr::Expr&, const ipr::Type&, const ipr::Type&);
-         Binary_fold* make_binary_fold(Category_code, const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
-         Where* make_where(const ipr::Region&);
-         Where_no_decl* make_where(const ipr::Expr&, const ipr::Expr&);
-         New* make_new(Optional<ipr::Expr_list>, const ipr::Construction&, Optional<ipr::Type> = {});
-         Conditional* make_conditional(const ipr::Expr&, const ipr::Expr&,
-                                       const ipr::Expr&, Optional<ipr::Type> = {});
-
-         Rname* rname_for_next_param(const Mapping&, const ipr::Type&);
-
-         Mapping* make_mapping(const ipr::Region&, Mapping_level);
-         Lambda* make_lambda(const ipr::Region&, Mapping_level);
-
-      private:
-         util::string_pool strings;
-
-         // Language linkage nodes.
-         util::rb_tree::container<impl::Linkage> linkages;
-
-         util::rb_tree::container<impl::Conversion> convs;
-         util::rb_tree::container<impl::Ctor_name> ctors;
-         util::rb_tree::container<impl::Dtor_name> dtors;
-         util::rb_tree::container<impl::Identifier> ids;
-         util::rb_tree::container<impl::Suffix> suffixes;
-         util::rb_tree::container<impl::Literal> lits;
-         util::rb_tree::container<impl::Operator> ops;
-         util::rb_tree::container<impl::Guide_name> guide_ids;
-         util::rb_tree::container<impl::Rname> rnames;
-         util::rb_tree::container<impl::Template_id> template_ids;
-         util::rb_tree::container<impl::Type_id> type_ids;
-
-         stable_farm<impl::Phantom> phantoms;
-         stable_farm<impl::Eclipsis> eclipses;
-         stable_farm<impl::This> these;
-
-         util::rb_tree::container<impl::Symbol> symbols;
-         stable_farm<impl::Alignof> alignofs;
-         stable_farm<impl::Sizeof> sizeofs;
-         stable_farm<impl::Typeid> xtypeids;
-         stable_farm<impl::Address> addresses;
-         stable_farm<impl::Annotation> annotations;
-         stable_farm<impl::Array_delete> array_deletes;
-         stable_farm<impl::Complement> complements;
-         stable_farm<impl::Delete> deletes;
-         stable_farm<impl::Demotion> demotions;
-         stable_farm<impl::Deref> derefs;
-         stable_farm<impl::Expr_list> xlists;
-         stable_farm<impl::Id_expr> id_exprs;
-         stable_farm<impl::Label> labels;
-         stable_farm<impl::Materialization> materializations;
-         stable_farm<impl::Not> nots;
-         stable_farm<impl::Enclosure> enclosures;
-         stable_farm<impl::Pre_increment> pre_increments;
-         stable_farm<impl::Pre_decrement> pre_decrements;
-         stable_farm<impl::Post_increment> post_increments;
-         stable_farm<impl::Post_decrement> post_decrements;
-         stable_farm<impl::Promotion> promotions;
-         stable_farm<impl::Read> reads;
-         stable_farm<impl::Throw> throws;
-         stable_farm<impl::Unary_minus> unary_minuses;
-         stable_farm<impl::Unary_plus> unary_pluses;
-         stable_farm<impl::Expansion> expansions;
-         stable_farm<impl::Construction> constructions;
-         stable_farm<impl::Noexcept> noexcepts;
-         stable_farm<impl::Args_cardinality> cardinalities;
-
-         stable_farm<impl::Rewrite> rewrites;
-         stable_farm<impl::Scope_ref> scope_refs;
-         stable_farm<impl::And> ands;
-         stable_farm<impl::Array_ref> array_refs;
-         stable_farm<impl::Arrow> arrows;
-         stable_farm<impl::Arrow_star> arrow_stars;
-         stable_farm<impl::Assign> assigns;
-         stable_farm<impl::Bitand> bitands;
-         stable_farm<impl::Bitand_assign> bitand_assigns;
-         stable_farm<impl::Bitor> bitors;
-         stable_farm<impl::Bitor_assign> bitor_assigns;
-         stable_farm<impl::Bitxor> bitxors;
-         stable_farm<impl::Bitxor_assign> bitxor_assigns;
-         stable_farm<impl::Cast> casts;
-         stable_farm<impl::Call> calls;
-         stable_farm<impl::Comma> commas;
-         stable_farm<impl::Const_cast> ccasts;
-         stable_farm<impl::Div> divs;
-         stable_farm<impl::Div_assign> div_assigns;
-         stable_farm<impl::Dot> dots;
-         stable_farm<impl::Dot_star> dot_stars;
-         stable_farm<impl::Dynamic_cast> dcasts;
-         stable_farm<impl::Equal> equals;
-         stable_farm<impl::Greater> greaters;
-         stable_farm<impl::Greater_equal> greater_equals;
-         stable_farm<impl::Less> lesses;
-         stable_farm<impl::Less_equal> less_equals;
-         stable_farm<impl::Lshift> lshifts;
-         stable_farm<impl::Lshift_assign> lshift_assigns;
-         stable_farm<impl::Member_init> member_inits;
-         stable_farm<impl::Minus> minuses;
-         stable_farm<impl::Minus_assign> minus_assigns;
-         stable_farm<impl::Modulo> modulos;
-         stable_farm<impl::Modulo_assign> modulo_assigns;
-         stable_farm<impl::Mul> muls;
-         stable_farm<impl::Mul_assign> mul_assigns;
-         stable_farm<impl::Narrow> narrows;
-         stable_farm<impl::Not_equal> not_equals;
-         stable_farm<impl::Or> ors;
-         stable_farm<impl::Plus> pluses;
-         stable_farm<impl::Plus_assign> plus_assigns;
-         stable_farm<impl::Pretend> pretends;
-         stable_farm<impl::Qualification> qualifications;
-         stable_farm<impl::Reinterpret_cast> rcasts;
-         stable_farm<impl::Rshift> rshifts;
-         stable_farm<impl::Rshift_assign> rshift_assigns;
-         stable_farm<impl::Static_cast> scasts;
-         stable_farm<impl::Widen> widens;
-         stable_farm<impl::Binary_fold> folds;
-         stable_farm<impl::Where_no_decl> where_nodecls;
-         stable_farm<impl::Where> wheres;
-
-         stable_farm<impl::New> news;
-         stable_farm<impl::Coercion> coercions;
-         stable_farm<impl::Conditional> conds;
-         stable_farm<impl::Mapping> mappings;
-         stable_farm<impl::Lambda> lambdas;
-      };
-
-      struct dir_factory {
-         impl::Asm* make_asm(const ipr::String&, const ipr::Type&);
-         impl::Static_assert* make_static_assert(const ipr::Expr&, Optional<ipr::String> = { });
-         impl::Structured_binding* make_structured_binding();
-         impl::single_using_declaration* make_using_declaration(const ipr::Scope_ref&,
-                                                                ipr::Using_declaration::Designator::Mode);
-         impl::Using_declaration* make_using_declaration();
-         impl::Using_directive* make_using_directive(const ipr::Scope&, const ipr::Type&);
-         impl::Pragma* make_pragma();
-      private:
-         stable_farm<impl::Asm> asms;
-         stable_farm<impl::Static_assert> asserts;
-         stable_farm<impl::Structured_binding> bindings;
-         stable_farm<impl::single_using_declaration> singles;
-         stable_farm<impl::Using_declaration> usings;
-         stable_farm<impl::Using_directive> dirs;
-         stable_farm<impl::Pragma> pragmas;
-      };
-
-      // This factory class takes on the implementation burden of
-      // allocating storage for statement nodes and their constructions.
-      struct stmt_factory : expr_factory, dir_factory {
-         impl::Break* make_break(const ipr::Type&);
-         impl::Continue* make_continue(const ipr::Type&);
-         impl::Empty_stmt* make_empty_stmt(const ipr::Type&);
-         impl::Block* make_block(const ipr::Region&, Optional<ipr::Type> = { });
-         impl::Ctor_body* make_ctor_body(const ipr::Expr_list&,
-                                         const ipr::Block&);
-         impl::Expr_stmt* make_expr_stmt(const ipr::Expr&);
-         impl::Goto* make_goto(const ipr::Expr&);
-         impl::Return* make_return(const ipr::Expr&);
-         impl::Do* make_do();
-         impl::If* make_if(const ipr::Expr&, const ipr::Stmt&);
-         impl::If* make_if(const ipr::Expr&, const ipr::Stmt&, const ipr::Stmt&);
-         impl::Switch* make_switch();
-         impl::Handler* make_handler(const ipr::Decl&, const ipr::Block&);
-         impl::Labeled_stmt* make_labeled_stmt(const ipr::Expr&,
-                                               const ipr::Stmt&);
-         impl::While* make_while();
-         impl::For* make_for();
-         impl::For_in* make_for_in();
-
-      protected:
-         stable_farm<impl::Break> breaks;
-         stable_farm<impl::Continue> continues;
-         stable_farm<impl::Empty_stmt> empty_stmts;
-         stable_farm<impl::Block> blocks;
-         stable_farm<impl::Expr_stmt> expr_stmts;
-         stable_farm<impl::Goto> gotos;
-         stable_farm<impl::Return> returns;
-         stable_farm<impl::Ctor_body> ctor_bodies;
-         stable_farm<impl::Do> dos;
-         stable_farm<impl::If> ifs;
-         stable_farm<impl::Handler> handlers;
-         stable_farm<impl::Labeled_stmt> labeled_stmts;
-         stable_farm<impl::Switch> switches;
-         stable_farm<impl::While> whiles;
-         stable_farm<impl::For> fors;
-         stable_farm<impl::For_in> for_ins;
-      };
-
-                                // -- impl::Lexicon --
-      struct Lexicon : ipr::Lexicon, stmt_factory {
-         Lexicon();
-         ~Lexicon();
-
-         const ipr::Linkage& cxx_linkage() const final;
-         const ipr::Linkage& c_linkage() const final;
-
-         const ipr::Identifier& get_identifier(util::word_view);
-         const ipr::Identifier& get_identifier(const ipr::String&);
-
-         const ipr::Suffix& get_suffix(const ipr::Identifier&);
-
-         const ipr::Operator& get_operator(util::word_view);
-         const ipr::Operator& get_operator(const ipr::String&);
-
-         const ipr::Ctor_name& get_ctor_name(const ipr::Type&);
-         const ipr::Dtor_name& get_dtor_name(const ipr::Type&);
-
-         const ipr::Conversion& get_conversion(const ipr::Type&);
-
-         const ipr::Template_id& get_template_id(const ipr::Name&,
-                                                 const ipr::Expr_list&);
-
-         const ipr::Literal& get_literal(const ipr::Type&, util::word_view);
-         const ipr::Literal& get_literal(const ipr::Type&, const ipr::String&);
-
-         const ipr::Type& void_type() const final;
-         const ipr::Type& bool_type() const final;
-
-         const ipr::Type& char_type() const final;
-         const ipr::Type& schar_type() const final;
-         const ipr::Type& uchar_type() const final;
-         const ipr::Type& wchar_t_type() const final;
-         const ipr::Type& char8_t_type() const final;
-         const ipr::Type& char16_t_type() const final;
-         const ipr::Type& char32_t_type() const final;
-
-         const ipr::Type& short_type() const final;
-         const ipr::Type& ushort_type() const final;
-
-         const ipr::Type& int_type() const final;
-         const ipr::Type& uint_type() const final;
-
-         const ipr::Type& long_type() const final;
-         const ipr::Type& ulong_type() const final;
-
-         const ipr::Type& long_long_type() const final;
-         const ipr::Type& ulong_long_type() const final;
-
-         const ipr::Type& float_type() const final;
-         const ipr::Type& double_type() const final;
-         const ipr::Type& long_double_type() const final;
-
-         const ipr::Type& ellipsis_type() const final;
-
-         const ipr::Type& typename_type() const final;
-         const ipr::Type& class_type() const final;
-         const ipr::Type& union_type() const final;
-         const ipr::Type& enum_type() const final;
-         const ipr::Type& namespace_type() const final;
-
-         const ipr::Expr& nullptr_value() const final;
-
-         const ipr::Array& get_array(const ipr::Type&, const ipr::Expr&);
-
-         const ipr::As_type& get_as_type(const ipr::Expr&);
-         const ipr::As_type& get_as_type(const ipr::Expr&,
-                                         const ipr::Linkage&);
-
-         const ipr::Decltype& get_decltype(const ipr::Expr&);
-
-         const ipr::Function& get_function(const ipr::Product&,
-                                           const ipr::Type&, const ipr::Sum&);
-         const ipr::Function& get_function(const ipr::Product&,
-                                           const ipr::Type&);
-         const ipr::Function& get_function(const ipr::Product&,
-                                           const ipr::Type&,
-                                           const ipr::Sum&,
-                                           const ipr::Linkage&);
-         const ipr::Function& get_function(const ipr::Product&,
-                                           const ipr::Type&,
-                                           const ipr::Linkage&);
-
-         const ipr::Pointer& get_pointer(const ipr::Type&);
-
-         const ipr::Product& get_product(const ref_sequence<ipr::Type>&);
-
-         const ipr::Ptr_to_member& get_ptr_to_member(const ipr::Type&,
-                                                     const ipr::Type&);
-
-         const ipr::Reference& get_reference(const ipr::Type&);
-         const ipr::Rvalue_reference& get_rvalue_reference(const ipr::Type&);
-
-         const ipr::Qualified& get_qualified(ipr::Type_qualifier,
-                                             const ipr::Type&);
-
-         const ipr::Sum& get_sum(const ref_sequence<ipr::Type>&);
-
-         const ipr::Forall& get_forall(const ipr::Product&,
-                                           const ipr::Type&);
-
-         impl::Mapping* make_mapping(const ipr::Region&, Mapping_level = { });
-         impl::Parameter* make_parameter(const ipr::Name&, const ipr::Type&,
-                                         impl::Mapping&);
-
-         impl::Class* make_class(const ipr::Region&);
-         impl::Enum* make_enum(const ipr::Region&, Enum::Kind);
-         impl::Namespace* make_namespace(const ipr::Region&);
-         impl::Union* make_union(const ipr::Region&);
-
-         const impl::Token* make_token(const ipr::String&,
-                                       const Source_location&,
-                                       TokenValue, TokenCategory);
-
-         const ipr::Auto& get_auto();
-
-      private:
-         void record_builtin_type(const ipr::As_type&);
-
-         stable_farm<impl::Token> tokens;
-         type_factory types;
-         util::rb_tree::container<ref_sequence<ipr::Expr>> expr_seqs;
-         util::rb_tree::container<ref_sequence<ipr::Type>> type_seqs;
-         util::rb_tree::container<node_ref<ipr::As_type>> builtin_map;
-         stable_farm<impl::Auto> autos;
-
-         const impl::Builtin<ipr::As_type> anytype;
-         const impl::Builtin<ipr::As_type> classtype;
-         const impl::Builtin<ipr::As_type> uniontype;
-         const impl::Builtin<ipr::As_type> enumtype;
-         const impl::Builtin<ipr::As_type> namespacetype;
-         const impl::Builtin<ipr::As_type> voidtype;
-         const impl::Builtin<ipr::As_type> booltype;
-         const impl::Builtin<ipr::As_type> chartype;
-         const impl::Builtin<ipr::As_type> schartype;
-         const impl::Builtin<ipr::As_type> uchartype;
-         const impl::Builtin<ipr::As_type> wchar_ttype;
-         const impl::Builtin<ipr::As_type> char8_ttype;
-         const impl::Builtin<ipr::As_type> char16_ttype;
-         const impl::Builtin<ipr::As_type> char32_ttype;
-         const impl::Builtin<ipr::As_type> shorttype;
-         const impl::Builtin<ipr::As_type> ushorttype;
-         const impl::Builtin<ipr::As_type> inttype;
-         const impl::Builtin<ipr::As_type> uinttype;
-         const impl::Builtin<ipr::As_type> longtype;
-         const impl::Builtin<ipr::As_type> ulongtype;
-         const impl::Builtin<ipr::As_type> longlongtype;
-         const impl::Builtin<ipr::As_type> ulonglongtype;
-         const impl::Builtin<ipr::As_type> floattype;
-         const impl::Builtin<ipr::As_type> doubletype;
-         const impl::Builtin<ipr::As_type> longdoubletype;
-         const impl::Builtin<ipr::As_type> ellipsistype;
-
-         const impl::Symbol null;
-
-         template<class T> T* finish_type(T*);
-      };
-
-      template<typename T>
-      struct unit_base : T {
-         using Interface = T;
-         unit_base(impl::Lexicon& l)
-               : context{ l },
-                 global_ns{ nullptr, context.namespace_type() }
-         {
-            global_ns.id = &context.get_identifier("");
-         }
-
-         void accept(Translation_unit::Visitor& v) const override {
-            v.visit(*this);
-         }
-
-         const ipr::Global_scope& global_namespace() const final {
-            return global_ns;
-         }
-
-         const ipr::Sequence<ipr::Module>& imported_modules() const final {
-            return modules_imported;
-         }
-
-         Region* global_region() { return &global_ns.body; }
-         Scope* global_scope() { return &global_ns.body.scope; }
-         ref_sequence<ipr::Module>* imports() { return &modules_imported; }
-
-      private:
-         impl::Lexicon& context;
-         impl::Udt<ipr::Global_scope> global_ns;
-         ref_sequence<ipr::Module> modules_imported;
-      };
-
-      template<typename T>
-      struct basic_unit : unit_base<T> {
-         const ipr::Module& parent;
-         impl::ref_sequence<ipr::Decl> owned_decls;
-
-         basic_unit(impl::Lexicon& l, const ipr::Module& m)
-               : unit_base<T>{ l }, parent{ m }
-         { }
-         const ipr::Module& parent_module() const final { return parent; }
-         const ipr::Sequence<ipr::Decl>& purview() const final {
-            return owned_decls;
-         }
-      };
-
-      using Translation_unit = unit_base<ipr::Translation_unit>;
-      using Module_unit = basic_unit<ipr::Module_unit>;
-
-      struct Interface_unit : basic_unit<ipr::Interface_unit> {
-         impl::ref_sequence<ipr::Module> modules_exported;
-         impl::ref_sequence<ipr::Decl> decls_exported;
-
-         Interface_unit(impl::Lexicon&, const ipr::Module&);
-         const ipr::Sequence<ipr::Module>& exported_modules() const final;
-         const ipr::Sequence<ipr::Decl>& exported_declarations() const final;
-      };
-
-      struct Module : ipr::Module {
-         using ImplUnits = impl::val_sequence<impl::Module_unit>;
-         impl::Lexicon& lexicon;
-         impl::Module_name stems;
-         impl::Interface_unit iface;
-         ImplUnits units;
-
-         Module(impl::Lexicon&);
-         const ipr::Module_name& name() const final;
-         const ipr::Interface_unit& interface_unit() const final;
-         const ipr::Sequence<ipr::Module_unit>& implementation_units() const final;
-         impl::Module_unit* make_unit();
-      };
+      return { };
    }
+
+   // -- impl::homogeneous_region:
+   template<typename Member, typename RegionKind = Node<ipr::Region>>
+   struct homogeneous_region : RegionKind {
+      using location_span = ipr::Region::Location_span;
+      using Index = typename Sequence<Member>::Index;
+      const ipr::Region& parent;
+      location_span extent;
+      Optional<ipr::Expr> owned_by { };
+      homogeneous_scope<Member> scope;
+
+      const ipr::Region& enclosing() const final { return parent; }
+      const ipr::Sequence<ipr::Expr>& body() const final { return scope; }
+      const ipr::Scope& bindings() const final { return scope; }
+      const location_span& span() const final { return extent; }
+      const ipr::Expr& owner() const final { return owned_by.get(); }
+      bool global() const final { return false; }
+
+      explicit homogeneous_region(const ipr::Region& p) : parent(p) { }
+   };
+}
+
+namespace ipr::impl {
+   // -- impl::Directive
+   template<typename T, Phases f>
+   struct Directive : impl::Expr<T> {
+      Phases phases() const final { return f; }
+   };
+
+   // -- impl::Stmt implements the common operations of statements.
+   struct Stmt_common {
+      ipr::Unit_location unit_locus;
+      ipr::Source_location src_locus;
+      ref_sequence<ipr::Annotation> notes;
+      ref_sequence<ipr::Attribute> attrs;
+   };
+
+   template<class S>
+   struct Stmt : S, Stmt_common {
+      const ipr::Unit_location& unit_location() const final { return unit_locus; }
+      const ipr::Source_location& source_location() const final { return src_locus; }
+      const ipr::Sequence<ipr::Annotation>& annotation() const final { return notes; }
+      const ipr::Sequence<ipr::Attribute>& attributes() const final { return attrs; }
+   };
+}
+
+namespace ipr::impl {
+   // -- unique_decl:
+   // Some declarations (e.g. parameters, base-classes, enumerators)
+   // cannot be redeclared in their declarative regions.  Consequently
+   // their decl-sets and overload sets are singleton, containing
+   // only the mater declarations.  Consequently, it seems
+   // heavyweight space wasteful to deploy the general representation
+   // machinery for them.  The class unique_decl<> implements the
+   // specialization of Decl<> in those cases.
+   template<class Interface>
+   struct unique_decl : impl::Stmt<Node<Interface>> {
+      ipr::DeclSpecifiers spec;
+      util::ref<const ipr::Linkage> langlinkage { };
+      singleton_overload overload;
+
+      unique_decl() : spec(ipr::DeclSpecifiers::None),
+                        overload(*this)
+      { }
+
+      ipr::DeclSpecifiers specifiers() const final { return spec; }
+      const ipr::Decl& master() const final { return *this; }
+      const ipr::Linkage& lang_linkage() const final
+      {
+         return langlinkage.get();
+      }
+      const ipr::Sequence<ipr::Decl>& decl_set() const final { return overload.seq; }
+   };
+}
+
+namespace ipr::impl {
+                              // -- impl::Rname --
+   struct Rname : Ternary<Node<ipr::Rname>> {
+      explicit Rname(Rep);
+
+      // It was not strictly necessary to actually define this class
+      // and the function type().  See the comments in <ipr/interface>.
+      const ipr::Type& type() const;
+   };
+
+                              // -- impl::Parameter --
+   struct Parameter final : unique_decl<ipr::Parameter> {
+      const ipr::Name& id;
+      const impl::Rname& abstract_name;
+      util::ref<const ipr::Parameter_list> where;
+      Optional<ipr::Expr> init;
+
+      Parameter(const ipr::Name&, const impl::Rname&);
+      const ipr::Name& name() const final { return id; }
+      const ipr::Type& type() const final;
+      const ipr::Region& home_region() const final { return where.get().region(); }
+      Decl_position position() const final;
+      Optional<ipr::Expr> initializer() const final { return init; }
+   };
+
+                              // -- impl::Parameter_list --
+   struct Parameter_list : impl::Node<ipr::Parameter_list> {
+      homogeneous_region<impl::Parameter> parms;
+      const Mapping_level nesting;
+
+      Parameter_list(const ipr::Region&, Mapping_level);
+      const ipr::Product& type() const final;
+      const ipr::Region& region() const final;
+      Mapping_level level() const final { return nesting; }
+      const ipr::Sequence<ipr::Parameter>& elements() const final;
+
+      impl::Parameter* add_member(const ipr::Name&, const impl::Rname&);
+   };
+}
+
+namespace ipr::cxx_form::impl {
+   template<typename T>
+   struct Indirector : T {
+      ipr::impl::ref_sequence<ipr::Attribute> attr_seq;
+      const ipr::Sequence<ipr::Attribute>& attributes() const final { return attr_seq; }
+      void accept(Indirector_visitor& v) const final { v.visit(static_cast<const T&>(*this)); }
+   };
+
+   struct Simple_indirector : impl::Indirector<cxx_form::Indirector::Simple> {
+      Mode indirection;
+      Mode mode() const final { return indirection; }
+   };
+
+   struct Member_indirector : impl::Indirector<cxx_form::Indirector::Member> {
+      util::ref<const ipr::Scope_ref> whole;
+      ipr::Type_qualifiers cv_quals;
+      const ipr::Scope_ref& scope() const final { return whole.get(); }
+      ipr::Type_qualifiers qualifiers() const final { return cv_quals; }
+   };
+
+   template<typename T>
+   struct Species : T {
+      void accept(Species_visitor& v) const final { v.visit(static_cast<const T&>(*this)); }
+   };
+
+   struct Id_species : impl::Species<cxx_form::Species_declarator::Id> {
+      util::ref<const ipr::Expr> expr;
+      const ipr::Expr& name() const final { return expr.get(); }
+   };
+
+   struct Callable_species : impl::Species<cxx_form::Species_declarator::Callable> {
+      ipr::impl::ref_sequence<cxx_form::Species_declarator> preceding_species;
+      ipr::impl::Parameter_list inputs;
+      Optional<ipr::Expr> eh_spec;
+      Type_qualifiers cv_quals;
+      Binding_mode ref_qual;
+      Callable_species(const ipr::Region&, Mapping_level);
+      const ipr::Sequence<cxx_form::Species_declarator>& prefix() const final { return preceding_species; }
+      const ipr::Parameter_list& parameters() const final { return inputs; }
+      Optional<ipr::Expr> throws() const final { return eh_spec; }
+      Type_qualifiers qualifiers() const final { return cv_quals; }
+      Binding_mode binding_mode() const final { return ref_qual; }
+   };
+
+   struct Array_species : impl::Species<cxx_form::Species_declarator::Array> {
+      ipr::impl::ref_sequence<cxx_form::Species_declarator> preceding_species;
+      Optional<ipr::Expr> array_bound;
+      const ipr::Sequence<cxx_form::Species_declarator>& prefix() const final { return preceding_species; }
+      Optional<ipr::Expr> bound() const final { return array_bound; }
+   };
+
+   struct Parenthesized_species : impl::Species<cxx_form::Species_declarator::Parenthesized> {
+      util::ref<const Declarator::Term> declarator;
+      const Declarator::Term& term() const final { return declarator.get(); }
+   };
+
+   struct form_factory {
+      Simple_indirector* make_simple_indirector();
+      Member_indirector* make_member_indirector();
+      Id_species* make_id_species();
+      Callable_species* make_callable_species();
+      Array_species* make_array_species();
+      Parenthesized_species* make_parenthesized_species();
+   private:
+      ipr::impl::stable_farm<Simple_indirector> simple_indirectors;
+      ipr::impl::stable_farm<Member_indirector> member_indirectors;
+      ipr::impl::stable_farm<Id_species> id_species;
+      ipr::impl::stable_farm<Callable_species> callable_species;
+      ipr::impl::stable_farm<Array_species> array_species;
+      ipr::impl::stable_farm<Parenthesized_species> paren_species;
+   };
+}
+
+namespace ipr::impl {
+   struct Lexicon;
+
+   template<class T>
+   struct node_ref {
+      const T& node;
+      explicit node_ref(const T& t) : node(t) { }
+   };
+
+                              // -- impl::Token --
+   struct Token : ipr::Lexeme, ipr::Token {
+      using Interface = ipr::Token;
+      Token(const ipr::String&, const Source_location&, TokenValue, TokenCategory);
+      const ipr::String& spelling() const final { return text; }
+      const Source_location& locus() const final { return location; }
+      const ipr::Lexeme& lexeme() const final { return *this; }
+      TokenValue value() const final { return token_value; }
+      TokenCategory category() const final { return token_category; }
+
+   private:
+      const ipr::String& text;
+      Source_location location;
+      TokenValue token_value;
+      TokenCategory token_category;
+   };
+
+   // -- Parameterized implementation of ipr::Attribute.
+   // -- The type parameter is used here as a device to implement an overrider
+   // -- for ipr::Attribute::visit(), for all T implementation classes of attribute.
+   template<typename T>
+   struct Attribute : T {
+      void accept(typename T::Visitor& v) const final { v.visit(*this); }
+   };
+
+   // -- implementation of ipr::BasicAttribute
+   struct BasicAttribute : impl::Attribute<ipr::BasicAttribute> {
+      explicit BasicAttribute(const ipr::Token& t) : tok{ t } { }
+      const ipr::Token& token() const final { return tok; }
+   private:
+      const ipr::Token& tok;
+   };
+
+   // -- implementation of ipr::ScopedAttribute
+   struct ScopedAttribute : impl::Attribute<ipr::ScopedAttribute> {
+      ScopedAttribute(const ipr::Token& s, const ipr::Token& m) : first{ s }, second{ m } { }
+      const ipr::Token& scope() const final { return first; }
+      const ipr::Token& member() const final { return second; }
+   private:
+      const ipr::Token& first;
+      const ipr::Token& second;
+   };
+
+   // -- implementation of ipr::LabeledAttribute
+   struct LabeledAttribute : impl::Attribute<ipr::LabeledAttribute> {
+      LabeledAttribute(const ipr::Token& l, const ipr::Attribute& a) : lbl{ l }, attr{ a } { }
+      const ipr::Token& label() const final { return lbl; }
+      const ipr::Attribute& attribute() const final { return attr; }
+   private:
+      const ipr::Token& lbl;
+      const ipr::Attribute& attr;
+   };
+
+   // -- implementation of ipr::CalledAttribute
+   struct CalledAttribute : impl::Attribute<ipr::CalledAttribute> {
+      CalledAttribute(const ipr::Attribute& f, const ipr::Sequence<ipr::Attribute>& s) : fun{ f }, args{ s } { }
+      const ipr::Attribute& function() const final { return fun; }
+      const ipr::Sequence<ipr::Attribute>& arguments() const final { return args; }
+   private:
+      const ipr::Attribute& fun;
+      const ipr::Sequence<ipr::Attribute>& args;
+   };
+
+   // -- implementation of ipr::ExpandedAttribute
+   struct ExpandedAttribute : impl::Attribute<ipr::ExpandedAttribute> {
+      ExpandedAttribute(const ipr::Token& t, const ipr::Attribute& a) : tok{ t }, attr{ a } { }
+      const ipr::Token& expander() const final { return tok; }
+      const ipr::Attribute& operand() const final { return attr; }
+   private:
+      const ipr::Token& tok;
+      const ipr::Attribute& attr;
+   };
+
+   // -- implementation of ipr::FactoredAttribute
+   struct FactoredAttribute : impl::Attribute<ipr::FactoredAttribute> {
+      FactoredAttribute(const ipr::Token& t, const ipr::Sequence<ipr::Attribute>& s) : tok{ t }, seq{ s } { }
+      const ipr::Token& factor() const final { return tok; }
+      const ipr::Sequence<ipr::Attribute>& terms() const final { return seq; }
+   private:
+      const ipr::Token& tok;
+      const ipr::Sequence<ipr::Attribute>& seq;
+   };
+
+   // -- implementation of ipr::ElaboratedAttribute
+   struct ElaboratedAttribute : impl::Attribute<ipr::ElaboratedAttribute> {
+      explicit ElaboratedAttribute(const ipr::Expr& x) : expr{ x } { }
+      const ipr::Expr& elaboration() const final { return expr; }
+   private:
+      const ipr::Expr& expr;
+   };
+
+   // -- Attributes factory --
+   struct attr_factory {
+      const ipr::BasicAttribute& make_basic_attribute(const ipr::Token&);
+      const ipr::ScopedAttribute& make_scoped_attribute(const ipr::Token&, const ipr::Token&);
+      const ipr::LabeledAttribute& make_labeled_attribute(const ipr::Token&, const ipr::Attribute&);
+      const ipr::CalledAttribute& make_called_attribute(const ipr::Attribute&, const ipr::Sequence<ipr::Attribute>&);
+      const ipr::ExpandedAttribute& make_expanded_attribute(const ipr::Token&, const ipr::Attribute&);
+      const ipr::FactoredAttribute& make_factored_attribute(const ipr::Token&, const ipr::Sequence<ipr::Attribute>&);
+      const ipr::ElaboratedAttribute& make_elaborated_attribute(const ipr::Expr&);
+   private:
+      stable_farm<impl::BasicAttribute> basics;
+      stable_farm<impl::ScopedAttribute> scopeds;
+      stable_farm<impl::LabeledAttribute> labeleds;
+      stable_farm<impl::CalledAttribute> calleds;
+      stable_farm<impl::ExpandedAttribute> expandeds;
+      stable_farm<impl::FactoredAttribute> factoreds;
+      stable_farm<impl::ElaboratedAttribute> elaborateds;
+   };
+
+   // -- implementation for ipr::Capture
+   struct Capture : ipr::Capture {
+      using Interface = ipr::Capture;
+      Capture(const ipr::Decl& d, ipr::Binding_mode m) : decl{d}, md{m} { }
+      ipr::Binding_mode mode() const final { return md; }
+      const ipr::Decl& entity() const final { return decl; }
+   private:
+      const ipr::Decl& decl;
+      const ipr::Binding_mode md;
+   };
+
+   // -- Generic implementation of ipr::Capture_specification
+   template<typename T>
+   struct Capture_specification : T {
+      void accept(typename T::Visitor& v) const final { v.visit(*this); }
+   };
+
+   // -- implementation of ipr::Capture_specification::Default
+   struct Default_capture_specification : Capture_specification<ipr::Capture_specification::Default> {
+      explicit Default_capture_specification(Binding_mode m) : md{m} { }
+      Binding_mode mode() const final { return md; }
+   private:
+      const Binding_mode md;
+   };
+
+   // -- implementation of ipr::Capture_specification::Implicit_object
+   struct Implicit_object_capture_specification : Capture_specification<ipr::Capture_specification::Implicit_object> {
+      explicit Implicit_object_capture_specification(Binding_mode m) : md{m} { }
+      Binding_mode how() const final { return md; }
+   private:
+      const Binding_mode md;
+   };
+
+   // -- implementation of ipr::Capture_specification::Enclosing_local
+   struct Enclosing_local_capture_specification : Capture_specification<ipr::Capture_specification::Enclosing_local> {
+      Enclosing_local_capture_specification(const ipr::Decl& x, Binding_mode m) : decl{x}, md{m} { }
+      Binding_mode mode() const final { return md; }
+      const ipr::Identifier& name() const final;
+      const ipr::Decl& declaration() const final { return decl; }
+   private:
+      const ipr::Decl& decl;
+      const Binding_mode md;
+   };
+
+   // -- implementation of ipr::Capture_capture::Binding
+   struct Binding_capture_specification : Capture_specification<ipr::Capture_specification::Binding> {
+      Binding_capture_specification(const ipr::Identifier& n, const ipr::Expr& x, Binding_mode m) : id{n}, init{x}, md{m} { }
+      Binding_mode mode() const final { return md; }
+      const ipr::Identifier& name() const { return id; }
+      const ipr::Expr& initializer() const { return init; }
+   private:
+      const ipr::Identifier& id;
+      const ipr::Expr& init;
+      const Binding_mode md;
+   };
+
+   // -- implementation of ipr::Capture_specification::Expansion.
+   struct Expansion_capture_specification : Capture_specification<ipr::Capture_specification::Expansion> {
+      explicit Expansion_capture_specification(const Named& x) : cap{x} { }
+      const Named& what() const final { return cap; }
+   private:
+      const Named& cap;
+   };
+
+   // -- capture specification factory
+   struct capture_spec_factory {
+      const ipr::Capture_specification::Default& default_capture(Binding_mode);
+      const ipr::Capture_specification::Implicit_object& implicit_object_capture(Binding_mode);
+      const ipr::Capture_specification::Enclosing_local& enclosing_local_capture(const ipr::Decl&, Binding_mode);
+      const ipr::Capture_specification::Binding& binding_capture(const ipr::Identifier&, const ipr::Expr&, Binding_mode);
+      const ipr::Capture_specification::Expansion& expansion_capture(const ipr::Capture_specification::Named&);
+   private:
+      stable_farm<impl::Default_capture_specification> defaults;
+      stable_farm<impl::Implicit_object_capture_specification> implicits;
+      stable_farm<impl::Enclosing_local_capture_specification> enclosings;
+      stable_farm<impl::Binding_capture_specification> bindings;
+      stable_farm<impl::Expansion_capture_specification> expansions;
+   };
+
+                              // -- impl::Module_name --
+   struct Module_name : ipr::Module_name {
+      ref_sequence<ipr::Identifier> components;
+
+      const ipr::Sequence<ipr::Identifier>& stems() const final;
+   };
+
+
+   template<typename T,
+         typename std::enable_if_t<std::is_scalar_v<T>, int> = 0>
+   constexpr int compare(T lhs, T rhs)
+   {
+      constexpr std::less<> lt { };
+      return lt(lhs, rhs) ? -1 : (lt(rhs, lhs) ? 1 : 0);
+   }
+
+   constexpr int compare(const ipr::Node& lhs, const ipr::Node& rhs)
+   {
+      return compare(&lhs, &rhs);
+   }
+
+   template<class Base>
+   struct type_from_operand : Unary_node<Base> {
+      using typename Base::Arg_type;
+      explicit type_from_operand(Arg_type a) : Unary_node<Base>{a} { }
+      const ipr::Type& type() const final { return this->operand().type(); }
+   };
+
+   template<class Base>
+   struct type_from_second : Binary_node<Base> {
+      using typename Base::Arg1_type;
+      using typename Base::Arg2_type;
+      type_from_second(Arg1_type f, Arg2_type s) : Binary_node<Base>{ f, s } { }
+      const ipr::Type& type() const final { return this->second().type(); }
+   };
+
+                              // -- Conversion_expr --
+   template<class Interface>
+   struct Conversion_expr : impl::Classic<Binary_node<Interface>> {
+      using Base = impl::Classic<Binary_node<Interface>>;
+      using Base::Base;
+
+      const ipr::Type& type() const { return this->rep.first; }
+   };
+
+                              // -- Linkage --
+   using Linkage = Unary_node<ipr::Linkage>;
+
+   // All declarations (except parameters, base-classes, enumerations)
+   // maintain data about their position and master declaration.  Since
+   // all declarations in a given decl-set have the same type, only
+   // the master declaration has the "type" information.
+   // Similarly, only the master declaration maintains the home
+   // region information.
+   //
+   // In a given decl-set, only one of the declarations is a definition.
+   // The master declaration keeps track of that definition, so all
+   // other redeclarations can refer to it through the master
+   // declaration data.
+
+   template<class> struct master_decl_data;
+   struct Overload;
+
+   // An entry in an overload set.  Part of the data that a
+   // master declaration manages.  It is determined, within
+   // an overload set, by its type.  All redeclarations must
+   // register themselves before the master declaration, at
+   // the creation time.
+
+   struct overload_entry : util::rb_tree::link<overload_entry> {
+      const ipr::Type& type;
+      ref_sequence<ipr::Decl> declset;
+      explicit overload_entry(const ipr::Type& t) : type(t) { }
+   };
+
+
+   template<class Interface>
+   struct basic_decl_data : scope_datum {
+      // Information about the master declaration.  This pointer
+      // shall be set at actual declaration creation time.
+      master_decl_data<Interface>* master_data;
+
+      explicit basic_decl_data(master_decl_data<Interface>* mdd)
+            : master_data(mdd)
+      { }
+   };
+
+   // A master declaration is the first seen introduction of
+   // a name with a given type.  Further redeclarations
+   // are represented by basic_decl_data<> and are linked to the
+   // master declaration.  That forms the declaration-set of
+   // that declaration.
+
+   template<class Interface>
+   struct master_decl_data : basic_decl_data<Interface>, overload_entry {
+      // The declaration that is considered to be the definition.
+      Optional<Interface> def { };
+      util::ref<const ipr::Linkage> langlinkage { };
+
+      // The overload set that contains this master declaration.  It
+      // shall be set at the time the node for the master declaration
+      // is created.
+      impl::Overload* overload;
+      const ipr::Region* home;
+      master_decl_data(impl::Overload* ovl, const ipr::Type& t)
+            : basic_decl_data<Interface>(this),
+               overload_entry(t),
+               overload(ovl),home(0)
+      { }
+   };
+
+   template<>
+   struct master_decl_data<ipr::Template>
+      : basic_decl_data<ipr::Template>, overload_entry {
+      using Base = basic_decl_data<ipr::Template>;
+      // The declaration that is considered to be the definition.
+      Optional<ipr::Template> def { };
+      util::ref<const ipr::Linkage> langlinkage { };
+      const ipr::Template* primary;
+      const ipr::Region* home;
+
+      // The overload set that contains this master declaration.  It
+      // shall be set at the time the node for the master declaration
+      // is created.
+      impl::Overload* overload;
+
+      // Sequence of specializations
+      decl_sequence specs;
+
+      master_decl_data(impl::Overload*, const ipr::Type&);
+   };
+
+
+   struct Overload : impl::Expr<ipr::Overload> {
+      // The name of this overload set.
+      const ipr::Name& name;
+
+      // All entries in this overload set, chained together in a
+      // red-back tree to permit fast retrieval based on type (as key).
+      // They are all master declarations.
+      util::rb_tree::chain<overload_entry> entries;
+
+      // A sequence of master declarations.  They are added as they
+      // appear in their enclosing scope.
+      std::vector<scope_datum*> masters;
+
+      explicit Overload(const ipr::Name&);
+      Optional<ipr::Decl> operator[](const ipr::Type&) const final;
+      overload_entry* lookup(const ipr::Type&) const;
+
+      template<class T>
+      void push_back(master_decl_data<T>*);
+   };
+
+   struct node_compare {
+      int operator()(const ipr::Node& lhs, const ipr::Node& rhs) const
+      {
+         return compare(lhs, rhs);
+      }
+
+      int
+      operator()(const overload_entry& e, const ipr::Type& t) const
+      {
+         return (*this)(e.type, t);
+      }
+
+      int
+      operator()(const overload_entry& l, const overload_entry& r) const
+      {
+         return (*this)(l.type, r.type);
+      }
+   };
+
+   // Capture the commonality of controlled statements such as `do-statement',
+   // `while-statement', and `switch-statement'.  This special class is introduced
+   // instead of reusing `type_from_second' because otherwise the contruction of
+   // nodes of such classes would require constructing the control expression and
+   // the body statement first, which can be awkward.
+   template<typename Base>
+   struct Controlled_stmt : Stmt<Node<Base>> {
+      using typename Base::Arg1_type;
+      using typename Base::Arg2_type;
+      util::ref<std::remove_reference_t<Arg1_type>> control;
+      util::ref<std::remove_reference_t<Arg2_type>> stmt;
+      Arg1_type first() const final { return control.get(); }
+      Arg2_type second() const final { return stmt.get(); }
+      const ipr::Type& type() const final { return second().type(); }
+   };
+
+   // The class template Decl<> implements common operations
+   // for most declarations nodes.  The exception cases are
+   // handled by the class template unique_decl<>.
+
+   template<class D>
+   struct Decl : Stmt<Node<D>> {
+      basic_decl_data<D> decl_data;
+
+      Decl() : decl_data{ nullptr } { }
+
+      const ipr::Linkage& lang_linkage() const final
+      {
+         return util::check(decl_data.master_data)->langlinkage.get();
+      }
+
+      const ipr::Region& home_region() const final {
+         return *util::check(util::check(decl_data.master_data)->home);
+      }
+
+      // Set declaration specifiers for this decl.
+      using D::specifiers;
+      void specifiers(ipr::DeclSpecifiers s) {
+         decl_data.spec = s;
+      }
+   };
+
+   struct Base_type final : unique_decl<ipr::Base_type> {
+      const ipr::Type& base;
+      const ipr::Region& where;
+      const Decl_position scope_pos;
+
+      Base_type(const ipr::Type&, const ipr::Region&, Decl_position);
+      const ipr::Type& type() const final { return base; }
+      // FIXME: for a base-class subobject, the home region and lexical
+      //        region are slightly different.  The home region should be that
+      //        of the class this is a base class, whereas the lexical region
+      //        should be the actual lexical region where the base type was specified.
+      const ipr::Region& lexical_region() const final { return where; }
+      const ipr::Region& home_region() const final { return where; }
+      Decl_position position() const final { return scope_pos; }
+      Optional<ipr::Expr> initializer() const final;
+   };
+
+   struct Enumerator final : unique_decl<ipr::Enumerator> {
+      const ipr::Name& id;
+      const ipr::Enum& constraint;
+      const Decl_position scope_pos;
+      util::ref<const ipr::Region> where;
+      Optional<ipr::Expr> init;
+
+      Enumerator(const ipr::Name&, const ipr::Enum&, Decl_position);
+      const ipr::Name& name() const final { return id; }
+      const ipr::Type& type() const final { return constraint; }
+      const ipr::Region& lexical_region() const final { return where.get(); }
+      const ipr::Region& home_region() const final { return where.get(); }
+      Decl_position position() const final { return scope_pos; }
+      Optional<ipr::Expr> initializer() const final { return init; }
+   };
+
+   template<typename T>
+   struct decl_rep : T {
+      using Interface = typename T::Interface;
+      decl_rep(master_decl_data<Interface>* mdd)
+      {
+         this->decl_data.master_data = mdd;
+         this->decl_data.decl = this;
+         mdd->declset.push_back(this);
+      }
+
+      const ipr::Name& name() const final
+      {
+         return this->decl_data.master_data->overload->name;
+      }
+
+      ipr::DeclSpecifiers specifiers() const final
+      {
+         return this->decl_data.spec;
+      }
+
+      const ipr::Type& type() const final
+      {
+         return this->decl_data.master_data->type;
+      }
+
+      const ipr::Scope& scope() const
+      {
+         return this->decl_data.master_data->overload->where;
+      }
+
+      Decl_position position() const
+      {
+         return this->decl_data.scope_pos;
+      }
+
+      const ipr::Decl& master() const
+      {
+         return *util::check(this->decl_data.master_data->decl);
+      }
+
+      const ipr::Sequence<ipr::Decl>& decl_set() const
+      {
+         return this->decl_data.master_data->declset;
+      }
+
+      Optional<Interface> definition() const
+      {
+         return this->decl_data.master_data->def;
+      }
+   };
+
+
+   using Array = Binary_type<ipr::Array>;
+   using Decltype = Unary_type<ipr::Decltype>;
+   using As_type = Binary_type<ipr::As_type>;
+   using Tor = Ternary_type<ipr::Tor>;
+   using Function = Quaternary<Type<ipr::Function>>;
+   using Pointer = Unary_type<ipr::Pointer>;
+   using Product = Unary_type<ipr::Product>;
+   using Ptr_to_member = Binary_type<ipr::Ptr_to_member>;
+   using Qualified = Binary_type<ipr::Qualified>;
+   using Reference = Unary_type<ipr::Reference>;
+   using Rvalue_reference = Unary_type<ipr::Rvalue_reference>;
+   using Sum = Unary_type<ipr::Sum>;
+   using Forall = Binary_type<ipr::Forall>;
+
+   using Comment = Unary_node<Comment>;
+
+   using Identifier = Unary_node<ipr::Identifier>;
+   using Suffix = Unary_node<ipr::Suffix>;
+   using Operator = Unary_node<ipr::Operator>;
+   using Conversion = Unary_node<ipr::Conversion>;
+   using Ctor_name = Unary_node<ipr::Ctor_name>;
+   using Dtor_name = Unary_node<ipr::Dtor_name>;
+   using Guide_name = Unary_node<ipr::Guide_name>;
+   using Type_id = Unary_node<ipr::Type_id>;
+
+   using Phantom = Expr<ipr::Phantom>;
+   using Eclipsis = Expr<ipr::Eclipsis>;
+
+   struct This : impl::Expr<ipr::This> {
+      Optional<ipr::Decl> owner;
+      Optional<ipr::Decl> context() const final { return owner; }
+   };
+
+   struct Symbol final : Unary_expr<ipr::Symbol> {
+      explicit Symbol(const ipr::Name&);
+      Symbol(const ipr::Name&, const ipr::Type&);
+   };
+
+   struct Lambda : impl::Node<ipr::Lambda> {
+      util::ref<const ipr::Closure> constraint;
+      Optional<ipr::Type> value_type;
+      impl::Parameter_list parms;
+      util::ref<const ipr::Expr> body;
+      Optional<ipr::Expr> decl_constraint;
+      impl::ref_sequence<ipr::Attribute> attrs;
+      impl::ref_sequence<ipr::Capture_specification> env_spec;
+      Optional<ipr::Expr> eh;
+      Lambda_specifiers lam_spec;
+
+      Lambda(const ipr::Region&, Mapping_level);
+      const ipr::Closure& type() const final { return constraint.get(); }
+      Optional<ipr::Type> target() const final { return value_type; }
+      const ipr::Parameter_list& parameters() const final { return parms; }
+      Optional<ipr::Expr> requirement() const final { return decl_constraint; }
+      const ipr::Expr& result() const final { return body.get(); }
+      const ipr::Sequence<ipr::Attribute>& attributes() const final { return attrs; }
+      Optional<ipr::Expr> eh_specification() const final { return eh; }
+      Lambda_specifiers specifiers() const final { return lam_spec; }
+      const ipr::Sequence<ipr::Capture_specification>& captures() const final { return env_spec; }
+   };
+
+   using Address = Classic_unary_expr<ipr::Address>;
+   using Array_delete = Classic_unary_expr<ipr::Array_delete>;
+   using Complement = Classic_unary_expr<ipr::Complement>;
+   using Delete = Classic_unary_expr<ipr::Delete>;
+   using Demotion = Unary_expr<ipr::Demotion>;
+   using Deref = Classic_unary_expr<ipr::Deref>;
+
+   struct Expr_list : impl::Node<ipr::Expr_list> {
+      typed_sequence<ref_sequence<ipr::Expr>> seq;
+
+      Expr_list();
+      explicit Expr_list(const ref_sequence<ipr::Expr>&);
+
+      const ipr::Product& type() const final;
+
+      const ipr::Sequence<ipr::Expr>& operand() const final;
+
+      void push_back(const ipr::Expr* e) { seq.seq.push_back(e); }
+   };
+
+   using Alignof = Unary_expr<ipr::Alignof>;
+   using Sizeof = Unary_expr<ipr::Sizeof>;
+   using Args_cardinality = Unary_expr<ipr::Args_cardinality>;
+   using Typeid = Unary_expr<ipr::Typeid>;
+   using Label = Unary_expr<ipr::Label>;
+
+   struct Id_expr : Unary_expr<ipr::Id_expr> {
+      Optional<ipr::Expr> decls { };
+
+      explicit Id_expr(const ipr::Name&);
+      Optional<ipr::Expr> resolution() const final;
+   };
+
+   using Materialization = Unary_expr<ipr::Materialization>;
+   using Not = Classic_unary_expr<ipr::Not>;
+
+   struct Enclosure : impl::Unary_expr<ipr::Enclosure> {
+      Enclosure(ipr::Delimiter, const ipr::Expr&);
+      Delimiter delimiters() const final { return delim; }
+   private:
+      Delimiter delim;
+   };
+
+   using Pre_decrement = Classic_unary_expr<ipr::Pre_decrement>;
+   using Pre_increment = Classic_unary_expr<ipr::Pre_increment>;
+   using Post_decrement = Classic_unary_expr<ipr::Post_decrement>;
+   using Post_increment = Classic_unary_expr<ipr::Post_increment>;
+   using Promotion = Unary_expr<ipr::Promotion>;
+   using Read = Unary_expr<ipr::Read>;
+   using Throw = Classic_unary_expr<ipr::Throw>;
+
+   using Unary_minus = Classic_unary_expr<ipr::Unary_minus>;
+   using Unary_plus = Classic_unary_expr<ipr::Unary_plus>;
+   using Expansion = Classic_unary_expr<ipr::Expansion>;
+   using Construction = Classic_unary_expr<ipr::Construction>;
+   using Noexcept = Unary_expr<ipr::Noexcept>;
+
+   using Rewrite = Binary_node<ipr::Rewrite>;
+   using And = Classic_binary_expr<ipr::And>;
+   using Annotation = Binary_node<ipr::Annotation>;
+   using Array_ref = Classic_binary_expr<ipr::Array_ref>;
+   using Arrow = Classic_binary_expr<ipr::Arrow>;
+   using Arrow_star = Classic_binary_expr<ipr::Arrow_star>;
+   using Assign = Classic_binary_expr<ipr::Assign>;
+   using Bitand = Classic_binary_expr<ipr::Bitand>;
+   using Bitand_assign = Classic_binary_expr<ipr::Bitand_assign>;
+   using Bitor = Classic_binary_expr<ipr::Bitor>;
+   using Bitor_assign = Classic_binary_expr<ipr::Bitor_assign>;
+   using Bitxor = Classic_binary_expr<ipr::Bitxor>;
+   using Bitxor_assign = Classic_binary_expr<ipr::Bitxor_assign>;
+   using Call = Classic_binary_expr<ipr::Call>;
+   using Cast = Conversion_expr<ipr::Cast>;
+   using Coercion = Classic_binary_expr<ipr::Coercion>;
+   using Comma = Classic_binary_expr<ipr::Comma>;
+   using Const_cast = Conversion_expr<ipr::Const_cast>;
+   using Div = Classic_binary_expr<ipr::Div>;
+   using Div_assign = Classic_binary_expr<ipr::Div_assign>;
+   using Dot = Classic_binary_expr<ipr::Dot>;
+   using Dot_star = Classic_binary_expr<ipr::Dot_star>;
+   using Dynamic_cast = Conversion_expr<ipr::Dynamic_cast>;
+   using Equal = Classic_binary_expr<ipr::Equal>;
+   using Greater = Classic_binary_expr<ipr::Greater>;
+   using Greater_equal = Classic_binary_expr<ipr::Greater_equal>;
+   using Less = Classic_binary_expr<ipr::Less>;
+   using Less_equal = Classic_binary_expr<ipr::Less_equal>;
+   using Literal = Conversion_expr<ipr::Literal>;
+   using Lshift = Classic_binary_expr<ipr::Lshift>;
+   using Lshift_assign = Classic_binary_expr<ipr::Lshift_assign>;
+
+   struct Mapping : impl::Expr<ipr::Mapping> {
+      impl::Parameter_list parms;
+      util::ref<const ipr::Type> value_type;
+      util::ref<const ipr::Expr> body;
+
+      Mapping(const ipr::Region&, Mapping_level);
+      const ipr::Parameter_list& parameters() const final { return parms; }
+      const ipr::Type& target() const final { return value_type.get(); }
+      const ipr::Expr& result() const final { return body.get(); }
+      impl::Parameter* param(const ipr::Name&, const impl::Rname&);
+   };
+
+   using Member_init = Binary_expr<ipr::Member_init>;
+   using Minus = Classic_binary_expr<ipr::Minus>;
+   using Minus_assign = Classic_binary_expr<ipr::Minus_assign>;
+   using Modulo = Classic_binary_expr<ipr::Modulo>;
+   using Modulo_assign = Classic_binary_expr<ipr::Modulo_assign>;
+   using Mul = Classic_binary_expr<ipr::Mul>;
+   using Mul_assign = Classic_binary_expr<ipr::Mul_assign>;
+   using Narrow = Binary_expr<ipr::Narrow>;
+   using Not_equal = Classic_binary_expr<ipr::Not_equal>;
+   using Or = Classic_binary_expr<ipr::Or>;
+   using Plus = Classic_binary_expr<ipr::Plus>;
+   using Plus_assign = Classic_binary_expr<ipr::Plus_assign>;
+   using Pretend = Binary_expr<ipr::Pretend>;
+   using Qualification = Binary_expr<ipr::Qualification>;
+   using Reinterpret_cast = Conversion_expr<ipr::Reinterpret_cast>;
+   using Rshift = Classic_binary_expr<ipr::Rshift>;
+   using Rshift_assign = Classic_binary_expr<ipr::Rshift_assign>;
+   using Scope_ref = Classic_binary_expr<ipr::Scope_ref>;
+   using Static_cast = Conversion_expr<ipr::Static_cast>;
+   using Template_id = Binary_node<ipr::Template_id>;
+   using Widen = Binary_expr<ipr::Widen>;
+   // A Where node where the attendant() is not a scope.
+   using Where_no_decl = Binary_node<ipr::Where>;
+
+   struct Binary_fold : Classic_binary_expr<ipr::Binary_fold> {
+      Category_code fold_op;
+
+      Binary_fold(Category_code, const ipr::Expr&, const ipr::Expr&);
+      Category_code operation() const final;
+   };
+
+   struct New : impl::Classic_binary_expr<ipr::New> {
+      bool global = false;
+
+      New(Optional<ipr::Expr_list>, const ipr::Construction&);
+      bool global_requested() const final;
+   };
+
+   using Conditional = Ternary<Classic<Expr<ipr::Conditional>>>;
+
+   struct Template : impl::Decl<ipr::Template> {
+      util::ref<impl::Mapping> init;
+      util::ref<const ipr::Region> lexreg;
+      impl::Expr_list args;
+
+      Template();
+      const ipr::Template& primary_template() const final;
+      const ipr::Sequence<ipr::Decl>& specializations() const final;
+      const ipr::Mapping& mapping() const final { return init.get(); }
+      // FIXME: The initializer should actually be the mapping, since a Template is a
+      //        *named* mapping.  In Classic IPR, and in the current incarnation, the initializer 
+      //        is the initializer of the current instantiation.
+      Optional<ipr::Expr> initializer() const final { return { &mapping().result() }; }
+      const ipr::Region& lexical_region() const final { return lexreg.get(); }
+   };
+
+   template<typename T>
+   struct decl_factory {
+      using Interface = typename T::Interface;
+      stable_farm<decl_rep<T>> decls;
+      stable_farm<master_decl_data<Interface>> master_info;
+
+      // We have gotten an overload-set for a name, and we are about
+      // to enter the first declaration for that name with the type T.
+      decl_rep<T>* declare(Overload* ovl, const ipr::Type& t)
+      {
+         // Grab bookkeeping memory for this master declaration.
+         master_decl_data<Interface>* data = master_info.make(ovl, t);
+         // The actual representation for the declaration points back
+         // to the master declaration bookkeeping store.
+         decl_rep<T>* master = decls.make(data);
+         // Inform the overload-set that we have a new master declaration.
+         ovl->push_back(data);
+
+         return master;
+      }
+
+      decl_rep<T>* redeclare(overload_entry* decl)
+      {
+         return decls.make
+            (static_cast<master_decl_data<Interface>*>(decl));
+      }
+   };
+
+
+   struct Alias : impl::Decl<ipr::Alias> {
+      const ipr::Expr* aliasee;
+
+      Alias();
+      Optional<ipr::Expr> initializer() const final { return aliasee; }
+   };
+
+   struct Var : impl::Decl<ipr::Var> {
+      Optional<ipr::Expr> init;
+      util::ref<const ipr::Region> lexreg;
+
+      Var();
+      Optional<ipr::Expr> initializer() const final { return init; }
+      const ipr::Region& lexical_region() const final { return lexreg.get(); }
+   };
+
+   // FIXME: Field should use unique_decl, not impl::Decl.
+   struct Field : impl::Decl<ipr::Field> {
+      Optional<ipr::Expr> init;
+
+      Field();
+      Optional<ipr::Expr> initializer() const final { return init; }
+   };
+
+   // FIXME: Bitfield should use unique_decl, not impl::Decl
+   struct Bitfield : impl::Decl<ipr::Bitfield> {
+      util::ref<const ipr::Expr> length;
+      Optional<ipr::Expr> init;
+
+      Bitfield();
+      const ipr::Expr& precision() const final { return length.get(); }
+      Optional<ipr::Expr> initializer() const final { return init; }
+   };
+
+   struct Typedecl : impl::Decl<ipr::Typedecl> {
+      Optional<ipr::Type> init;
+      util::ref<const ipr::Region> lexreg;
+
+      Typedecl();
+      Optional<ipr::Expr> initializer() const final { return init; }
+      const ipr::Region& lexical_region() const final { return lexreg.get(); }
+   };
+
+   // For a non-defining function declaration, the parameters - if any is named
+   // or has a default argument - are stored with that particular declaration.
+   // A function definition is one that specifies the initializer (Mapping) which
+   // already has room for the named parameters or the default arguments.
+   struct fundecl_data : std::variant<impl::Parameter_list*, impl::Mapping*> {
+      impl::Parameter_list* parameters() const { return std::get<0>(*this); }
+      impl::Mapping* mapping() const { return std::get<1>(*this); }
+   };
+
+   struct Fundecl : impl::Decl<ipr::Fundecl> {
+      fundecl_data data;
+      util::ref<const ipr::Region> lexreg;
+
+      Fundecl();
+
+      const ipr::Parameter_list& parameters() const final;
+      Optional<ipr::Mapping> mapping() const final;
+      Optional<ipr::Expr> initializer() const final;
+      const ipr::Region& lexical_region() const final { return lexreg.get(); }
+   };
+
+   // A heterogeneous scope is a sequence of declarations of
+   // almost of kinds.  The omitted kinds being parameters,
+   // base-class subobjects and enumerators.   Those form
+   // a homogeneous scope, implemented by homogeneous_scope.
+
+   struct Scope : impl::Node<ipr::Scope> {
+      Scope();
+      const ipr::Type& type() const final { return decls; }
+      const ipr::Sequence<ipr::Decl>& elements() const final { return decls.seq; }
+      Optional<ipr::Overload> operator[](const ipr::Name&) const final;
+
+      impl::Alias* make_alias(const ipr::Name&, const ipr::Expr&);
+      impl::Var* make_var(const ipr::Name&, const ipr::Type&);
+      impl::Field* make_field(const ipr::Name&, const ipr::Type&);
+      impl::Bitfield* make_bitfield(const ipr::Name&, const ipr::Type&);
+      impl::Typedecl* make_typedecl(const ipr::Name&, const ipr::Type&);
+      impl::Fundecl* make_fundecl(const ipr::Name&, const ipr::Function&);
+      impl::Template* make_primary_template(const ipr::Name&, const ipr::Forall&);
+      impl::Template* make_secondary_template(const ipr::Name&, const ipr::Forall&);
+
+   private:
+      util::rb_tree::container<impl::Overload> overloads;
+      typed_sequence<decl_sequence> decls;
+      decl_factory<impl::Alias> aliases;
+      decl_factory<impl::Var> vars;
+      decl_factory<impl::Field> fields;
+      decl_factory<impl::Bitfield> bitfields;
+      decl_factory<impl::Fundecl> fundecls;
+      decl_factory<impl::Typedecl> typedecls;
+      decl_factory<impl::Template> primary_maps;
+      decl_factory<impl::Template> secondary_maps;
+
+      template<class T> inline void add_member(T*);
+   };
+
+
+   // A heterogeneous region is a region of program text that
+   // contains heterogeneous scope (as defined above).
+
+   struct Region : impl::Node<ipr::Region>, cxx_form::impl::form_factory {
+      using location_span = ipr::Region::Location_span;
+      Optional<ipr::Region> parent;
+      location_span extent;
+      util::ref<const ipr::Expr> owned_by;
+      impl::Scope scope;
+      impl::ref_sequence<ipr::Expr> expr_seq;         // all the expressions making up the body.
+
+      const ipr::Region& enclosing() const final { return parent.get(); }
+      const ipr::Sequence<ipr::Expr>& body() const final { return expr_seq; }
+      const ipr::Scope& bindings() const final { return scope; }
+      const location_span& span() const final { return extent; }
+      const ipr::Expr& owner() const final { return owned_by.get(); }
+      bool global() const final { return not parent.is_valid(); }
+
+      impl::Region* make_subregion();
+
+      // Convenient functions, forwarding to those of SCOPE.
+      impl::Alias* declare_alias(const ipr::Name& n, const ipr::Type& t)
+      {
+         return scope.make_alias(n, t);
+      }
+
+      impl::Var* declare_var(const ipr::Name& n, const ipr::Type& t)
+      {
+         return scope.make_var(n, t);
+      }
+
+      impl::Field* declare_field(const ipr::Name& n, const ipr::Type& t)
+      {
+         return scope.make_field(n, t);
+      }
+
+      impl::Bitfield* declare_bitfield(const ipr::Name& n,
+                                       const ipr::Type& t)
+      {
+         return scope.make_bitfield(n, t);
+      }
+
+      Typedecl* declare_type(const ipr::Name& n, const ipr::Type& t)
+      {
+         return scope.make_typedecl(n, t);
+      }
+
+      Fundecl* declare_fun(const ipr::Name& n, const ipr::Function& t)
+      {
+         return scope.make_fundecl(n, t);
+      }
+
+      Template* declare_primary_template(const ipr::Name& n, const ipr::Forall& t)
+      {
+         return scope.make_primary_template(n, t);
+      }
+
+      Template* declare_secondary_template(const ipr::Name& n, const ipr::Forall& t)
+      {
+         return scope.make_secondary_template(n, t);
+      }
+
+      explicit Region(Optional<ipr::Region>);
+
+   private:
+      stable_farm<Region> subregions;
+   };
+
+
+   // Implement common operations for user-defined types.  The case
+   // of enums is handled separately because its body is a
+   // homogeneous region.
+
+   template<class Interface>
+   struct Udt : impl::Type<Interface> {
+      Region body;
+      Udt(const ipr::Region* pr, const ipr::Type& t) : body(pr)
+      {
+         this->constraint = &t;
+         body.owned_by = this;
+      }
+
+      const ipr::Region& region() const final { return body; }
+
+      impl::Alias*
+      declare_alias(const ipr::Name& n, const ipr::Type& t)
+      {
+         impl::Alias* alias = body.declare_alias(n, t);
+         return alias;
+      }
+
+      impl::Field*
+      declare_field(const ipr::Name& n, const ipr::Type& t)
+      {
+         impl::Field* field = body.declare_field(n, t);
+         return field;
+      }
+
+      impl::Bitfield*
+      declare_bitfield(const ipr::Name& n, const ipr::Type& t)
+      {
+         impl::Bitfield* field = body.declare_bitfield(n, t);
+         return field;
+      }
+
+      impl::Var*
+      declare_var(const ipr::Name& n, const ipr::Type& t)
+      {
+         impl::Var* var = body.declare_var(n, t);
+         return var;
+      }
+
+      impl::Typedecl*
+      declare_type(const ipr::Name& n, const ipr::Type& t)
+      {
+         impl::Typedecl* typedecl = body.declare_type(n, t);
+         return typedecl;
+      }
+
+      impl::Fundecl*
+      declare_fun(const ipr::Name& n, const ipr::Function& t)
+      {
+         impl::Fundecl* fundecl = body.declare_fun(n, t);
+         return fundecl;
+      }
+
+      impl::Template*
+      declare_primary_template(const ipr::Name& n, const ipr::Forall& t)
+      {
+         impl::Template* map = body.declare_primary_template(n, t);
+         return map;
+      }
+
+      impl::Template*
+      declare_secondary_template(const ipr::Name& n, const ipr::Forall& t)
+      {
+         impl::Template* map = body.declare_secondary_template(n, t);
+         return map;
+      }
+   };
+
+   struct Enum : impl::Type<ipr::Enum> {
+      homogeneous_region<impl::Enumerator> body;
+      const Kind enum_kind;
+
+      const ipr::Region& region() const final;
+      const Sequence<ipr::Enumerator>& members() const final;
+      Kind kind() const final;
+      impl::Enumerator* add_member(const ipr::Name&);
+
+      Enum(const ipr::Region&, Kind);
+   };
+
+   using Union = Udt<ipr::Union>;
+   using Namespace = Udt<ipr::Namespace>;
+
+   struct Class : impl::Udt<ipr::Class> {
+      homogeneous_region<impl::Base_type> base_subobjects;
+
+      Class(const ipr::Region&, const ipr::Type&);
+
+      const ipr::Sequence<ipr::Base_type>& bases() const final;
+      impl::Base_type* declare_base(const ipr::Type&);
+
+   };
+
+   struct Auto : impl::Type<ipr::Auto> {
+   };
+
+   struct Closure : impl::Udt<ipr::Closure> {
+      impl::val_sequence<impl::Capture> captures;
+
+      Closure(const ipr::Region&, const ipr::Type&);
+      const ipr::Sequence<ipr::Capture>& members() const final { return captures; }
+   };
+
+   // This class is responsible for creating nodes that
+   // represent types.  It is responsible for the storage
+   // management that is implied.  Notice that the type nodes
+   // created by this class may need additional processing such
+   // as setting their types (as expressions) and their names.
+
+   struct type_factory {
+      // Build an IPR node for an expression that denotes a type.
+      // The linkage, if not specified, is assumed to be C++.
+      impl::As_type* make_as_type(const ipr::Expr&);
+      impl::As_type* make_as_type(const ipr::Expr&, const ipr::Linkage&);
+
+      impl::Array* make_array(const ipr::Type&, const ipr::Expr&);
+      impl::Qualified* make_qualified(ipr::Type_qualifiers,
+                                       const ipr::Type&);
+      impl::Decltype* make_decltype(const ipr::Expr&);
+      impl::Tor* make_tor(const ipr::Product&, const ipr::Sum&, const ipr::Linkage&);
+      impl::Function* make_function(const ipr::Product&, const ipr::Type&,
+                                    const ipr::Sum&, const ipr::Linkage&);
+      impl::Pointer* make_pointer(const ipr::Type&);
+      impl::Product* make_product(const ipr::Sequence<ipr::Type>&);
+      impl::Ptr_to_member* make_ptr_to_member(const ipr::Type&,
+                                                const ipr::Type&);
+      impl::Reference* make_reference(const ipr::Type&);
+      impl::Rvalue_reference* make_rvalue_reference(const ipr::Type&);
+      impl::Sum* make_sum(const ipr::Sequence<ipr::Type>&);
+      impl::Forall* make_forall(const ipr::Product&, const ipr::Type&);
+
+      impl::Enum* make_enum(const ipr::Region&, Enum::Kind);
+      impl::Class* make_class(const ipr::Region&, const ipr::Type&);
+      impl::Union* make_union(const ipr::Region&, const ipr::Type&);
+      impl::Namespace* make_namespace(const ipr::Region*, const ipr::Type&);
+      impl::Closure* make_closure(const ipr::Region&, const ipr::Type&);
+   private:
+      util::rb_tree::container<impl::Array> arrays;
+      util::rb_tree::container<impl::As_type> type_refs;
+      util::rb_tree::container<impl::Tor> tors;
+      util::rb_tree::container<impl::Function> functions;
+      util::rb_tree::container<impl::Pointer> pointers;
+      util::rb_tree::container<impl::Product> products;
+      util::rb_tree::container<impl::Ptr_to_member> member_ptrs;
+      util::rb_tree::container<impl::Qualified> qualifieds;
+      util::rb_tree::container<impl::Reference> references;
+      util::rb_tree::container<impl::Rvalue_reference> refrefs;
+      util::rb_tree::container<impl::Sum> sums;
+      util::rb_tree::container<impl::Forall> foralls;
+      stable_farm<impl::Decltype> decltypes;
+      stable_farm<impl::Enum> enums;
+      stable_farm<impl::Class> classes;
+      stable_farm<impl::Union> unions;
+      stable_farm<impl::Namespace> namespaces;
+      stable_farm<impl::Closure> closures;
+   };
+
+   // -- Implementation of directives --
+   struct Asm : impl::Directive<ipr::Asm, Phases::Code_generation> {
+      explicit Asm(const ipr::String&);
+      const ipr::String& text() const final { return txt; }
+   private:
+      const ipr::String& txt;
+   };
+
+   struct Specifiers_spread : impl::Directive<ipr::Specifiers_spread, Phases::Elaboration> {
+      impl::ref_sequence<cxx_form::Proclamator> proc_seq;
+      ipr::DeclSpecifiers specs;
+
+      const ipr::Sequence<cxx_form::Proclamator>& targets() const final { return proc_seq; }
+      ipr::DeclSpecifiers specifiers() const final { return specs; }
+   };
+
+   struct Static_assert : impl::Directive<ipr::Static_assert, Phases::Elaboration> {
+      Static_assert(const ipr::Expr&, Optional<ipr::String>);
+      const ipr::Expr& condition() const final { return cond; }
+      Optional<ipr::String> message() const final { return txt; }
+   private:
+      const ipr::Expr& cond;
+      Optional<ipr::String> txt;
+   };
+
+   struct Structured_binding : impl::Directive<ipr::Structured_binding, Phases::Elaboration> {
+      impl::ref_sequence<ipr::Identifier> ids;           // names in this structured binding
+      util::ref<const ipr::Expr> init;                   // initializer of this structured binding
+      impl::ref_sequence<ipr::Decl> decl_seq;            // declarations resulting from this structured binding
+      ipr::DeclSpecifiers specs;                         // the non-type part of decl-specifier-seq in 
+                                                         // this structured binding.  Note: `type()` contains the
+                                                         // the type part of the decl-specifier-seq
+      ipr::Binding_mode binding_mode;                    // the binding mode of this structured binding
+
+      ipr::DeclSpecifiers specifiers() const final { return specs; }
+      ipr::Binding_mode mode() const final { return binding_mode; }
+      const ipr::Sequence<ipr::Identifier>& names() const final { return ids; }
+      const ipr::Expr& initializer() const final { return init.get(); }
+      const ipr::Sequence<ipr::Decl>& bindings() const final { return decl_seq; }
+   };
+
+   // Implementation of ipr::Using_declaration in case where using-declarator-list is a singleton.
+   struct single_using_declaration : impl::Directive<ipr::Using_declaration, Phases::Elaboration> {
+      single_using_declaration(const ipr::Scope_ref&, Designator::Mode);
+      const ipr::Sequence<Designator>& designators() const final { return what; }
+   private:
+      singleton<Designator> what;
+   };
+
+   struct Using_declaration : impl::Directive<ipr::Using_declaration, Phases::Elaboration> {
+      impl::val_sequence<Designator> seq;
+
+      const ipr::Sequence<Designator>& designators() const final { return seq; }
+   };
+
+   struct Using_directive : impl::Directive<ipr::Using_directive, Phases::Elaboration> {
+      explicit Using_directive(const ipr::Scope&);
+      const ipr::Scope& nominated_scope() const final { return scope; }
+   private:
+      const ipr::Scope& scope;
+   };
+
+   struct Pragma : impl::Directive<ipr::Pragma, Phases::All> {
+      val_sequence<impl::Token> tokens;
+      const ipr::Sequence<ipr::Token>& operand() const final { return tokens; }
+   };
+
+   // ----------------------------------
+   // -- Implementation of statements --
+   // ----------------------------------
+
+   using Ctor_body = Binary<Stmt<Expr<ipr::Ctor_body>>>;
+   using Do = Controlled_stmt<ipr::Do>;
+   using Expr_stmt = type_from_operand<Stmt<ipr::Expr_stmt>>;
+   using Empty_stmt = type_from_operand<Stmt<ipr::Empty_stmt>>;
+   using Goto = type_from_operand<Stmt<ipr::Goto>>;
+   using Handler = type_from_second<Stmt<ipr::Handler>>;
+   using If = Ternary<Stmt<Expr<ipr::If>>>;
+   using Labeled_stmt = type_from_second<Stmt<ipr::Labeled_stmt>>;
+   using Return = type_from_operand<Stmt<ipr::Return>>;
+   using Switch = Controlled_stmt<ipr::Switch>;
+   using While = Controlled_stmt<ipr::While>;
+
+   // A Block holds a heterogeneous region, suitable for
+   // recording the set of declarations appearing in that
+   // block.  It also holds a sequence of handlers, when the
+   // block actually represents a C++ try-block.
+   struct Block : impl::Stmt<Expr<ipr::Block>> {
+      impl::Region lexical_region;
+      impl::ref_sequence<ipr::Handler> handler_seq;
+
+      explicit Block(const ipr::Region&);
+      const ipr::Region& region() const final { return lexical_region; }
+      const ipr::Sequence<ipr::Handler>& handlers() const final { return handler_seq; }
+
+      // The scope of declarations in this block
+      impl::Scope* scope() { return &lexical_region.scope; }
+
+      void add_stmt(const ipr::Expr& s)
+      {
+         lexical_region.expr_seq.push_back(&s);
+      }
+
+      void add_handler(const ipr::Handler& h)
+      {
+         handler_seq.push_back(&h);
+      }
+   };
+
+
+   // A for-statement node in its most general form is a quaternry
+   // expresion; for flexibility, it is made in a way that
+   // supports settings of its components after construction.
+
+   struct For : impl::Stmt<impl::Node<ipr::For>> {
+      util::ref<const ipr::Expr> init;
+      util::ref<const ipr::Expr> cond;
+      util::ref<const ipr::Expr> inc;
+      util::ref<const ipr::Stmt> stmt;
+
+      For();
+      const ipr::Type& type() const final { return body().type(); }
+      const ipr::Expr& initializer() const final { return init.get(); }
+      const ipr::Expr& condition() const final { return cond.get(); }
+      const ipr::Expr& increment() const final { return inc.get(); }
+      const ipr::Stmt& body() const final { return stmt.get(); }
+   };
+
+   struct For_in : impl::Stmt<impl::Node<ipr::For_in>> {
+      util::ref<const ipr::Var> var;
+      util::ref<const ipr::Expr> seq;
+      util::ref<const ipr::Stmt> stmt;
+
+      For_in();
+      const ipr::Type& type() const final { return body().type(); }
+      const ipr::Var& variable() const final { return var.get(); }
+      const ipr::Expr& sequence() const final { return seq.get(); }
+      const ipr::Stmt& body() const final { return stmt.get(); }
+   };
+
+
+   // A Break node can record the selction- of iteration-statement it
+   // transfers control out of.
+
+   struct Break : Stmt<Expr<ipr::Break>> {
+      util::ref<const ipr::Stmt> stmt;
+
+      Break();
+      const ipr::Stmt& from() const final { return stmt.get(); }
+   };
+
+   // Like a Break, a Continue node can refer back to the
+   // iteration-statement containing it.
+   struct Continue : Stmt<Expr<ipr::Continue>> {
+      util::ref<const ipr::Stmt> stmt;
+
+      Continue();
+      const ipr::Stmt& iteration() const final { return stmt.get(); }
+   };
+
+   // This template will be instantiated to implementations
+   // of several builtin type singletons.  It does not reuse
+   // implementations of Type, and Binary, to save space since
+   // most data needed by those implementations are shared.
+   template<class T>
+   struct Builtin : impl::Expr<T> {
+      using Arg1_type = typename T::Arg1_type;
+      using Arg2_type = typename T::Arg2_type;
+      Builtin(const ipr::Name& n, Arg2_type l, const ipr::Type& t)
+            : impl::Expr<T>(&t), id(n), link(l) { }
+
+      const ipr::Name& name() const final { return id; }
+      Arg1_type first() const final { return *this; }
+      Arg2_type second() const final { return link; }
+
+   private:
+      const ipr::Name& id;
+      Arg2_type link;
+   };
+
+   // Type of `Where`-nodes introducing declarations in their `attendant()` expressions.
+   // Note: See impl::Where_no_decls for the degenerated case where the `attendant()`
+   //       is just a classic expression, with no declaration introduced.
+   struct Where : impl::Node<ipr::Where> {
+      impl::Region region;                            // hosts the declarations in the `attendant()`.
+      util::ref<const ipr::Expr> result;              // the `main()` expression.
+
+      explicit Where(const ipr::Region&);
+      const ipr::Expr& first() const final { return result.get(); }
+      const ipr::Scope& second() const final { return region.bindings(); }
+   };
+
+   struct expr_factory {
+      // Returns an IPR node for unified string literals.
+      const ipr::String& get_string(util::word_view);
+
+      // Returns an IPR node a language linkage.
+      const ipr::Linkage& get_linkage(util::word_view);
+      const ipr::Linkage& get_linkage(const ipr::String&);
+
+      // Return a symbol with a given name and type.
+      const ipr::Symbol& get_symbol(const ipr::Name&, const ipr::Type&);
+
+      Annotation* make_annotation(const ipr::String&, const ipr::Literal&);
+
+      // Build a node for a missing expression of an unspecified type.
+      Phantom* make_phantom();
+      // Build an unspecified expression node of a given type.
+      const ipr::Phantom* make_phantom(const ipr::Type&);
+
+      Eclipsis* make_eclipsis(const ipr::Type&);
+      This* make_this();
+
+      // Returns an IPR node for a typed literal expression.
+      Literal* make_literal(const ipr::Type&, const ipr::String&);
+      Literal* make_literal(const ipr::Type&, util::word_view);
+
+      // Builds an IPR object for an identifier.
+      Identifier* make_identifier(const ipr::String&);
+      Identifier* make_identifier(util::word_view);
+
+      Suffix* make_suffix(const ipr::Identifier&);
+
+      // Builds an IPR object for an operator name.
+      Operator* make_operator(const ipr::String&);
+      Operator* make_operator(util::word_view);
+
+      Guide_name* make_guide_name(const ipr::Template&);
+
+      Address* make_address(const ipr::Expr&, Optional<ipr::Type> = {});
+      Array_delete* make_array_delete(const ipr::Expr&);
+      Complement* make_complement(const ipr::Expr&, Optional<ipr::Type> = {});
+      Conversion* make_conversion(const ipr::Type&);
+      Ctor_name* make_ctor_name(const ipr::Type&);
+      Delete* make_delete(const ipr::Expr&);
+      Demotion* make_demotion(const ipr::Expr&, const ipr::Type&);
+      Deref* make_deref(const ipr::Expr&, Optional<ipr::Type> = {});
+      Dtor_name* make_dtor_name(const ipr::Type&);
+      Expr_list* make_expr_list();
+      Alignof* make_alignof(const ipr::Expr&, Optional<ipr::Type> = { });
+      Sizeof* make_sizeof(const ipr::Expr&, Optional<ipr::Type> = { });
+      Args_cardinality* make_args_cardinality(const ipr::Expr&, Optional<ipr::Type> = { });
+      Typeid* make_typeid(const ipr::Expr&, Optional<ipr::Type> = { });
+      impl::Id_expr* make_id_expr(const ipr::Name&, Optional<ipr::Type> = {});
+      Id_expr* make_id_expr(const ipr::Decl&);
+      Label* make_label(const ipr::Identifier&, Optional<ipr::Type> = {});
+      Materialization* make_materialization(const ipr::Expr&, const ipr::Type&);
+      Not* make_not(const ipr::Expr&, Optional<ipr::Type> = {});
+      Enclosure* make_enclosure(ipr::Delimiter, const ipr::Expr&, Optional<ipr::Type> = { });
+      Post_increment* make_post_increment(const ipr::Expr&, Optional<ipr::Type> = {});
+      Post_decrement* make_post_decrement(const ipr::Expr&, Optional<ipr::Type> = {});
+      Pre_increment* make_pre_increment(const ipr::Expr&, Optional<ipr::Type> = {});
+      Pre_decrement* make_pre_decrement(const ipr::Expr&, Optional<ipr::Type> = {});
+      Promotion* make_promotion(const ipr::Expr&, const ipr::Type&);
+      Read* make_read(const ipr::Expr&, const ipr::Type&);
+      Throw* make_throw(const ipr::Expr&, Optional<ipr::Type> = {});
+      Type_id* make_type_id(const ipr::Type&);
+      Unary_minus* make_unary_minus(const ipr::Expr&, Optional<ipr::Type> = {});
+      Unary_plus* make_unary_plus(const ipr::Expr&, Optional<ipr::Type> = {});
+      Expansion* make_expansion(const ipr::Expr&, Optional<ipr::Type> = {});
+      Construction* make_construction(const ipr::Type&, const ipr::Enclosure&);
+      Noexcept* make_noexcept(const ipr::Expr&, Optional<ipr::Type> = { });
+
+      Rewrite* make_rewrite(const ipr::Expr&, const ipr::Expr&);
+      And* make_and(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
+      Array_ref* make_array_ref(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
+      Arrow* make_arrow(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
+      Arrow_star* make_arrow_star(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
+      Assign* make_assign(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
+      Bitand* make_bitand(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
+      Bitand_assign* make_bitand_assign(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
+      Bitor* make_bitor(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
+      Bitor_assign* make_bitor_assign(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
+      Bitxor* make_bitxor(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
+      Bitxor_assign* make_bitxor_assign(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
+      Cast* make_cast(const ipr::Type&, const ipr::Expr&);
+      Call* make_call(const ipr::Expr&, const ipr::Expr_list&, Optional<ipr::Type> = {});
+      Coercion* make_coercion(const ipr::Expr&, const ipr::Type&, const ipr::Type&);
+      Comma* make_comma(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
+      Const_cast* make_const_cast(const ipr::Type&, const ipr::Expr&);
+      Div* make_div(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
+      Div_assign* make_div_assign(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
+      Dot* make_dot(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
+      Dot_star* make_dot_star(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
+      Dynamic_cast* make_dynamic_cast(const ipr::Type&, const ipr::Expr&);
+      Equal* make_equal(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
+      Greater* make_greater(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
+      Greater_equal* make_greater_equal(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
+      Less* make_less(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
+      Less_equal* make_less_equal(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
+      Lshift* make_lshift(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
+      Lshift_assign* make_lshift_assign(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
+      Member_init* make_member_init(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
+      Minus* make_minus(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
+      Minus_assign* make_minus_assign(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
+      Modulo* make_modulo(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
+      Modulo_assign* make_modulo_assign(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
+      Mul* make_mul(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
+      Mul_assign* make_mul_assign(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
+      Narrow* make_narrow(const ipr::Expr&, const ipr::Type&, const ipr::Type&);
+      Not_equal* make_not_equal(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
+      Or* make_or(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
+      Plus* make_plus(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
+      Plus_assign* make_plus_assign(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
+      Pretend* make_pretend(const ipr::Expr&, const ipr::Type&, const ipr::Type&);
+      Qualification* make_qualification(const ipr::Expr&, ipr::Type_qualifiers, const ipr::Type&);
+      Reinterpret_cast* make_reinterpret_cast(const ipr::Type&,
+                                                const ipr::Expr&);
+      Scope_ref* make_scope_ref(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
+      Rshift* make_rshift(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
+      Rshift_assign* make_rshift_assign(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
+      Template_id* make_template_id(const ipr::Name&,
+                                    const ipr::Expr_list&);
+      Static_cast* make_static_cast(const ipr::Type&, const ipr::Expr&);
+      Widen* make_widen(const ipr::Expr&, const ipr::Type&, const ipr::Type&);
+      Binary_fold* make_binary_fold(Category_code, const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
+      Where* make_where(const ipr::Region&);
+      Where_no_decl* make_where(const ipr::Expr&, const ipr::Expr&);
+      New* make_new(Optional<ipr::Expr_list>, const ipr::Construction&, Optional<ipr::Type> = {});
+      Conditional* make_conditional(const ipr::Expr&, const ipr::Expr&,
+                                    const ipr::Expr&, Optional<ipr::Type> = {});
+
+      Rname* rname_for_next_param(const Mapping&, const ipr::Type&);
+
+      Mapping* make_mapping(const ipr::Region&, Mapping_level);
+      Lambda* make_lambda(const ipr::Region&, Mapping_level);
+
+   private:
+      util::string_pool strings;
+
+      // Language linkage nodes.
+      util::rb_tree::container<impl::Linkage> linkages;
+
+      util::rb_tree::container<impl::Conversion> convs;
+      util::rb_tree::container<impl::Ctor_name> ctors;
+      util::rb_tree::container<impl::Dtor_name> dtors;
+      util::rb_tree::container<impl::Identifier> ids;
+      util::rb_tree::container<impl::Suffix> suffixes;
+      util::rb_tree::container<impl::Literal> lits;
+      util::rb_tree::container<impl::Operator> ops;
+      util::rb_tree::container<impl::Guide_name> guide_ids;
+      util::rb_tree::container<impl::Rname> rnames;
+      util::rb_tree::container<impl::Template_id> template_ids;
+      util::rb_tree::container<impl::Type_id> type_ids;
+
+      stable_farm<impl::Phantom> phantoms;
+      stable_farm<impl::Eclipsis> eclipses;
+      stable_farm<impl::This> these;
+
+      util::rb_tree::container<impl::Symbol> symbols;
+      stable_farm<impl::Alignof> alignofs;
+      stable_farm<impl::Sizeof> sizeofs;
+      stable_farm<impl::Typeid> xtypeids;
+      stable_farm<impl::Address> addresses;
+      stable_farm<impl::Annotation> annotations;
+      stable_farm<impl::Array_delete> array_deletes;
+      stable_farm<impl::Complement> complements;
+      stable_farm<impl::Delete> deletes;
+      stable_farm<impl::Demotion> demotions;
+      stable_farm<impl::Deref> derefs;
+      stable_farm<impl::Expr_list> xlists;
+      stable_farm<impl::Id_expr> id_exprs;
+      stable_farm<impl::Label> labels;
+      stable_farm<impl::Materialization> materializations;
+      stable_farm<impl::Not> nots;
+      stable_farm<impl::Enclosure> enclosures;
+      stable_farm<impl::Pre_increment> pre_increments;
+      stable_farm<impl::Pre_decrement> pre_decrements;
+      stable_farm<impl::Post_increment> post_increments;
+      stable_farm<impl::Post_decrement> post_decrements;
+      stable_farm<impl::Promotion> promotions;
+      stable_farm<impl::Read> reads;
+      stable_farm<impl::Throw> throws;
+      stable_farm<impl::Unary_minus> unary_minuses;
+      stable_farm<impl::Unary_plus> unary_pluses;
+      stable_farm<impl::Expansion> expansions;
+      stable_farm<impl::Construction> constructions;
+      stable_farm<impl::Noexcept> noexcepts;
+      stable_farm<impl::Args_cardinality> cardinalities;
+
+      stable_farm<impl::Rewrite> rewrites;
+      stable_farm<impl::Scope_ref> scope_refs;
+      stable_farm<impl::And> ands;
+      stable_farm<impl::Array_ref> array_refs;
+      stable_farm<impl::Arrow> arrows;
+      stable_farm<impl::Arrow_star> arrow_stars;
+      stable_farm<impl::Assign> assigns;
+      stable_farm<impl::Bitand> bitands;
+      stable_farm<impl::Bitand_assign> bitand_assigns;
+      stable_farm<impl::Bitor> bitors;
+      stable_farm<impl::Bitor_assign> bitor_assigns;
+      stable_farm<impl::Bitxor> bitxors;
+      stable_farm<impl::Bitxor_assign> bitxor_assigns;
+      stable_farm<impl::Cast> casts;
+      stable_farm<impl::Call> calls;
+      stable_farm<impl::Comma> commas;
+      stable_farm<impl::Const_cast> ccasts;
+      stable_farm<impl::Div> divs;
+      stable_farm<impl::Div_assign> div_assigns;
+      stable_farm<impl::Dot> dots;
+      stable_farm<impl::Dot_star> dot_stars;
+      stable_farm<impl::Dynamic_cast> dcasts;
+      stable_farm<impl::Equal> equals;
+      stable_farm<impl::Greater> greaters;
+      stable_farm<impl::Greater_equal> greater_equals;
+      stable_farm<impl::Less> lesses;
+      stable_farm<impl::Less_equal> less_equals;
+      stable_farm<impl::Lshift> lshifts;
+      stable_farm<impl::Lshift_assign> lshift_assigns;
+      stable_farm<impl::Member_init> member_inits;
+      stable_farm<impl::Minus> minuses;
+      stable_farm<impl::Minus_assign> minus_assigns;
+      stable_farm<impl::Modulo> modulos;
+      stable_farm<impl::Modulo_assign> modulo_assigns;
+      stable_farm<impl::Mul> muls;
+      stable_farm<impl::Mul_assign> mul_assigns;
+      stable_farm<impl::Narrow> narrows;
+      stable_farm<impl::Not_equal> not_equals;
+      stable_farm<impl::Or> ors;
+      stable_farm<impl::Plus> pluses;
+      stable_farm<impl::Plus_assign> plus_assigns;
+      stable_farm<impl::Pretend> pretends;
+      stable_farm<impl::Qualification> qualifications;
+      stable_farm<impl::Reinterpret_cast> rcasts;
+      stable_farm<impl::Rshift> rshifts;
+      stable_farm<impl::Rshift_assign> rshift_assigns;
+      stable_farm<impl::Static_cast> scasts;
+      stable_farm<impl::Widen> widens;
+      stable_farm<impl::Binary_fold> folds;
+      stable_farm<impl::Where_no_decl> where_nodecls;
+      stable_farm<impl::Where> wheres;
+
+      stable_farm<impl::New> news;
+      stable_farm<impl::Coercion> coercions;
+      stable_farm<impl::Conditional> conds;
+      stable_farm<impl::Mapping> mappings;
+      stable_farm<impl::Lambda> lambdas;
+   };
+
+   struct dir_factory {
+      impl::Asm* make_asm(const ipr::String&, const ipr::Type&);
+      impl::Specifiers_spread* make_specifiers_spread();
+      impl::Static_assert* make_static_assert(const ipr::Expr&, Optional<ipr::String> = { });
+      impl::Structured_binding* make_structured_binding();
+      impl::single_using_declaration* make_using_declaration(const ipr::Scope_ref&,
+                                                               ipr::Using_declaration::Designator::Mode);
+      impl::Using_declaration* make_using_declaration();
+      impl::Using_directive* make_using_directive(const ipr::Scope&, const ipr::Type&);
+      impl::Pragma* make_pragma();
+   private:
+      stable_farm<impl::Asm> asms;
+      stable_farm<impl::Specifiers_spread> spreads;
+      stable_farm<impl::Static_assert> asserts;
+      stable_farm<impl::Structured_binding> bindings;
+      stable_farm<impl::single_using_declaration> singles;
+      stable_farm<impl::Using_declaration> usings;
+      stable_farm<impl::Using_directive> dirs;
+      stable_farm<impl::Pragma> pragmas;
+   };
+
+   // This factory class takes on the implementation burden of
+   // allocating storage for statement nodes and their constructions.
+   struct stmt_factory : expr_factory, dir_factory {
+      impl::Break* make_break(const ipr::Type&);
+      impl::Continue* make_continue(const ipr::Type&);
+      impl::Empty_stmt* make_empty_stmt(const ipr::Type&);
+      impl::Block* make_block(const ipr::Region&, Optional<ipr::Type> = { });
+      impl::Ctor_body* make_ctor_body(const ipr::Expr_list&,
+                                       const ipr::Block&);
+      impl::Expr_stmt* make_expr_stmt(const ipr::Expr&);
+      impl::Goto* make_goto(const ipr::Expr&);
+      impl::Return* make_return(const ipr::Expr&);
+      impl::Do* make_do();
+      impl::If* make_if(const ipr::Expr&, const ipr::Stmt&);
+      impl::If* make_if(const ipr::Expr&, const ipr::Stmt&, const ipr::Stmt&);
+      impl::Switch* make_switch();
+      impl::Handler* make_handler(const ipr::Decl&, const ipr::Block&);
+      impl::Labeled_stmt* make_labeled_stmt(const ipr::Expr&,
+                                             const ipr::Stmt&);
+      impl::While* make_while();
+      impl::For* make_for();
+      impl::For_in* make_for_in();
+
+   protected:
+      stable_farm<impl::Break> breaks;
+      stable_farm<impl::Continue> continues;
+      stable_farm<impl::Empty_stmt> empty_stmts;
+      stable_farm<impl::Block> blocks;
+      stable_farm<impl::Expr_stmt> expr_stmts;
+      stable_farm<impl::Goto> gotos;
+      stable_farm<impl::Return> returns;
+      stable_farm<impl::Ctor_body> ctor_bodies;
+      stable_farm<impl::Do> dos;
+      stable_farm<impl::If> ifs;
+      stable_farm<impl::Handler> handlers;
+      stable_farm<impl::Labeled_stmt> labeled_stmts;
+      stable_farm<impl::Switch> switches;
+      stable_farm<impl::While> whiles;
+      stable_farm<impl::For> fors;
+      stable_farm<impl::For_in> for_ins;
+   };
+
+                              // -- impl::Lexicon --
+   struct Lexicon : ipr::Lexicon, stmt_factory {
+      Lexicon();
+      ~Lexicon();
+
+      const ipr::Linkage& cxx_linkage() const final;
+      const ipr::Linkage& c_linkage() const final;
+
+      const ipr::Identifier& get_identifier(util::word_view);
+      const ipr::Identifier& get_identifier(const ipr::String&);
+
+      const ipr::Suffix& get_suffix(const ipr::Identifier&);
+
+      const ipr::Operator& get_operator(util::word_view);
+      const ipr::Operator& get_operator(const ipr::String&);
+
+      const ipr::Ctor_name& get_ctor_name(const ipr::Type&);
+      const ipr::Dtor_name& get_dtor_name(const ipr::Type&);
+
+      const ipr::Conversion& get_conversion(const ipr::Type&);
+
+      const ipr::Template_id& get_template_id(const ipr::Name&,
+                                                const ipr::Expr_list&);
+
+      const ipr::Literal& get_literal(const ipr::Type&, util::word_view);
+      const ipr::Literal& get_literal(const ipr::Type&, const ipr::String&);
+
+      const ipr::Type& void_type() const final;
+      const ipr::Type& bool_type() const final;
+
+      const ipr::Type& char_type() const final;
+      const ipr::Type& schar_type() const final;
+      const ipr::Type& uchar_type() const final;
+      const ipr::Type& wchar_t_type() const final;
+      const ipr::Type& char8_t_type() const final;
+      const ipr::Type& char16_t_type() const final;
+      const ipr::Type& char32_t_type() const final;
+
+      const ipr::Type& short_type() const final;
+      const ipr::Type& ushort_type() const final;
+
+      const ipr::Type& int_type() const final;
+      const ipr::Type& uint_type() const final;
+
+      const ipr::Type& long_type() const final;
+      const ipr::Type& ulong_type() const final;
+
+      const ipr::Type& long_long_type() const final;
+      const ipr::Type& ulong_long_type() const final;
+
+      const ipr::Type& float_type() const final;
+      const ipr::Type& double_type() const final;
+      const ipr::Type& long_double_type() const final;
+
+      const ipr::Type& ellipsis_type() const final;
+
+      const ipr::Type& typename_type() const final;
+      const ipr::Type& class_type() const final;
+      const ipr::Type& union_type() const final;
+      const ipr::Type& enum_type() const final;
+      const ipr::Type& namespace_type() const final;
+
+      const ipr::Expr& nullptr_value() const final;
+
+      const ipr::Array& get_array(const ipr::Type&, const ipr::Expr&);
+
+      const ipr::As_type& get_as_type(const ipr::Expr&);
+      const ipr::As_type& get_as_type(const ipr::Expr&,
+                                       const ipr::Linkage&);
+
+      const ipr::Decltype& get_decltype(const ipr::Expr&);
+
+      const ipr::Function& get_function(const ipr::Product&,
+                                          const ipr::Type&, const ipr::Sum&);
+      const ipr::Function& get_function(const ipr::Product&,
+                                          const ipr::Type&);
+      const ipr::Function& get_function(const ipr::Product&,
+                                          const ipr::Type&,
+                                          const ipr::Sum&,
+                                          const ipr::Linkage&);
+      const ipr::Function& get_function(const ipr::Product&,
+                                          const ipr::Type&,
+                                          const ipr::Linkage&);
+
+      const ipr::Pointer& get_pointer(const ipr::Type&);
+
+      const ipr::Product& get_product(const ref_sequence<ipr::Type>&);
+
+      const ipr::Ptr_to_member& get_ptr_to_member(const ipr::Type&,
+                                                   const ipr::Type&);
+
+      const ipr::Reference& get_reference(const ipr::Type&);
+      const ipr::Rvalue_reference& get_rvalue_reference(const ipr::Type&);
+
+      const ipr::Qualified& get_qualified(ipr::Type_qualifiers,
+                                          const ipr::Type&);
+
+      const ipr::Sum& get_sum(const ref_sequence<ipr::Type>&);
+
+      const ipr::Forall& get_forall(const ipr::Product&,
+                                          const ipr::Type&);
+
+      impl::Mapping* make_mapping(const ipr::Region&, Mapping_level = { });
+      impl::Parameter* make_parameter(const ipr::Name&, const ipr::Type&,
+                                       impl::Mapping&);
+
+      impl::Class* make_class(const ipr::Region&);
+      impl::Enum* make_enum(const ipr::Region&, Enum::Kind);
+      impl::Namespace* make_namespace(const ipr::Region&);
+      impl::Union* make_union(const ipr::Region&);
+
+      const impl::Token* make_token(const ipr::String&,
+                                    const Source_location&,
+                                    TokenValue, TokenCategory);
+
+      const ipr::Auto& get_auto();
+
+   private:
+      void record_builtin_type(const ipr::As_type&);
+
+      stable_farm<impl::Token> tokens;
+      type_factory types;
+      util::rb_tree::container<ref_sequence<ipr::Expr>> expr_seqs;
+      util::rb_tree::container<ref_sequence<ipr::Type>> type_seqs;
+      util::rb_tree::container<node_ref<ipr::As_type>> builtin_map;
+      stable_farm<impl::Auto> autos;
+
+      const impl::Builtin<ipr::As_type> anytype;
+      const impl::Builtin<ipr::As_type> classtype;
+      const impl::Builtin<ipr::As_type> uniontype;
+      const impl::Builtin<ipr::As_type> enumtype;
+      const impl::Builtin<ipr::As_type> namespacetype;
+      const impl::Builtin<ipr::As_type> voidtype;
+      const impl::Builtin<ipr::As_type> booltype;
+      const impl::Builtin<ipr::As_type> chartype;
+      const impl::Builtin<ipr::As_type> schartype;
+      const impl::Builtin<ipr::As_type> uchartype;
+      const impl::Builtin<ipr::As_type> wchar_ttype;
+      const impl::Builtin<ipr::As_type> char8_ttype;
+      const impl::Builtin<ipr::As_type> char16_ttype;
+      const impl::Builtin<ipr::As_type> char32_ttype;
+      const impl::Builtin<ipr::As_type> shorttype;
+      const impl::Builtin<ipr::As_type> ushorttype;
+      const impl::Builtin<ipr::As_type> inttype;
+      const impl::Builtin<ipr::As_type> uinttype;
+      const impl::Builtin<ipr::As_type> longtype;
+      const impl::Builtin<ipr::As_type> ulongtype;
+      const impl::Builtin<ipr::As_type> longlongtype;
+      const impl::Builtin<ipr::As_type> ulonglongtype;
+      const impl::Builtin<ipr::As_type> floattype;
+      const impl::Builtin<ipr::As_type> doubletype;
+      const impl::Builtin<ipr::As_type> longdoubletype;
+      const impl::Builtin<ipr::As_type> ellipsistype;
+
+      const impl::Symbol null;
+
+      template<class T> T* finish_type(T*);
+   };
+
+   template<typename T>
+   struct unit_base : T {
+      using Interface = T;
+      unit_base(impl::Lexicon& l)
+            : context{ l },
+               global_ns{ nullptr, context.namespace_type() }
+      {
+         global_ns.id = &context.get_identifier("");
+      }
+
+      void accept(Translation_unit::Visitor& v) const override {
+         v.visit(*this);
+      }
+
+      const ipr::Global_scope& global_namespace() const final {
+         return global_ns;
+      }
+
+      const ipr::Sequence<ipr::Module>& imported_modules() const final {
+         return modules_imported;
+      }
+
+      Region* global_region() { return &global_ns.body; }
+      Scope* global_scope() { return &global_ns.body.scope; }
+      ref_sequence<ipr::Module>* imports() { return &modules_imported; }
+
+   private:
+      impl::Lexicon& context;
+      impl::Udt<ipr::Global_scope> global_ns;
+      ref_sequence<ipr::Module> modules_imported;
+   };
+
+   template<typename T>
+   struct basic_unit : unit_base<T> {
+      const ipr::Module& parent;
+      impl::ref_sequence<ipr::Decl> owned_decls;
+
+      basic_unit(impl::Lexicon& l, const ipr::Module& m)
+            : unit_base<T>{ l }, parent{ m }
+      { }
+      const ipr::Module& parent_module() const final { return parent; }
+      const ipr::Sequence<ipr::Decl>& purview() const final {
+         return owned_decls;
+      }
+   };
+
+   using Translation_unit = unit_base<ipr::Translation_unit>;
+   using Module_unit = basic_unit<ipr::Module_unit>;
+
+   struct Interface_unit : basic_unit<ipr::Interface_unit> {
+      impl::ref_sequence<ipr::Module> modules_exported;
+      impl::ref_sequence<ipr::Decl> decls_exported;
+
+      Interface_unit(impl::Lexicon&, const ipr::Module&);
+      const ipr::Sequence<ipr::Module>& exported_modules() const final;
+      const ipr::Sequence<ipr::Decl>& exported_declarations() const final;
+   };
+
+   struct Module : ipr::Module {
+      using ImplUnits = impl::val_sequence<impl::Module_unit>;
+      impl::Lexicon& lexicon;
+      impl::Module_name stems;
+      impl::Interface_unit iface;
+      ImplUnits units;
+
+      Module(impl::Lexicon&);
+      const ipr::Module_name& name() const final;
+      const ipr::Interface_unit& interface_unit() const final;
+      const ipr::Sequence<ipr::Module_unit>& implementation_units() const final;
+      impl::Module_unit* make_unit();
+   };
 }
 
 #endif

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -8,13 +8,17 @@
 #ifndef IPR_INTERFACE_INCLUDED
 #define IPR_INTERFACE_INCLUDED
 
-#include <stdint.h>
+#include <cstdint>
 #include <utility>
 #include <iterator>
 #include <stdexcept>
 #include <type_traits>
 #include <ipr/utility>
 #include <ipr/synopsis>
+#include <ipr/ancillary>
+#include <ipr/location>
+#include <ipr/attribute>
+#include <ipr/cxx-form>
 
 namespace ipr {
    // IPR is designed to be regular, fully general enough to
@@ -66,30 +70,6 @@ namespace ipr {
    // Warning:  If you add any new "leaf" node type, you need to update
    //           "ipr/node-category.def" for the numerical mapping.
 
-   // ---------------------------
-   // -- Phases of translation --
-   // ---------------------------
-   // A bitmask type for the various phases of C++ program translation.
-   enum class Phases {
-      Unknown              = 0x0000,   // Unknown translation phase
-      Reading              = 0x0001,   // Opening and reading an input source
-      Lexing               = 0x0002,   // Lexical decomposition of input source
-      Preprocessing        = 0x0004,   // Macro expansion and friends
-      Parsing              = 0x0008,   // Grammatical decomposition of the input source
-      Name_resolution      = 0x0010,   // Name lookup
-      Typing               = 0x0020,   // Type assignment of expressions
-      Evaluation           = 0x0040,   // Compile-time evaluation
-      Instantiation        = 0x0080,   // Template instantiation phase
-      Code_generation      = 0x0100,   // Code generation phase
-      Linking              = 0x0200,   // Linking phase
-      Loading              = 0x0400,   // Program loading phase
-      Execution            = 0x0800,   // Runtime execution
-
-      Elaboration          = Name_resolution | Typing | Evaluation | Instantiation,
-      All                  = ~0x0,
-   };
-
-
                                 // -- Category_node --
    // A list of numerical codes in one-to-one correspondence with
    // IPR node "interface types".  In a sufficiently expressive and
@@ -100,44 +80,6 @@ namespace ipr {
 #include <ipr/node-category>
    };
 
-                                // -- Various Location Types --
-   // C++ constructs span locations.  There are at least four flavours of
-   // locations:
-   //       (a) physical source location;
-   //       (b) logical source location;
-   //       (c) physical unit location; and
-   //       (d) logical unit location.
-   // Physical and logical source locations are locations as witnessed
-   // at translation phase 2 (see ISO C++, §2.1/1).
-   // Physical and logical unit locations are locations as manifest when
-   // looking at a translation unit, at translation phase 4.
-   //
-   // Many IPR nodes will have a source and unit locations.  Instead of
-   // storing a source file and unit name as a string in every
-   // location data type, we save space by mapping file-names and
-   // unit-names to IDs (integers).  That mapping is managed by the Unit
-   // instance.
-
-   enum class Line_number : uint32_t { };
-   enum class Column_number : uint32_t { };
-
-   struct Basic_location {
-      Line_number line = { };
-      Column_number column = { };
-   };
-
-   enum class File_index : uint32_t { };
-
-   struct Source_location : Basic_location {
-      File_index file = { };    // ID of the file
-   };
-
-   enum class Unit_index : uint32_t { };
-
-   struct Unit_location : Basic_location {
-      Unit_index unit = { };    // ID of the unit
-   };
-
    // -- General structural utility types.
 
    template<Category_code Cat, class T = Expr>
@@ -146,159 +88,11 @@ namespace ipr {
       constexpr Category() : T{ Cat } { }
    };
 
-                                // -- Sequence<> --
-   // Often, we use a notion of sequence to represent intermediate
-   // abstractions like base-classes, enumerators, catch-clauses,
-   // parameter-type-list, etc.  A "Sequence" is a collection abstractly
-   // described by its "begin()" and "end()" iterators.  It is made
-   // abstract because it may admit different implementations depending
-   // on concrete constraints.  For example, a scope (a sequence of
-   // declarations, that additionally supports look-up by name) may
-   // implement this interface either as a associative-array that maps
-   // Names to Declarations (with no particular order) or as
-   // vector<Declaration*> (in order of their appearance in programs), or
-   // as a much more elaborated data structure.
-   template<class T>
-   struct Sequence  {
-      struct Iterator;          // An iterator is a pair of (sequence,
-                                // position).  The position indicates
-                                // the particular value referenced in
-                                // the sequence.
-
-      // Provide STL-style interface, for use with some STL algorithm
-      // helper classes.  Sequence<> is an immutable sequence.
-      using value_type = T;
-      using reference = const T&;
-      using pointer = const T*;
-      using Index = std::size_t;
-      using iterator = Iterator;
-
-      virtual Index size() const = 0;
-      bool empty() const { return not (size() > 0); }
-      Iterator begin() const;
-      Iterator end() const;
-      Iterator position(Index) const;
-
-   protected:
-      virtual const T& get(Index) const = 0;
-   };
-
-                                // -- Sequence<>::Iterator --
-   // This iterator class is as abstract as it could be, for useful
-   // purposes.  It forwards most operations to the "Sequence" class
-   // it provides a view for.
-   template<class T>
-   struct Sequence<T>::Iterator {
-      using self_type = Sequence<T>::Iterator;
-      using value_type = const T;
-      using reference = const T&;
-      using pointer = const T*;
-      using difference_type = ptrdiff_t;
-      using Index = typename Sequence<T>::Index;
-      using iterator_category = std::bidirectional_iterator_tag;
-
-      Iterator() {}
-      Iterator(const Sequence* s, Index i) : seq{ s }, index{ i } { }
-
-      const T& operator*() const
-      { return seq->get(index); }
-
-      const T* operator->() const
-      { return &seq->get(index); }
-
-      Iterator& operator++()
-      {
-         ++index;
-         return *this;
-      }
-
-      Iterator& operator--()
-      {
-        --index;
-        return *this;
-      }
-
-      Iterator operator++(int)
-      {
-         Iterator tmp = *this;
-         ++index;
-         return tmp;
-      }
-
-      Iterator operator--(int)
-      {
-        Iterator tmp = *this;
-        --index;
-        return tmp;
-      }
-
-      bool operator==(Iterator other) const
-      { return seq == other.seq and index == other.index; }
-
-      bool operator!=(Iterator other) const
-      { return not(*this == other); }
-
-   private:
-      const Sequence* seq { };
-      Index index { };
-   };
-
-   template<class T>
-   inline typename Sequence<T>::Iterator
-   Sequence<T>::position(Index i) const
-   { return { this, i }; }
-
-   template<class T>
-   inline typename Sequence<T>::Iterator
-   Sequence<T>::begin() const
-   { return { this, 0 }; }
-
-   template<class T>
-   inline typename Sequence<T>::Iterator
-   Sequence<T>::end() const
-   { return { this, size() }; }
-
-                                 // -- Delimiter --
-   // Enclosure delimiters of expressions
-   enum class Delimiter {
-      Nothing,                   // no delimiter
-      Paren,                     // "()"
-      Brace,                     // "{}"
-      Bracket,                   // "[]"
-      Angle,                     // "<>"
-   };
-
    // Nesting level of a mapping
    enum class Mapping_level : std::size_t { };
 
    // Position of a declaration in its declarative region
    enum class Decl_position : std::size_t { };
-
-
-                                // -- Binding_move --
-   // Mode of binding of a object value to a name (parameter, variable, alias, etc).
-   enum class Binding_mode : std::uint8_t {
-      Copy,                         // by copy operation; default binding mode of C and C++
-      Reference,                    // by ref; the parameter or varable has an lvalue reference type
-      Move,                         // by move operation; transfer of ownership
-      Default = Copy,
-   };
-
-                                // -- Optional<> --
-   // Occasionally, a node has an optional property (e.g. a variable
-   // has an optional initializer).  This class template captures
-   // that commonality and provides a checked access.
-   template<typename T>
-   struct Optional {
-      Optional(const T* p = nullptr) : ptr { p } { }
-      const T& get() const { return *util::check(ptr); }
-      bool is_valid() const { return ptr != nullptr; }
-      explicit operator bool() const { return is_valid(); }
-      template<typename U, bool = std::is_base_of_v<T, U>>
-      operator Optional<U>() const { return { ptr }; }
-   private:
-      const T* ptr;
-   };
 
                                 // -- Unary<> --
    // A unary-expression is a specification of an operation that takes
@@ -315,7 +109,6 @@ namespace ipr {
       using Arg_type = Operand;
       virtual Operand operand() const = 0;
    };
-
 
                                 // -- Binary<> --
    // In full generality, a binary-expression is an expression that
@@ -370,93 +163,8 @@ namespace ipr {
       virtual Fourth fourth() const = 0;
    };
 
-
-   // -----------------------------------
-   // -- Basic syntactic units: Tokens --
-   // -----------------------------------
-   // The IPR focuses primarily on semantic aspects of C++ constructs.
-   // Certain constructs, such as uninstantiated template definitions,
-   // are primarily syntactic with minimal semantic processing.  IPR nodes
-   // can fully represent those structurally well-defined syntactic entities.
-   // However, C++11 added attributes which are essentially token soups.  These
-   // attributes make the IPR interface less abstract than wanted.
-
-   // General classification of tokens, e.g. identifier, number, space, comment, etc.
-   enum class TokenCategory : uint8_t { };
-
-   // A numerical value associated with each token.
-   enum class TokenValue : uint16_t { };
-
-   struct Lexeme {
-      virtual const String& spelling() const = 0;
-      virtual const Source_location& locus() const = 0;
-   };
-
-   struct Token {
-      virtual const Lexeme& lexeme() const = 0;
-      virtual TokenValue value() const = 0;
-      virtual TokenCategory category() const = 0;
-   };
-
-   struct Attribute {
-      struct Visitor;
-      virtual void accept(Visitor&) const = 0;
-   };
-
-   // A simple token used as attribute.
-   struct BasicAttribute : Attribute {
-      virtual const Token& token() const = 0;
-   };
-
-   // An attribute of the form `token1 :: token2'
-   struct ScopedAttribute : Attribute {
-      virtual const Token& scope() const = 0;
-      virtual const Token& member() const = 0;
-   };
-
-   // An attribute of the form `token : attribute'.
-   struct LabeledAttribute : Attribute {
-      virtual const Token& label() const = 0;
-      virtual const Attribute& attribute() const = 0;
-   };
-
-   // An attribute of the form `f(args)'.
-   struct CalledAttribute : Attribute {
-      virtual const Attribute& function() const = 0;
-      virtual const Sequence<Attribute>& arguments() const = 0;
-   };
-
-   // An attribute of the form `attribute...'
-   struct ExpandedAttribute : Attribute {
-      virtual const Token& expander() const = 0;
-      virtual const Attribute& operand() const = 0;
-   };
-
-   // An attribute of the form `[[using check: memory(3), type(2)]]'
-   struct FactoredAttribute : Attribute {
-      virtual const Token& factor() const = 0;
-      virtual const Sequence<Attribute>& terms() const = 0;
-   };
-
-   // An attribute of the form `[[ expr ]]', where `expr' is the elaboration result
-   // of parsing and semantics analysis of the enclosed token sequence.  This is a 
-   // common non-standard form of attribute.
-   struct ElaboratedAttribute : Attribute {
-      virtual const Expr& elaboration() const = 0;
-   };
-
-   struct Attribute::Visitor {
-      virtual void visit(const BasicAttribute&) = 0;
-      virtual void visit(const ScopedAttribute&) = 0;
-      virtual void visit(const LabeledAttribute&) = 0;
-      virtual void visit(const CalledAttribute&) = 0;
-      virtual void visit(const ExpandedAttribute&) = 0;
-      virtual void visit(const FactoredAttribute&) = 0;
-      virtual void visit(const ElaboratedAttribute&) = 0;
-   };
-
                                 // -- DeclSpecifiers --
-   enum class DeclSpecifiers : uint32_t {
+   enum class DeclSpecifiers : std::uint32_t {
       None       = 0,
       Register   = 1 << 0,   // Banned from C++17.
       Static     = 1 << 1,
@@ -487,7 +195,7 @@ namespace ipr {
 
    constexpr DeclSpecifiers operator|(DeclSpecifiers a, DeclSpecifiers b)
    {
-      return DeclSpecifiers(uint32_t(a) | uint32_t(b));
+      return DeclSpecifiers(std::uint32_t(a) | std::uint32_t(b));
    }
 
    constexpr DeclSpecifiers& operator|=(DeclSpecifiers& a, DeclSpecifiers b)
@@ -497,7 +205,7 @@ namespace ipr {
 
    constexpr DeclSpecifiers operator&(DeclSpecifiers a, DeclSpecifiers b)
    {
-      return DeclSpecifiers(uint32_t(a) & uint32_t(b));
+      return DeclSpecifiers(std::uint32_t(a) & std::uint32_t(b));
    }
 
    constexpr DeclSpecifiers& operator&=(DeclSpecifiers& a, DeclSpecifiers b)
@@ -507,7 +215,7 @@ namespace ipr {
 
    constexpr DeclSpecifiers operator^(DeclSpecifiers a, DeclSpecifiers b)
    {
-      return DeclSpecifiers(uint32_t(a) ^ uint32_t(b));
+      return DeclSpecifiers(std::uint32_t(a) ^ std::uint32_t(b));
    }
 
    constexpr DeclSpecifiers& operator^=(DeclSpecifiers& a, DeclSpecifiers b)
@@ -522,7 +230,7 @@ namespace ipr {
 
                                  // -- Lambda_specifiers --
    // Declaration specifiers that can appear on a lambda expression.
-   enum class Lambda_specifiers : uint32_t {
+   enum class Lambda_specifiers : std::uint32_t {
       None = 0,
       Mutable    = 1 << 0,
       Constexpr  = 1 << 1,
@@ -833,58 +541,6 @@ namespace ipr {
       constexpr Type(Category_code c) : Expr{ c } { }
    };
 
-   // cv-qualifiers are actually type operators.  Much of these operators
-   // currently make sense only for classic type -- although it might
-   // be interesting to explore the notion of pointer to overload-set
-   // or reference to such an expression.
-   enum class Type_qualifier : uint8_t {
-      None             = 0,
-      Const            = 1 << 0,
-      Volatile         = 1 << 1,
-      Restrict         = 1 << 2        // not standard C++
-   };
-
-   constexpr Type_qualifier
-   operator|(Type_qualifier a, Type_qualifier b)
-   {
-      return Type_qualifier(uint8_t(a) | uint8_t(b));
-   }
-
-   inline Type_qualifier&
-   operator|=(Type_qualifier& a, Type_qualifier b)
-   {
-      return a = a | b;
-   }
-
-   constexpr Type_qualifier
-   operator&(Type_qualifier a, Type_qualifier b)
-   {
-      return Type_qualifier(uint8_t(a) & uint8_t(b));
-   }
-
-   inline Type_qualifier&
-   operator&=(Type_qualifier& a, Type_qualifier b)
-   {
-      return a = a & b;
-   }
-
-   constexpr Type_qualifier
-   operator^(Type_qualifier a, Type_qualifier b)
-   {
-      return Type_qualifier(uint8_t(a) ^ uint8_t(b));
-   }
-
-   inline Type_qualifier&
-   operator^=(Type_qualifier& a, Type_qualifier b)
-   {
-      return a = a ^ b;
-   }
-
-   constexpr bool implies(Type_qualifier a, Type_qualifier b)
-   {
-      return (a & b) == b;
-   }
-
                                 // -- Array --
    // An array-type describes object expressions that designate C-style
    // homogenous object containers that meet the random-access
@@ -1003,7 +659,7 @@ namespace ipr {
    // We also maintain the invariant that Qualified::qualifiers is never
    // Type::None, consequently it is an error to attempt to create such a node.
    struct Qualified : Binary<Category<Category_code::Qualified, Type>,
-                             ipr::Type_qualifier, const Type&> {
+                             ipr::Type_qualifiers, const Type&> {
       Arg1_type qualifiers() const { return first(); }
       Arg2_type main_variant() const { return second(); }
    };
@@ -1091,7 +747,7 @@ namespace ipr {
    // the definitions of which as part of the definition of the enumeration
    // itself.  By historical accident, enumerators are not "properly scoped".
    struct Enum : Category<Category_code::Enum, Udt<Enumerator>> {
-      enum class Kind : uint8_t {     // The kind of enum.
+      enum class Kind : std::uint8_t {     // The kind of enum.
          Legacy,                      // traditional C-style enum
          Scoped                       // scoped enum (C++11)
       };
@@ -1655,9 +1311,9 @@ namespace ipr {
 
                                 // -- Qualification --
    // A conversion that add cv-qualifiers
-   struct Qualification : Binary<Category<Category_code::Qualification>, const Expr&, Type_qualifier> {
+   struct Qualification : Binary<Category<Category_code::Qualification>, const Expr&, Type_qualifiers> {
       Arg1_type expr() const { return first(); }
-      Arg2_type qualifier() const { return second(); }
+      Arg2_type qualifiers() const { return second(); }
    };
 
                                 // -- Reinterpret_cast --
@@ -1773,6 +1429,16 @@ namespace ipr {
    // Its type should be set to "void".
    struct Asm : Category<Category_code::Asm, Directive> {
       virtual const String& text() const = 0;
+   };
+
+                                // -- Specifiers_spread --
+   // A directive to spread a decl-specifier-seq over a collection of init-declarators.
+   // - The init-declarators are given by the `targets()` operation.
+   // - The type component of the decl-specifier-seq is given by `type()`.
+   // - The non-type component of the decl-specifier-seq is given by `specifiers()`.
+   struct Specifiers_spread : Category<Category_code::Specifiers_spread, Directive> {
+      virtual DeclSpecifiers specifiers() const = 0;
+      virtual const Sequence<cxx_form::Proclamator>& targets() const = 0;
    };
 
                                 // -- Static_assert --
@@ -2395,6 +2061,7 @@ namespace ipr {
 
       virtual void visit(const Directive&) = 0;
       virtual void visit(const Asm&);
+      virtual void visit(const Specifiers_spread&);
       virtual void visit(const Static_assert&);
       virtual void visit(const Structured_binding&);
       virtual void visit(const Using_declaration&);

--- a/include/ipr/location
+++ b/include/ipr/location
@@ -1,0 +1,54 @@
+// -*- C++ -*-
+//
+// This file is part of The Pivot framework.
+// Written by Gabriel Dos Reis.
+// See LICENSE for copyright and license notices.
+//
+
+#ifndef IPR_LOCATION_INCLUDED
+#define IPR_LOCATION_INCLUDED
+
+#include <cstdint>
+
+namespace ipr {
+
+                                // -- Various Location Types --
+   // C++ constructs span locations.  There are at least four flavours of
+   // locations:
+   //       (a) physical source location;
+   //       (b) logical source location;
+   //       (c) physical unit location; and
+   //       (d) logical unit location.
+   // Physical and logical source locations are locations as witnessed
+   // at translation phase 2 (see ISO C++, §2.1/1).
+   // Physical and logical unit locations are locations as manifest when
+   // looking at a translation unit, at translation phase 4.
+   //
+   // Many IPR nodes will have a source and unit locations.  Instead of
+   // storing a source file and unit name as a string in every
+   // location data type, we save space by mapping file-names and
+   // unit-names to IDs (integers).  That mapping is managed by the Unit
+   // instance.
+
+   enum class Line_number : std::uint32_t { };
+   enum class Column_number : std::uint32_t { };
+
+   struct Basic_location {
+      Line_number line = { };
+      Column_number column = { };
+   };
+
+   enum class File_index : std::uint32_t { };
+
+   struct Source_location : Basic_location {
+      File_index file = { };    // ID of the file
+   };
+
+   enum class Unit_index : std::uint32_t { };
+
+   struct Unit_location : Basic_location {
+      Unit_index unit = { };    // ID of the unit
+   };
+}
+
+#endif // IPR_LOCATION_INCLUDED

--- a/include/ipr/node-category
+++ b/include/ipr/node-category
@@ -146,6 +146,7 @@ Scope,                              // ipr::Scope
 
 Asm,                                // ipr::Asm
 Deduction_guide,                    // ipr::Deduction_guide
+Specifiers_spread,                  // ipr::Specifiers_spread
 Static_assert,                      // ipr::Static_assert
 Structured_binding,                 // ipr::Structured_binding
 Using_declaration,                  // ipr::Using_declaration

--- a/include/ipr/synopsis
+++ b/include/ipr/synopsis
@@ -8,6 +8,8 @@
 #ifndef IPR_SYNOPSIS_INCLUDED
 #define IPR_SYNOPSIS_INCLUDED
 
+#include <ipr/ancillary>
+
 namespace ipr {
    struct Node;                  // universal base class for all IPR nodes
 
@@ -161,6 +163,7 @@ namespace ipr {
    struct Reinterpret_cast;      // reinterpret-cast  reinterpret_cast<T>(v)
    struct Rshift;                // right shift                    a >> b
    struct Rshift_assign;         // in-place right shift           a >>= b
+   struct Scope_ref;             // qualified name                N::f
    struct Static_cast;           // static-cast            static_cast<T>(v)
    struct Widen;                 // derived to base class conversion
 
@@ -201,6 +204,7 @@ namespace ipr {
    // -----------------------------------------------
    struct Asm;                   // asm-declaration
    struct Deduction_guide;       // deduction-guide declaration
+   struct Specifiers_spread;     // spread of decls-sequence-seq over a sequence of declarators
    struct Static_assert;         // static-assert declaration
    struct Structured_binding;    // structured-binding declaration
    struct Using_declaration;     // using-declaration
@@ -236,6 +240,9 @@ namespace ipr {
    // -- built-ins, but not constants --
    // ----------------------------------
    struct Global_scope;          // global namespace -- "::"
+
+   // -- Ancillary classes --
+   template<typename> struct Sequence;    // sequence of items
 }
 
 #endif // IPR_SYNOPSIS_INCLUDED

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -100,6 +100,37 @@ namespace ipr::util {
     }
 }
 
+namespace ipr::cxx_form::impl {
+   Callable_species::Callable_species(const ipr::Region& parent, Mapping_level level)
+      : inputs{ parent, level }
+   { }
+
+   Simple_indirector* form_factory::make_simple_indirector()
+   {
+      return simple_indirectors.make();
+   }
+
+   Member_indirector* form_factory::make_member_indirector()
+   {
+      return member_indirectors.make();
+   }
+
+   Id_species* form_factory::make_id_species()
+   {
+      return id_species.make();
+   }
+
+   Array_species* form_factory::make_array_species()
+   {
+      return array_species.make();
+   }
+
+   Parenthesized_species* form_factory::make_parenthesized_species()
+   {
+      return paren_species.make();
+   }
+}
+
 namespace ipr::impl {
       Token::Token(const ipr::String& s, const Source_location& l,
                    TokenValue v, TokenCategory c)
@@ -476,6 +507,11 @@ namespace ipr::impl {
          return make(asms, s).with_type(t);
       }
 
+      impl::Specifiers_spread* dir_factory::make_specifiers_spread()
+      {
+         return spreads.make();
+      }
+
       impl::Static_assert* dir_factory::make_static_assert(const ipr::Expr& e, Optional<ipr::String> s)
       {
          return asserts.make(e, s);
@@ -812,11 +848,11 @@ namespace ipr::impl {
       }
 
       impl::Qualified*
-      type_factory::make_qualified(ipr::Type_qualifier cv, const ipr::Type& t)
+      type_factory::make_qualified(ipr::Type_qualifiers cv, const ipr::Type& t)
       {
          // It is an error to call this function if there is no real
          // qualified.
-         if (cv == ipr::Type_qualifier::None)
+         if (cv == ipr::Type_qualifiers::None)
             throw std::domain_error
                ("type_factoy::make_qualified: no qualifier");
 
@@ -1750,7 +1786,7 @@ namespace ipr::impl {
       }
 
       impl::Qualification*
-      expr_factory::make_qualification(const ipr::Expr& e, ipr::Type_qualifier q, const ipr::Type& t)
+      expr_factory::make_qualification(const ipr::Expr& e, ipr::Type_qualifiers q, const ipr::Type& t)
       {
          return make(qualifications, e, q).with_type(t);
       }
@@ -2118,8 +2154,8 @@ namespace ipr::impl {
       }
 
       const ipr::Qualified&
-      Lexicon::get_qualified(ipr::Type_qualifier cv, const ipr::Type& t) {
-         assert (cv != ipr::Type_qualifier::None);
+      Lexicon::get_qualified(ipr::Type_qualifiers cv, const ipr::Type& t) {
+         assert (cv != ipr::Type_qualifiers::None);
          return *finish_type(types.make_qualified(cv, t));
       }
 
@@ -2237,7 +2273,7 @@ int main()
    // Build the variable's name,
    const Name* name = lexicon.make_identifier("bufsz");
    // then its type,
-   auto& type = lexicon.get_qualified(Type_qualifier::Const, lexicon.int_type());
+   auto& type = lexicon.get_qualified(Type_qualifiers::Const, lexicon.int_type());
    // and the actual impl::Var node,
    impl::Var* var = global_scope->make_var(*name, type);
    // set its initializer,

--- a/src/io.cxx
+++ b/src/io.cxx
@@ -1303,13 +1303,13 @@ namespace ipr {
    }
 
    Printer&
-   operator<<(Printer& printer, Type_qualifier cv)
+   operator<<(Printer& printer, Type_qualifiers cv)
    {
-      if (implies(cv, Type_qualifier::Const))
+      if (implies(cv, Type_qualifiers::Const))
          printer << xpr_identifier("const");
-      if (implies(cv, Type_qualifier::Volatile))
+      if (implies(cv, Type_qualifiers::Volatile))
          printer << xpr_identifier("volatile");
-      if (implies(cv, Type_qualifier::Restrict))
+      if (implies(cv, Type_qualifiers::Restrict))
          printer << xpr_identifier("restrict");
 
       return printer;

--- a/src/traversal.cxx
+++ b/src/traversal.cxx
@@ -811,6 +811,11 @@ ipr::Visitor::visit(const Asm& d)
    visit(as<Directive>(d));
 }
 
+void ipr::Visitor::visit(const Specifiers_spread& d)
+{
+   visit(as<Directive>(d));
+}
+
 void
 ipr::Visitor::visit(const Static_assert& d)
 {

--- a/tests/unit-tests/conversions.cpp
+++ b/tests/unit-tests/conversions.cpp
@@ -25,7 +25,7 @@ TEST_CASE("C++ Standard Conversions") {
   INFO("int* const ptr = 0;");
   // Pointer Conversion            (Coercion)
   const auto& ptr_type = lexicon.get_qualified(
-    Type_qualifier::Const, lexicon.get_pointer(lexicon.int_type()));
+    Type_qualifiers::Const, lexicon.get_pointer(lexicon.int_type()));
   auto& ptr = *unit.global_region()->declare_var(*lexicon.make_identifier("ptr"), ptr_type);
   ptr.init = lexicon.make_coercion(
     *lexicon.make_literal(lexicon.int_type(), "0"),
@@ -110,19 +110,19 @@ TEST_CASE("CV Conversions") {
   INFO("(int) -> (volatile int)");
   lexicon.make_qualification(
     *lexicon.make_literal(lexicon.int_type(), "7"),
-    Type_qualifier::Volatile,
+    Type_qualifiers::Volatile,
     lexicon.int_type() // prvalue can be adjusted to remove qualifiers (see 7.2.2/2)
   );
 
   INFO("const int* ptr;");
   const auto& ptr_type = lexicon.get_qualified(
-    Type_qualifier::Const, lexicon.get_pointer(lexicon.int_type()));
+    Type_qualifiers::Const, lexicon.get_pointer(lexicon.int_type()));
   auto& ptr = *unit.global_region()->declare_var(*lexicon.make_identifier("ptr"), ptr_type);
 
   // Removal of const is a non-implicit conversion
   INFO("const_cast<int* const>(ptr);");
   lexicon.make_const_cast(
-    lexicon.get_qualified(Type_qualifier::Const, lexicon.get_pointer(lexicon.int_type())),
+    lexicon.get_qualified(Type_qualifiers::Const, lexicon.get_pointer(lexicon.int_type())),
     *lexicon.make_id_expr(ptr)
   );
 
@@ -135,18 +135,18 @@ TEST_CASE("CV Conversions") {
   lexicon.make_qualification(
     *lexicon.make_qualification(
       *lexicon.make_id_expr(ptr_ptr),
-      Type_qualifier::Const,
-      lexicon.get_qualified(Type_qualifier::Const, ptr_ptr.type())
+      Type_qualifiers::Const,
+      lexicon.get_qualified(Type_qualifiers::Const, ptr_ptr.type())
     ),
-    Type_qualifier::Const,
-    lexicon.get_pointer(lexicon.get_qualified(Type_qualifier::Const,
+    Type_qualifiers::Const,
+    lexicon.get_pointer(lexicon.get_qualified(Type_qualifiers::Const,
       lexicon.get_pointer(lexicon.int_type())))
       // prvalue can be adjusted to remove qualifier on top-level (see 7.2.2/2)
   );
 
   INFO("const int var = 0;");
   auto& var = *unit.global_region()->declare_var(*lexicon.make_identifier("var"), 
-    lexicon.get_qualified(Type_qualifier::Const, lexicon.int_type()));
+    lexicon.get_qualified(Type_qualifiers::Const, lexicon.int_type()));
 
   // Pretend can be used to explicitly reperesent automatic type adjustment as detailed
   // in (7.2.2/2). Compilers are likely to just apply this adjustment on constraints without
@@ -156,7 +156,7 @@ TEST_CASE("CV Conversions") {
   lexicon.make_pretend(
     *lexicon.make_address(
       *lexicon.make_id_expr(var),
-      &lexicon.get_qualified(Type_qualifier::Const, lexicon.int_type())
+      &lexicon.get_qualified(Type_qualifiers::Const, lexicon.int_type())
     ),
     lexicon.int_type(),
     lexicon.int_type()

--- a/tests/unit-tests/simple.cpp
+++ b/tests/unit-tests/simple.cpp
@@ -13,7 +13,7 @@ TEST_CASE("global constant variable can be printed") {
   impl::Scope* global_scope = unit.global_scope();
 
   const Name* name = lexicon.make_identifier("bufsz");
-  auto& type = lexicon.get_qualified(Type_qualifier::Const, lexicon.int_type());
+  auto& type = lexicon.get_qualified(Type_qualifiers::Const, lexicon.int_type());
   impl::Var* var = global_scope->make_var(*name, type);
   var->init = lexicon.make_literal(lexicon.int_type(), "1024");
 
@@ -33,7 +33,7 @@ TEST_CASE("Can create and print line numbers")
   impl::Scope* global_scope = unit.global_scope();
 
   const Name* name = lexicon.make_identifier("bufsz");
-  auto& type = lexicon.get_qualified(Type_qualifier::Const, lexicon.int_type());
+  auto& type = lexicon.get_qualified(Type_qualifiers::Const, lexicon.int_type());
   impl::Var* var = global_scope->make_var(*name, type);
   var->init = lexicon.make_literal(lexicon.int_type(), "1024");
 


### PR DESCRIPTION
This patch adds support for multiple _init-declarator_ s in a single declaration, as an IPR directive.

The patch also incorporates some Spring cleaning, which leads to source level breakage.

Fixes https://github.com/GabrielDosReis/ipr/issues/177