### PR TITLE
Rename `impl::Expr<T>::constraint`

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -327,10 +327,10 @@ namespace ipr::impl {
    // -- impl::Expr
    template<class Interface>
    struct Expr : impl::Node<Interface> {
-      Optional<ipr::Type> constraint;
+      Optional<ipr::Type> typing;
 
-      Expr(Optional<ipr::Type> t = { }) : constraint{ t } { }
-      const ipr::Type& type() const final { return constraint.get(); }
+      Expr(Optional<ipr::Type> t = { }) : typing{ t } { }
+      const ipr::Type& type() const final { return typing.get(); }
    };
 
    // -- impl::Unary_expr: Short hand for the implementation of generic unary expression nodes.
@@ -1145,14 +1145,14 @@ namespace ipr::impl {
 
    struct Enumerator final : unique_decl<ipr::Enumerator> {
       const ipr::Name& id;
-      const ipr::Enum& constraint;
+      const ipr::Enum& typing;
       const Decl_position scope_pos;
       util::ref<const ipr::Region> where;
       Optional<ipr::Expr> init;
 
       Enumerator(const ipr::Name&, const ipr::Enum&, Decl_position);
       const ipr::Name& name() const final { return id; }
-      const ipr::Type& type() const final { return constraint; }
+      const ipr::Type& type() const final { return typing; }
       const ipr::Region& lexical_region() const final { return where.get(); }
       const ipr::Region& home_region() const final { return where.get(); }
       Decl_position position() const final { return scope_pos; }
@@ -1250,7 +1250,7 @@ namespace ipr::impl {
    };
 
    struct Lambda : impl::Node<ipr::Lambda> {
-      util::ref<const ipr::Closure> constraint;
+      util::ref<const ipr::Closure> typing;
       Optional<ipr::Type> value_type;
       impl::Parameter_list parms;
       util::ref<const ipr::Expr> body;
@@ -1261,7 +1261,7 @@ namespace ipr::impl {
       Lambda_specifiers lam_spec;
 
       Lambda(const ipr::Region&, Mapping_level);
-      const ipr::Closure& type() const final { return constraint.get(); }
+      const ipr::Closure& type() const final { return typing.get(); }
       Optional<ipr::Type> target() const final { return value_type; }
       const ipr::Parameter_list& parameters() const final { return parms; }
       Optional<ipr::Expr> requirement() const final { return decl_constraint; }
@@ -1636,7 +1636,7 @@ namespace ipr::impl {
       Region body;
       Udt(const ipr::Region* pr, const ipr::Type& t) : body(pr)
       {
-         this->constraint = &t;
+         this->typing = &t;
          body.owned_by = this;
       }
 

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -228,7 +228,7 @@ namespace ipr::impl {
       Symbol::Symbol(const ipr::Name& n, const ipr::Type& t)
          : Unary_expr<ipr::Symbol>{ n }
       {
-         constraint = &t;
+         typing = &t;
       }
 
       // -- impl::New --
@@ -331,13 +331,13 @@ namespace ipr::impl {
 
                T* with_type(const ipr::Type& t) 
                {
-                  impl->constraint = &t;
+                  impl->typing = &t;
                   return impl;
                }
 
                T* with_type(Optional<ipr::Type> t) 
                {
-                  impl->constraint = t;
+                  impl->typing = t;
                   return impl;
                }
 
@@ -381,7 +381,7 @@ namespace ipr::impl {
       // ----------------------
 
       Enumerator::Enumerator(const ipr::Name& n, const ipr::Enum& t, Decl_position p)
-            : id{n}, constraint{t}, scope_pos{p}, where{}, init{}
+            : id{n}, typing{t}, scope_pos{p}, where{}, init{}
       { }
 
       // -----------------
@@ -1278,7 +1278,7 @@ namespace ipr::impl {
          };
 
          auto sym = symbols.insert(n, comparator);
-         sym->constraint = &t;
+         sym->typing = &t;
          return *sym;
       }
 
@@ -2050,8 +2050,8 @@ namespace ipr::impl {
 
       template<class T>
       T* Lexicon::finish_type(T* t) {
-         if (not t->constraint.is_valid())
-            t->constraint = &anytype;
+         if (not t->typing.is_valid())
+            t->typing = &anytype;
 
          if (not t->id.is_valid())
             t->id = make_type_id(*t);
@@ -2185,7 +2185,7 @@ namespace ipr::impl {
       impl::Enum*
       Lexicon::make_enum(const ipr::Region& pr, Enum::Kind k) {
          auto t = types.make_enum(pr, k);
-         t->constraint = &enumtype;
+         t->typing = &enumtype;
          return t;
       }
 
@@ -2203,7 +2203,7 @@ namespace ipr::impl {
       Lexicon::make_mapping(const ipr::Region& r, Mapping_level l) {
          auto x = expr_factory::make_mapping(r, l);
          // Note: the parameters form a Product type needing its type set
-         x->parms.parms.scope.decls.constraint = &anytype;
+         x->parms.parms.scope.decls.typing = &anytype;
          return x;
       }
 


### PR DESCRIPTION
Back in 2004, the vision and the details of how concepts were supposed to work were different from what eventually ended up in C++20.  In particular, in those days a concept is just a generalized type - and each expression had a minimal set of constraints or properties (concept) which is its type.  Hence the naming of the implementation field `impl::Expr<T>::constraint`.

The vocabulary of C++20 concepts are slightly different from those of the early days, so renaming `constraint` to `typing` (type assigned through the usual type assignment rules) to avoid confusion.