### PR TITLE
The type of an alias is now always that of its initializer

### DIFF
--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -1779,7 +1779,6 @@ namespace ipr {
    // An alias is always initialized -- with what it is an alias for.
    // The type of an Alias expression is that of its initializer.
    struct Alias : Category<Category_code::Alias, Decl> {
-      const Type& type() const override { return initializer().get().type(); }
       const Region& lexical_region() const final { return home_region(); }
    };
 


### PR DESCRIPTION
In general, the type of an initializer is that of its initializer -- especially for type aliases.  However, structured bindings can introduce aliases too (at object level) and the corresponding binding may have acquired a _cv-qualifier_.  Therefore, this patch removes the incorrect override in the interface of `Alias` -- since it is overriden later in the implementation, it is never executed.

In short, this is a removal of a wrong dead code.