### PR TITLE
Cleanup `util::string::arena`

### DIFF
--- a/include/ipr/utility
+++ b/include/ipr/utility
@@ -372,21 +372,19 @@ namespace ipr {
       struct string {
          struct arena;
 
-         using size_type = int; // integer type that string length
+         using size_type = std::ptrdiff_t; // integer type that string length
 
          // number of characters directly contained in this header
-         // of the string.  Takent to be the number of bytes in size_type.
-         enum {
-            padding_count = sizeof (size_type)
-         };
+         // of the string.  Taken to be the number of bytes in size_type.
+         static constexpr size_type padding_count = sizeof (size_type);
 
-         int size() const { return length; }
-         char operator[](int) const;
+         size_type size() const { return length; }
+         char operator[](size_type) const;
 
          const char* begin() const { return data; }
          const char* end() const { return begin() + length; }
 
-         int length;
+         size_type length;
          char data[padding_count];
       };
 
@@ -394,26 +392,26 @@ namespace ipr {
          arena();
          ~arena();
 
-         const string* make_string(const char*, int);
+         const string* make_string(const char*, size_type);
 
       private:
-         util::string* allocate(int);
-         int remaining_header_count() const
+         util::string* allocate(size_type);
+         auto remaining_header_count() const
          {
-            return static_cast<int>(next_header - &mem->storage[0]);
+            return next_header - &mem->storage[0];
          }
 
          struct pool;
 
-         enum { headersz = sizeof (util::string) };
-         enum { bufsz = headersz << (20 - sizeof (pool*)) };
+         static constexpr size_type headersz = sizeof (util::string);
+         static constexpr size_type bufsz = headersz << (20 - sizeof (pool*));
 
          struct pool {
             pool* previous;
             util::string storage[bufsz];
          };
 
-         enum { poolsz = sizeof (pool) };
+         static constexpr size_type poolsz = sizeof (pool);
 
          pool* mem;
          string* next_header;

--- a/src/utility.cxx
+++ b/src/utility.cxx
@@ -9,7 +9,7 @@
 #include <algorithm>
 
 char
-ipr::util::string::operator[](int i) const
+ipr::util::string::operator[](size_type i) const
 {
    if (i < 0 or i >= length)
       throw std::domain_error("invalid index for util::string::operator[]");
@@ -35,9 +35,9 @@ ipr::util::string::arena::~arena()
 // Allocate storage sufficient to hold an immutable string of length "n".
 
 ipr::util::string*
-ipr::util::string::arena::allocate(int n)
+ipr::util::string::arena::allocate(size_type n)
 {
-   const int m = (n - string::padding_count + headersz - 1) / headersz + 1;
+   const auto m = (n - string::padding_count + headersz - 1) / headersz + 1;
    string* header{};
 
    // If we have enough space left, juts grab it.
@@ -71,14 +71,10 @@ ipr::util::string::arena::allocate(int n)
 }
 
 const ipr::util::string*
-ipr::util::string::arena::make_string(const char* s, int n)
+ipr::util::string::arena::make_string(const char* s, size_type n)
 {
    string* header = allocate(n);
-
    header->length = n;
-   // >>>> Yuriy Solodkyy: 2007/05/29
-   // Put cast to avoid gettinch assert with safe STL in MSVC
-   std::copy(s, s + n, (char*)header->data);
-   // <<<< Yuriy Solodkyy: 2007/05/29
+   std::copy(s, s + n, &header->data[0]);
    return header;
 }


### PR DESCRIPTION
Most of the `ipr/utility` header was written in the first half of the 2000s, and it shows :-)

This patch takes the opportunity of fixing an issue reported by the Analysis workflow to do some Spring cleaning, avoiding the good old unnamed `enum` trick in favor of typed `constexpr` variables.

Fixes #210 