### PR TITLE
Simplify Tor type

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -1214,7 +1214,7 @@ namespace ipr::impl {
    using Array = Binary_type<ipr::Array>;
    using Decltype = Unary_type<ipr::Decltype>;
    using As_type = Binary_type<ipr::As_type>;
-   using Tor = Ternary_type<ipr::Tor>;
+   using Tor = Binary_type<ipr::Tor>;
    using Function = Quaternary<Type<ipr::Function>>;
    using Pointer = Unary_type<ipr::Pointer>;
    using Product = Unary_type<ipr::Product>;
@@ -1750,7 +1750,7 @@ namespace ipr::impl {
       impl::Qualified* make_qualified(ipr::Type_qualifiers,
                                        const ipr::Type&);
       impl::Decltype* make_decltype(const ipr::Expr&);
-      impl::Tor* make_tor(const ipr::Product&, const ipr::Sum&, const ipr::Linkage&);
+      impl::Tor* make_tor(const ipr::Product&, const ipr::Sum&);
       impl::Function* make_function(const ipr::Product&, const ipr::Type&,
                                     const ipr::Sum&, const ipr::Linkage&);
       impl::Pointer* make_pointer(const ipr::Type&);

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -587,14 +587,11 @@ namespace ipr {
    // may look at them as just some regular function, and assign them a Function type,
    // the higher level semantics of C++ is best served by a dedicated type to abstract
    // over ABI interpretation.
-   struct Tor : Ternary<Category<Category_code::Tor, Type>,
-                        const Expr&, const Type&, const Linkage&> {
+   struct Tor : Binary<Category<Category_code::Tor, Type>, const Expr&, const Type&> {
       // The parameter-list to a tor type.  Always empty for a Standard C++ destructor.
       Arg1_type source() const { return first(); }
       // The exception-specification for this tor type.
       Arg2_type throws() const { return second(); }
-      // The language linkage for this to type.  Default is "C++".
-      Arg3_type lang_linkage() const { return third(); }
    };
 
                                 // -- Function --

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -920,10 +920,10 @@ namespace ipr::impl {
       };
 
       impl::Tor*
-      type_factory::make_tor(const ipr::Product& s, const ipr::Sum& e, const ipr::Linkage& l)
+      type_factory::make_tor(const ipr::Product& s, const ipr::Sum& e)
       {
          using rep = impl::Tor::Rep;
-         return tors.insert(rep{ s, e, l }, ternary_compare());
+         return tors.insert(rep{ s, e }, binary_compare());
       }
 
       impl::Function*


### PR DESCRIPTION
While in general, a `Tor` type is close to a `Function` type and, in principle, should have a language linkage, that does not actually happen in practice.  This patch removes that possibility for now.  It should be reinstated when we have more evidence of its usefulness (non-`C++` language linkage constructors) in practice.