### PR TITLE
C and C++ linkage are known to all implementations

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -43,7 +43,7 @@ namespace ipr::util {
    // This utility class captures the intent of disabling the automatic generation of the usual
    // copy/move operations.  The class definition is more verbose than the intent.
    struct immotile {
-      immotile() = default;
+      constexpr immotile() = default;
       immotile(immotile&&) = delete;
       immotile(const immotile&) = delete;
       immotile& operator=(immotile&&) = delete;
@@ -65,7 +65,7 @@ namespace ipr::impl {
       using typename Interface::Arg_type;
       Arg_type rep;
 
-      explicit Unary(Arg_type a) : rep{ a } { }
+      explicit constexpr Unary(Arg_type a) : rep{ a } { }
       Arg_type operand() const final { return rep; }
    };
 


### PR DESCRIPTION
Make them `constexpr`.

Back in the early 2004, there was no support for `constexpr` data (the constexpr feature was being debated by the C++ standards committee), so orderly initialization had to be hand rolled.  This patch takes advantages of `constexpr` to remove ceremonial computation and increase certainty around `C` and `C++` linkage data objects.

Fixes #213 #214