### PR TITLE
Use utilities to deduce enumeration underlying type

### DIFF
--- a/include/ipr/io
+++ b/include/ipr/io
@@ -18,19 +18,20 @@
 namespace ipr
 {
    // FIXME: Remove these data structures.
-   /// A data structure used to map different uses of a name to the
-   /// corresponding declaration. It is used by XPR printer to print name
-   /// disambiguation information. A similar but a bit more elaborated structure
-   /// is used by XPR parser to relink uses of names to appropriate declarations.
-   /// The key of the map is the node_id of the name used, while the value
-   /// is the information about corresponding declaration.
+   // A data structure used to map different uses of a name to the
+   // corresponding declaration. It is used by XPR printer to print name
+   // disambiguation information. A similar but a bit more elaborated structure
+   // is used by XPR parser to relink uses of names to appropriate declarations.
+   // The key of the map is the node_id of the name used, while the value
+   // is the information about corresponding declaration.
    struct disambiguation_map_type : std::map<const ipr::Name*, std::vector<const ipr::Decl*>>
    {
       using declarations = std::vector<const ipr::Decl*>;
+      using size_type = std::ptrdiff_t;
 
-      /// Given a name and a declaration that corresponds to it, looks up
-      /// or allocates a disambiguation id for them.
-      int get_disambiguation(const ipr::Name& name, const ipr::Decl& declaration)
+      // Given a name and a declaration that corresponds to it, looks up
+      // or allocates a disambiguation id for them.
+      size_type get_disambiguation(const ipr::Name& name, const ipr::Decl& declaration)
       {
          declarations& decls = (*this)[&name];
          declarations::const_iterator p = std::find(decls.begin(), decls.end(), &declaration);
@@ -38,11 +39,11 @@ namespace ipr
          if (p == decls.end())
          {
             decls.push_back(&declaration);
-            return static_cast<int>(decls.size()); // Because disambiguations are 1-based
+            return decls.size();                         // Because disambiguations are 1-based
          }
-         return static_cast<int>(p - decls.begin()) + 1; // Because disambiguations are 1-based
+         return (p - decls.begin()) + 1;                 // Because disambiguations are 1-based
       }
-   }; // of struct disambiguation_map_type
+   };
 
    struct Printer {
       enum class Padding {
@@ -65,17 +66,8 @@ namespace ipr
       // take over all other good candidates when an implicit conversion
       // would be needed.
       Printer& operator<<(const char*);
-
-      Printer& operator<<(char c) { stream << c; return *this; }
-
-      Printer& operator<<(signed char c) { stream << c; return *this; }
-
-      Printer& operator<<(unsigned char c) { stream << c; return *this; }
-
-      Printer& operator<<(int i) { stream << i; return *this; }
-
-      template<class T>
-      Printer& operator<<(T& f(T&)) { stream << f; return *this; }
+      template<typename T> requires util::std_insertable<T>
+      Printer& operator<<(T t) { stream << t; return *this; }
 
       // Setting padding flags
       Printer& operator<<(Padding p) { pad = p; return *this; }

--- a/include/ipr/utility
+++ b/include/ipr/utility
@@ -16,423 +16,433 @@
 #include <algorithm>
 #include <iosfwd>
 #include <memory>
-
-namespace ipr {
-   namespace util {
-
-      // -- Check for nonnull pointer.
-      template<typename T>
-      inline T* check(T* ptr)
-      {
-         if (ptr == nullptr)
-            throw std::logic_error("attempt to dereference a null pointer");
-         return ptr;
-      }
-
-      // At various places in the implementation of the IPR interface, certain logical
-      // references are stored as pointers because of implementation necessity, or sometimes convenience.
-      // This wrapper class ensures that when the data behind those logical references are 
-      // access the implementation pointer is not null.  Note that the role served by this
-      // class is not the same as ipr::Optional (which is a genuine representation of optional information),
-      // or std::reference_wrapper (which assumes existence of reference to begin with).
-      template<typename T>
-      struct ref {
-         ref(T* p = { }) : ptr{p} { }
-         T& get() const { return *util::check(ptr); }
-      private:
-         T* ptr;
-      };
-
-      // --------------------
-      // -- Red-back trees --
-      // --------------------
-
-      // The implementation found here is based on ideas in
-      // T. H. Cormen, C. E. Leiserson, R. L. Rivest and C. Strein:
-      //     "Introduction to Algorithms", 2nd edition.
-
-      // One reason why we (re-)implement our own "set" data structures
-      // instead of using the standard ones is because standard sets
-      // do not allow for in-place modification.  That puts an
-      // unreasonable burden on how we can write the codes for IPR.
-      // Another reason is that, while the standard set is really a
-      // a red-lack tree in disguise, there is no way one can have
-      // access to that structure.  Furthermore, we use red-black
-      // trees in both "intrusive" and "non-intrusive" forms.
-
-      namespace rb_tree {
-         // Marker used to designate a tree node as either 'black' or 'red'.
-         enum class Color { Black, Red };
-
-         // The type of the links used to chain together data in
-         // a red-black tree.
-         template<class Node>
-         struct link {
-            enum Dir { Left, Right, Parent };
-
-            Node*& parent() { return arm[Parent]; }
-            Node*& left() { return arm[Left]; }
-            Node*& right() { return arm[Right]; }
-
-            Node* arm[3] { };
-            Color color = Color::Red;
-         };
-
-         template<class Node>
-         struct core {
-            std::ptrdiff_t size() const { return count; }
-
-         protected:
-            Node* root { };
-            std::ptrdiff_t count { };
-
-            // Do a left rotation about X.  X->left() is assumed nonnull,
-            // which after the manoeuvre becomes X's parent.
-            void rotate_left(Node*);
-
-            // Same as rotate_left, except that the rotation does right.
-            void rotate_right(Node*);
-
-            // After raw insertion, the tree is unbalanced again; this
-            // function re-balance the tree, fixing up properties destroyed.
-            void fixup_insert(Node*);
-         };
-
-         template<class Node>
-         void
-         core<Node>::rotate_left(Node* x)
-         {
-            Node* y = x->right();
-            // Make y's left a subtree of x's right subtree.
-            x->right() = y->left();
-            if (y->left() != nullptr)
-               y->left()->parent() = x;
-
-            // Update y's parent and its left or right arms.
-            y->parent() = x->parent();
-            if (x->parent() == nullptr)
-               // x was the root of the tree; make y the new root.
-               this->root = y;
-            else if (x->parent()->left() == x)
-               x->parent()->left() = y;
-            else
-               x->parent()->right() = y;
-
-            // Now, x must go on y's left.
-            y->left() = x;
-            x->parent() = y;
-         }
-
-         template<class Node>
-         void
-         core<Node>::rotate_right(Node* x)
-         {
-            Node* y = x->left();
-
-            x->left() = y->right();
-            if (y->right() != nullptr)
-               y->right()->parent() = x;
-
-            y->parent() = x->parent();
-            if (x->parent() == nullptr)
-               this->root = y;
-            else if (x->parent()->right() == x)
-               x->parent()->right() = y;
-            else
-               x->parent()->left() = y;
-
-            y->right() = x;
-            x->parent() = y;
-         }
-
-         template<class Node>
-         void
-         core<Node>::fixup_insert(Node* z)
-         {
-            while (z != root and z->parent()->color == Color::Red) {
-               if (z->parent() == z->parent()->parent()->left()) {
-                  Node* y = z->parent()->parent()->right();
-                  if (y != nullptr and y->color == Color::Red) {
-                     z->parent()->color = Color::Black;
-                     y->color = Color::Black;
-                     z->parent()->parent()->color = Color::Red;
-                     z = z->parent()->parent();
-                  } else {
-                     if (z->parent()->right() == z) {
-                        z = z->parent();
-                        rotate_left(z);
-                     }
-                     z->parent()->color = Color::Black;
-                     z->parent()->parent()->color = Color::Red;
-                     rotate_right(z->parent()->parent());
-                  }
-               } else {
-                  Node* y = z->parent()->parent()->left();
-                  if (y != nullptr and y->color == Color::Red) {
-                     z->parent()->color = Color::Black;
-                     y->color = Color::Black;
-                     z->parent()->parent()->color = Color::Red;
-                     z = z->parent()->parent();
-                  } else {
-                     if (z->parent()->left() == z) {
-                        z = z->parent();
-                        rotate_right(z);
-                     }
-                     z->parent()->color = Color::Black;
-                     z->parent()->parent()->color = Color::Red;
-                     rotate_left(z->parent()->parent());
-                  }
-               }
-
-            }
-
-            root->color = Color::Black;
-         }
-
-
-         // A chain is an rb-tree that supports search and insertion, with
-         // the comparison object passed as a parameter instead of being built
-         // into the tree type directly.  The comparison object `cmp` is always
-         // invoked as `cmp(data, key)` where `data` designates an existing
-         // object stored at a node in the chain, and `key` is the parameter by which
-         // the tree is searched.
-         template<class Node>
-         struct chain : core<Node> {
-            template<class Comp>
-            Node* insert(Node*, Comp);
-
-            template<typename Key, class Comp>
-            Node* find(const Key&, Comp) const;
-         };
-
-         template<class Node>
-         template<typename Key, class Comp>
-         Node*
-         chain<Node>::find(const Key& key, Comp comp) const
-         {
-            bool found = false;
-            Node* result = this->root;
-            while (result != nullptr and not found) {
-               auto ordering = comp(*result, key) ;
-               if (ordering < 0)
-                  result = result->left();
-               else if (ordering > 0)
-                  result = result->right();
-               else
-                  found = true;
-            }
-
-            return result;
-         }
-
-         template<class Node>
-         template<class Comp>
-         Node*
-         chain<Node>::insert(Node* z, Comp comp)
-         {
-            Node** slot = &this->root;
-            Node* up = nullptr;
-
-            bool found = false;
-            while (not found and *slot != nullptr) {
-               auto ordering = comp(**slot, *z);
-               if (ordering < 0) {
-                  up = *slot;
-                  slot = &up->left();
-               }
-               else if (ordering > 0) {
-                  up = *slot;
-                  slot = &up->right();
-               }
-               else
-                  found = true;
-            }
-
-            if (this->root == nullptr) {
-               // This is the first time we're inserting into the tree.
-               this->root = z;
-               z->color = Color::Black;
-            }
-            else if (*slot == nullptr) {
-               // key is not present, do what we're asked to do.
-               *slot = z;
-               z->parent() = up;
-               z->color = Color::Red;
-               this->fixup_insert(z);
-            }
-
-            ++this->count;
-            return z;
-         }
-
-         template<typename T>
-         struct node : link<node<T>> {
-            T data;
-         };
-
-
-         template<typename T>
-         struct container : core<node<T>>, private std::allocator<node<T>> {
-            template<typename Key, class Comp>
-            T* find(const Key&, Comp) const;
-
-            // We want to insert a node constructed out of a Key, using
-            // an admissible comparator LESS.  Returns a pointer to the
-            // newly created node, if successfully inserted, or the old
-            // one if the Key is already present.
-            template<class Key, class Comp>
-            T* insert(const Key&, Comp);
-
-         private:
-            template<class U>
-            node<T>* make_node(const U& u) {
-               node<T>* n = this->allocate(1);
-               new (&n->data) T(u);
-               n->left() = nullptr;
-               n->right() = nullptr;
-               n->parent() = nullptr;
-               return n;
-            }
-
-            void destroy_node(node<T>* n) {
-               if (n != nullptr) {
-                  n->data.~T();
-                  this->deallocate(n, 1);
-               }
-            }
-         };
-
-         template<typename T>
-         template<typename Key, class Comp>
-         T*
-         container<T>::find(const Key& key, Comp comp) const
-         {
-            for (node<T>* x = this->root; x != nullptr; ) {
-               auto ordering = comp(x->data, key);
-               if (ordering < 0)
-                  x = x->left();
-               else if (ordering > 0)
-                  x = x->right();
-               else
-                  return &x->data;
-            }
-
-            return nullptr;
-         }
-
-         template<typename T>
-         template<typename Key, class Comp>
-         T*
-         container<T>::insert(const Key& key, Comp comp)
-         {
-            if (this->root == nullptr) {
-               // This is the first time we're inserting into the tree.
-               this->root = make_node(key);
-               this->root->color = Color::Black;
-               ++this->count;
-               return &this->root->data;
-            }
-
-            node<T>** slot = &this->root;
-            node<T>* parent = nullptr;
-            node<T>* where = nullptr;
-            bool found = false;
-
-            for (where = this->root; where != nullptr and not found; where = *slot) {
-               auto ordering = comp(where->data, key);
-               if (ordering < 0) {
-                  parent = where;
-                  slot = &where->left();
-               }
-               else if (ordering > 0) {
-                  parent = where;
-                  slot = &where->right();
-               }
-               else
-                  found = true;
-            }
-
-            if (where == nullptr) {
-               // key is not present, do what we're asked to do.
-               where = *slot = make_node(key);
-               where->parent() = parent;
-               where->color = Color::Red;
-               ++this->count;
-               this->fixup_insert(where);
-            }
-
-            return &where->data;
-         }
-      }
-
-
-      // -- helper for implementing permanent string objects.  They uniquely
-      // -- represent their contents throughout their lifetime.  Ideally,
-      // -- they are allocated from a pool.
-      struct string {
-         struct arena;
-
-         using size_type = std::ptrdiff_t; // integer type that string length
-
-         // number of characters directly contained in this header
-         // of the string.  Taken to be the number of bytes in size_type.
-         static constexpr size_type padding_count = sizeof (size_type);
-
-         size_type size() const { return length; }
-         char operator[](size_type) const;
-
-         const char* begin() const { return data; }
-         const char* end() const { return begin() + length; }
-
-         size_type length;
-         char data[padding_count];
-      };
-
-      struct string::arena {
-         arena();
-         ~arena();
-
-         const string* make_string(const char*, size_type);
-
-      private:
-         util::string* allocate(size_type);
-         auto remaining_header_count() const
-         {
-            return next_header - &mem->storage[0];
-         }
-
-         struct pool;
-
-         static constexpr size_type headersz = sizeof (util::string);
-         static constexpr size_type bufsz = headersz << (20 - sizeof (pool*));
-
-         struct pool {
-            pool* previous;
-            util::string storage[bufsz];
-         };
-
-         static constexpr size_type poolsz = sizeof (pool);
-
-         pool* mem;
-         string* next_header;
-      };
-
-
-      struct lexicographical_compare {
-         template<typename In1, typename In2, class Compare>
-         int operator()(In1 first1, In1 last1, In2 first2, In2 last2,
-                        Compare compare) const
-         {
-            for (; first1 != last1 and first2 != last2; ++first1, ++first2)
-               if (auto cmp = compare(*first1, *first2))
-                  return cmp;
-
-            return first1 == last1 ? (first2 == last2 ? 0 : -1) : 1;
-         }
-      };
-
-
+#include <type_traits>
+#include <concepts>
+
+namespace ipr::util {
+   // Return the value representation of an enumeration value.
+   template<typename T> requires std::is_enum_v<T>
+   constexpr auto rep(T t)
+   {
+      return static_cast<std::underlying_type_t<T>>(t);
    }
+
+   // A predicate for types with values that can be inserted into standard streams.
+   template<typename T>
+   concept std_insertable = requires(std::ostream& os, const T& t) {
+      os << t;
+   };
+
+   // -- Check for nonnull pointer.
+   template<typename T>
+   inline T* check(T* ptr)
+   {
+      if (ptr == nullptr)
+         throw std::logic_error("attempt to dereference a null pointer");
+      return ptr;
+   }
+
+   // At various places in the implementation of the IPR interface, certain logical
+   // references are stored as pointers because of implementation necessity, or sometimes convenience.
+   // This wrapper class ensures that when the data behind those logical references are 
+   // access the implementation pointer is not null.  Note that the role served by this
+   // class is not the same as ipr::Optional (which is a genuine representation of optional information),
+   // or std::reference_wrapper (which assumes existence of reference to begin with).
+   template<typename T>
+   struct ref {
+      ref(T* p = { }) : ptr{p} { }
+      T& get() const { return *util::check(ptr); }
+   private:
+      T* ptr;
+   };
+
+   // --------------------
+   // -- Red-back trees --
+   // --------------------
+
+   // The implementation found here is based on ideas in
+   // T. H. Cormen, C. E. Leiserson, R. L. Rivest and C. Strein:
+   //     "Introduction to Algorithms", 2nd edition.
+
+   // One reason why we (re-)implement our own "set" data structures
+   // instead of using the standard ones is because standard sets
+   // do not allow for in-place modification.  That puts an
+   // unreasonable burden on how we can write the codes for IPR.
+   // Another reason is that, while the standard set is really a
+   // a red-lack tree in disguise, there is no way one can have
+   // access to that structure.  Furthermore, we use red-black
+   // trees in both "intrusive" and "non-intrusive" forms.
+
+   namespace rb_tree {
+      // Marker used to designate a tree node as either 'black' or 'red'.
+      enum class Color { Black, Red };
+
+      // The type of the links used to chain together data in
+      // a red-black tree.
+      template<class Node>
+      struct link {
+         enum Dir { Left, Right, Parent };
+
+         Node*& parent() { return arm[Parent]; }
+         Node*& left() { return arm[Left]; }
+         Node*& right() { return arm[Right]; }
+
+         Node* arm[3] { };
+         Color color = Color::Red;
+      };
+
+      template<class Node>
+      struct core {
+         std::ptrdiff_t size() const { return count; }
+
+      protected:
+         Node* root { };
+         std::ptrdiff_t count { };
+
+         // Do a left rotation about X.  X->left() is assumed nonnull,
+         // which after the manoeuvre becomes X's parent.
+         void rotate_left(Node*);
+
+         // Same as rotate_left, except that the rotation does right.
+         void rotate_right(Node*);
+
+         // After raw insertion, the tree is unbalanced again; this
+         // function re-balance the tree, fixing up properties destroyed.
+         void fixup_insert(Node*);
+      };
+
+      template<class Node>
+      void
+      core<Node>::rotate_left(Node* x)
+      {
+         Node* y = x->right();
+         // Make y's left a subtree of x's right subtree.
+         x->right() = y->left();
+         if (y->left() != nullptr)
+            y->left()->parent() = x;
+
+         // Update y's parent and its left or right arms.
+         y->parent() = x->parent();
+         if (x->parent() == nullptr)
+            // x was the root of the tree; make y the new root.
+            this->root = y;
+         else if (x->parent()->left() == x)
+            x->parent()->left() = y;
+         else
+            x->parent()->right() = y;
+
+         // Now, x must go on y's left.
+         y->left() = x;
+         x->parent() = y;
+      }
+
+      template<class Node>
+      void
+      core<Node>::rotate_right(Node* x)
+      {
+         Node* y = x->left();
+
+         x->left() = y->right();
+         if (y->right() != nullptr)
+            y->right()->parent() = x;
+
+         y->parent() = x->parent();
+         if (x->parent() == nullptr)
+            this->root = y;
+         else if (x->parent()->right() == x)
+            x->parent()->right() = y;
+         else
+            x->parent()->left() = y;
+
+         y->right() = x;
+         x->parent() = y;
+      }
+
+      template<class Node>
+      void
+      core<Node>::fixup_insert(Node* z)
+      {
+         while (z != root and z->parent()->color == Color::Red) {
+            if (z->parent() == z->parent()->parent()->left()) {
+               Node* y = z->parent()->parent()->right();
+               if (y != nullptr and y->color == Color::Red) {
+                  z->parent()->color = Color::Black;
+                  y->color = Color::Black;
+                  z->parent()->parent()->color = Color::Red;
+                  z = z->parent()->parent();
+               } else {
+                  if (z->parent()->right() == z) {
+                     z = z->parent();
+                     rotate_left(z);
+                  }
+                  z->parent()->color = Color::Black;
+                  z->parent()->parent()->color = Color::Red;
+                  rotate_right(z->parent()->parent());
+               }
+            } else {
+               Node* y = z->parent()->parent()->left();
+               if (y != nullptr and y->color == Color::Red) {
+                  z->parent()->color = Color::Black;
+                  y->color = Color::Black;
+                  z->parent()->parent()->color = Color::Red;
+                  z = z->parent()->parent();
+               } else {
+                  if (z->parent()->left() == z) {
+                     z = z->parent();
+                     rotate_right(z);
+                  }
+                  z->parent()->color = Color::Black;
+                  z->parent()->parent()->color = Color::Red;
+                  rotate_left(z->parent()->parent());
+               }
+            }
+
+         }
+
+         root->color = Color::Black;
+      }
+
+
+      // A chain is an rb-tree that supports search and insertion, with
+      // the comparison object passed as a parameter instead of being built
+      // into the tree type directly.  The comparison object `cmp` is always
+      // invoked as `cmp(data, key)` where `data` designates an existing
+      // object stored at a node in the chain, and `key` is the parameter by which
+      // the tree is searched.
+      template<class Node>
+      struct chain : core<Node> {
+         template<class Comp>
+         Node* insert(Node*, Comp);
+
+         template<typename Key, class Comp>
+         Node* find(const Key&, Comp) const;
+      };
+
+      template<class Node>
+      template<typename Key, class Comp>
+      Node*
+      chain<Node>::find(const Key& key, Comp comp) const
+      {
+         bool found = false;
+         Node* result = this->root;
+         while (result != nullptr and not found) {
+            auto ordering = comp(*result, key) ;
+            if (ordering < 0)
+               result = result->left();
+            else if (ordering > 0)
+               result = result->right();
+            else
+               found = true;
+         }
+
+         return result;
+      }
+
+      template<class Node>
+      template<class Comp>
+      Node*
+      chain<Node>::insert(Node* z, Comp comp)
+      {
+         Node** slot = &this->root;
+         Node* up = nullptr;
+
+         bool found = false;
+         while (not found and *slot != nullptr) {
+            auto ordering = comp(**slot, *z);
+            if (ordering < 0) {
+               up = *slot;
+               slot = &up->left();
+            }
+            else if (ordering > 0) {
+               up = *slot;
+               slot = &up->right();
+            }
+            else
+               found = true;
+         }
+
+         if (this->root == nullptr) {
+            // This is the first time we're inserting into the tree.
+            this->root = z;
+            z->color = Color::Black;
+         }
+         else if (*slot == nullptr) {
+            // key is not present, do what we're asked to do.
+            *slot = z;
+            z->parent() = up;
+            z->color = Color::Red;
+            this->fixup_insert(z);
+         }
+
+         ++this->count;
+         return z;
+      }
+
+      template<typename T>
+      struct node : link<node<T>> {
+         T data;
+      };
+
+
+      template<typename T>
+      struct container : core<node<T>>, private std::allocator<node<T>> {
+         template<typename Key, class Comp>
+         T* find(const Key&, Comp) const;
+
+         // We want to insert a node constructed out of a Key, using
+         // an admissible comparator LESS.  Returns a pointer to the
+         // newly created node, if successfully inserted, or the old
+         // one if the Key is already present.
+         template<class Key, class Comp>
+         T* insert(const Key&, Comp);
+
+      private:
+         template<class U>
+         node<T>* make_node(const U& u) {
+            node<T>* n = this->allocate(1);
+            new (&n->data) T(u);
+            n->left() = nullptr;
+            n->right() = nullptr;
+            n->parent() = nullptr;
+            return n;
+         }
+
+         void destroy_node(node<T>* n) {
+            if (n != nullptr) {
+               n->data.~T();
+               this->deallocate(n, 1);
+            }
+         }
+      };
+
+      template<typename T>
+      template<typename Key, class Comp>
+      T*
+      container<T>::find(const Key& key, Comp comp) const
+      {
+         for (node<T>* x = this->root; x != nullptr; ) {
+            auto ordering = comp(x->data, key);
+            if (ordering < 0)
+               x = x->left();
+            else if (ordering > 0)
+               x = x->right();
+            else
+               return &x->data;
+         }
+
+         return nullptr;
+      }
+
+      template<typename T>
+      template<typename Key, class Comp>
+      T*
+      container<T>::insert(const Key& key, Comp comp)
+      {
+         if (this->root == nullptr) {
+            // This is the first time we're inserting into the tree.
+            this->root = make_node(key);
+            this->root->color = Color::Black;
+            ++this->count;
+            return &this->root->data;
+         }
+
+         node<T>** slot = &this->root;
+         node<T>* parent = nullptr;
+         node<T>* where = nullptr;
+         bool found = false;
+
+         for (where = this->root; where != nullptr and not found; where = *slot) {
+            auto ordering = comp(where->data, key);
+            if (ordering < 0) {
+               parent = where;
+               slot = &where->left();
+            }
+            else if (ordering > 0) {
+               parent = where;
+               slot = &where->right();
+            }
+            else
+               found = true;
+         }
+
+         if (where == nullptr) {
+            // key is not present, do what we're asked to do.
+            where = *slot = make_node(key);
+            where->parent() = parent;
+            where->color = Color::Red;
+            ++this->count;
+            this->fixup_insert(where);
+         }
+
+         return &where->data;
+      }
+   }
+
+
+   // -- helper for implementing permanent string objects.  They uniquely
+   // -- represent their contents throughout their lifetime.  Ideally,
+   // -- they are allocated from a pool.
+   struct string {
+      struct arena;
+
+      using size_type = std::ptrdiff_t; // integer type that string length
+
+      // number of characters directly contained in this header
+      // of the string.  Taken to be the number of bytes in size_type.
+      static constexpr size_type padding_count = sizeof (size_type);
+
+      size_type size() const { return length; }
+      char operator[](size_type) const;
+
+      const char* begin() const { return data; }
+      const char* end() const { return begin() + length; }
+
+      size_type length;
+      char data[padding_count];
+   };
+
+   struct string::arena {
+      arena();
+      ~arena();
+
+      const string* make_string(const char*, size_type);
+
+   private:
+      util::string* allocate(size_type);
+      auto remaining_header_count() const
+      {
+         return next_header - &mem->storage[0];
+      }
+
+      struct pool;
+
+      static constexpr size_type headersz = sizeof (util::string);
+      static constexpr size_type bufsz = headersz << (20 - sizeof (pool*));
+
+      struct pool {
+         pool* previous;
+         util::string storage[bufsz];
+      };
+
+      static constexpr size_type poolsz = sizeof (pool);
+
+      pool* mem;
+      string* next_header;
+   };
+
+
+   struct lexicographical_compare {
+      template<typename In1, typename In2, class Compare>
+      int operator()(In1 first1, In1 last1, In2 first2, In2 last2,
+                     Compare compare) const
+      {
+         for (; first1 != last1 and first2 != last2; ++first1, ++first2)
+            if (auto cmp = compare(*first1, *first2))
+               return cmp;
+
+         return first1 == last1 ? (first2 == last2 ? 0 : -1) : 1;
+      }
+   };
 }
 
 #endif // IPR_UTILITY_INCLUDED

--- a/src/io.cxx
+++ b/src/io.cxx
@@ -404,7 +404,7 @@ namespace ipr {
          void visit(const Enclosure& e) final
          {
             static constexpr const char* syntax[] = { "\0\0", "()", "{}", "[]", "<>" };
-            const auto delimiters = syntax[static_cast<int>(e.delimiters())];
+            const auto delimiters = syntax[util::rep(e.delimiters())];
             pp << token(delimiters[0]) << xpr_expr(e.expr()) << token(delimiters[1]);
          }
          void visit(const Expr& e) override
@@ -1717,10 +1717,10 @@ namespace ipr {
             auto& locus = stmt.source_location();
             if (locus.file != File_index{})
             {
-               *pp << token("F") << static_cast<int>(locus.file) << token(':')
-                   << static_cast<int>(locus.line);
+               *pp << token("F") << util::rep(locus.file) << token(':')
+                   << util::rep(locus.line);
                if (locus.column != Column_number{})
-                  *pp << token(':') << static_cast<int>(locus.column);
+                  *pp << token(':') << util::rep(locus.column);
                *pp << token(' ');
             }
          }


### PR DESCRIPTION
The primary purpose of this patch is to remove a couple of places where `static_cast` is being used to beat a value into `int` representation.  That battle was lost a decade ago, and again with `std::span`.  Adjust to new reality.

As a secondary purpose, this patch introduces a utility to retrieve the underlying value representation of an enumeration value without using `static_cast`.

Fixes #216 
Fixes #217 