### PR TITLE
`name_factory`: factories for names

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -12,3 +12,17 @@ Use:
   - `or` for logical disjunction
 
 
+## Factory function names
+
+Use:
+  - `get_xxx` for factory function names that return the same output for same inputs
+  - `make_xxx` for factory function names that always return fresh structures
+
+
+## Source file extensions
+
+Use
+  - `.cxx` for implementation source files
+
+
+

--- a/include/ipr/ancillary
+++ b/include/ipr/ancillary
@@ -219,7 +219,8 @@ namespace ipr {
    // that commonality and provides a checked access.
    template<typename T>
    struct Optional {
-      Optional(const T* p = nullptr) : ptr { p } { }
+      constexpr Optional(const T* p = nullptr) : ptr{p} { }
+      constexpr Optional(const T& t) requires std::is_abstract_v<T> : ptr{&t} { }
       const T& get() const { return *util::check(ptr); }
       bool is_valid() const { return ptr != nullptr; }
       explicit operator bool() const { return is_valid(); }

--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -520,7 +520,7 @@ namespace ipr::impl {
       for (Index i = 0; i < s; ++i) {
          const auto& decl = decls.seq.get(i);
          if (&decl.name() == &n)
-            return { &decl.overload };
+            return { decl.overload };
       }
 
       return { };
@@ -1370,7 +1370,7 @@ namespace ipr::impl {
       const ipr::Parameter_list& parameters() const final { return parms; }
       const ipr::Type& target() const final { return value_type.get(); }
       const ipr::Expr& result() const final { return body.get(); }
-      impl::Parameter* param(const ipr::Name&, const impl::Rname&);
+      impl::Parameter* param(const ipr::Name&, const ipr::Rname&);
    };
 
    using Member_init = Binary_expr<ipr::Member_init>;
@@ -1425,7 +1425,7 @@ namespace ipr::impl {
       // FIXME: The initializer should actually be the mapping, since a Template is a
       //        *named* mapping.  In Classic IPR, and in the current incarnation, the initializer 
       //        is the initializer of the current instantiation.
-      Optional<ipr::Expr> initializer() const final { return { &mapping().result() }; }
+      Optional<ipr::Expr> initializer() const final { return { mapping().result() }; }
       const ipr::Region& lexical_region() const final { return lexreg.get(); }
    };
 
@@ -1459,10 +1459,10 @@ namespace ipr::impl {
 
 
    struct Alias : impl::Decl<ipr::Alias> {
-      const ipr::Expr* aliasee;
+      util::ref<const ipr::Expr> aliasee;
 
       Alias();
-      Optional<ipr::Expr> initializer() const final { return aliasee; }
+      Optional<ipr::Expr> initializer() const final { return aliasee.get(); }
    };
 
    struct Var : impl::Decl<ipr::Var> {
@@ -1980,10 +1980,34 @@ namespace ipr::impl {
       const ipr::Scope& second() const final { return region.bindings(); }
    };
 
-   struct expr_factory {
-      // Returns an IPR node for unified string literals.
+   struct name_factory {
       const ipr::String& get_string(util::word_view);
+      const ipr::Identifier& get_identifier(const ipr::String&);
+      const ipr::Identifier& get_identifier(util::word_view);
+      const ipr::Suffix& get_suffix(const ipr::Identifier&);
+      const ipr::Operator& get_operator(const ipr::String&);
+      const ipr::Operator& get_operator(util::word_view);
+      const ipr::Type_id& get_type_id(const ipr::Type&);
+      const ipr::Conversion& get_conversion(const ipr::Type&);
+      const ipr::Ctor_name& get_ctor_name(const ipr::Type&);
+      const ipr::Dtor_name& get_dtor_name(const ipr::Type&);
+      const ipr::Guide_name& get_guide_name(const ipr::Template&);
+      const ipr::Rname& get_rname(Mapping_level, Decl_position, const ipr::Type&);
 
+   private:
+      util::string_pool strings;
+      util::rb_tree::container<impl::Identifier> ids;
+      util::rb_tree::container<impl::Suffix> suffixes;
+      util::rb_tree::container<impl::Conversion> convs;
+      util::rb_tree::container<impl::Ctor_name> ctors;
+      util::rb_tree::container<impl::Dtor_name> dtors;
+      util::rb_tree::container<impl::Operator> ops;
+      util::rb_tree::container<impl::Guide_name> guide_ids;
+      util::rb_tree::container<impl::Rname> rnames;
+      util::rb_tree::container<impl::Type_id> type_ids;
+   };
+
+   struct expr_factory : name_factory {
       // Returns an IPR node a language linkage.
       const ipr::Linkage& get_linkage(util::word_view);
       const ipr::Linkage& get_linkage(const ipr::String&);
@@ -2005,27 +2029,13 @@ namespace ipr::impl {
       Literal* make_literal(const ipr::Type&, const ipr::String&);
       Literal* make_literal(const ipr::Type&, util::word_view);
 
-      // Builds an IPR object for an identifier.
-      Identifier* make_identifier(const ipr::String&);
-      Identifier* make_identifier(util::word_view);
-
-      Suffix* make_suffix(const ipr::Identifier&);
-
-      // Builds an IPR object for an operator name.
-      Operator* make_operator(const ipr::String&);
-      Operator* make_operator(util::word_view);
-
-      Guide_name* make_guide_name(const ipr::Template&);
 
       Address* make_address(const ipr::Expr&, Optional<ipr::Type> = {});
       Array_delete* make_array_delete(const ipr::Expr&);
       Complement* make_complement(const ipr::Expr&, Optional<ipr::Type> = {});
-      Conversion* make_conversion(const ipr::Type&);
-      Ctor_name* make_ctor_name(const ipr::Type&);
       Delete* make_delete(const ipr::Expr&);
       Demotion* make_demotion(const ipr::Expr&, const ipr::Type&);
       Deref* make_deref(const ipr::Expr&, Optional<ipr::Type> = {});
-      Dtor_name* make_dtor_name(const ipr::Type&);
       Expr_list* make_expr_list();
       Alignof* make_alignof(const ipr::Expr&, Optional<ipr::Type> = { });
       Sizeof* make_sizeof(const ipr::Expr&, Optional<ipr::Type> = { });
@@ -2044,7 +2054,6 @@ namespace ipr::impl {
       Promotion* make_promotion(const ipr::Expr&, const ipr::Type&);
       Read* make_read(const ipr::Expr&, const ipr::Type&);
       Throw* make_throw(const ipr::Expr&, Optional<ipr::Type> = {});
-      Type_id* make_type_id(const ipr::Type&);
       Unary_minus* make_unary_minus(const ipr::Expr&, Optional<ipr::Type> = {});
       Unary_plus* make_unary_plus(const ipr::Expr&, Optional<ipr::Type> = {});
       Expansion* make_expansion(const ipr::Expr&, Optional<ipr::Type> = {});
@@ -2110,28 +2119,17 @@ namespace ipr::impl {
       Conditional* make_conditional(const ipr::Expr&, const ipr::Expr&,
                                     const ipr::Expr&, Optional<ipr::Type> = {});
 
-      Rname* rname_for_next_param(const Mapping&, const ipr::Type&);
+      const ipr::Rname& rname_for_next_param(const Mapping&, const ipr::Type&);
 
       Mapping* make_mapping(const ipr::Region&, Mapping_level);
       Lambda* make_lambda(const ipr::Region&, Mapping_level);
 
    private:
-      util::string_pool strings;
-
       // Language linkage nodes.
       util::rb_tree::container<impl::Linkage> linkages;
 
-      util::rb_tree::container<impl::Conversion> convs;
-      util::rb_tree::container<impl::Ctor_name> ctors;
-      util::rb_tree::container<impl::Dtor_name> dtors;
-      util::rb_tree::container<impl::Identifier> ids;
-      util::rb_tree::container<impl::Suffix> suffixes;
       util::rb_tree::container<impl::Literal> lits;
-      util::rb_tree::container<impl::Operator> ops;
-      util::rb_tree::container<impl::Guide_name> guide_ids;
-      util::rb_tree::container<impl::Rname> rnames;
       util::rb_tree::container<impl::Template_id> template_ids;
-      util::rb_tree::container<impl::Type_id> type_ids;
 
       stable_farm<impl::Phantom> phantoms;
       stable_farm<impl::Eclipsis> eclipses;
@@ -2297,19 +2295,6 @@ namespace ipr::impl {
 
       const ipr::Linkage& cxx_linkage() const final;
       const ipr::Linkage& c_linkage() const final;
-
-      const ipr::Identifier& get_identifier(util::word_view);
-      const ipr::Identifier& get_identifier(const ipr::String&);
-
-      const ipr::Suffix& get_suffix(const ipr::Identifier&);
-
-      const ipr::Operator& get_operator(util::word_view);
-      const ipr::Operator& get_operator(const ipr::String&);
-
-      const ipr::Ctor_name& get_ctor_name(const ipr::Type&);
-      const ipr::Dtor_name& get_dtor_name(const ipr::Type&);
-
-      const ipr::Conversion& get_conversion(const ipr::Type&);
 
       const ipr::Template_id& get_template_id(const ipr::Name&,
                                                 const ipr::Expr_list&);

--- a/tests/unit-tests/conversions.cpp
+++ b/tests/unit-tests/conversions.cpp
@@ -26,7 +26,7 @@ TEST_CASE("C++ Standard Conversions") {
   // Pointer Conversion            (Coercion)
   const auto& ptr_type = lexicon.get_qualified(
     Type_qualifiers::Const, lexicon.get_pointer(lexicon.int_type()));
-  auto& ptr = *unit.global_region()->declare_var(*lexicon.make_identifier("ptr"), ptr_type);
+  auto& ptr = *unit.global_region()->declare_var(lexicon.get_identifier("ptr"), ptr_type);
   ptr.init = lexicon.make_coercion(
     *lexicon.make_literal(lexicon.int_type(), "0"),
     ptr_type,
@@ -70,8 +70,8 @@ TEST_CASE("Class Conversions") {
   INFO("Derived* d;");
   auto& base_ptr = lexicon.get_pointer(base);
   auto& derived_ptr = lexicon.get_pointer(derived);
-  auto& b = *unit.global_region()->declare_var(*lexicon.make_identifier("b"), base_ptr);
-  auto& d = *unit.global_region()->declare_var(*lexicon.make_identifier("d"), derived_ptr);
+  auto& b = *unit.global_region()->declare_var(lexicon.get_identifier("b"), base_ptr);
+  auto& d = *unit.global_region()->declare_var(lexicon.get_identifier("d"), derived_ptr);
 
   // Derived-to-base conversion
   INFO("b = d;");
@@ -117,7 +117,7 @@ TEST_CASE("CV Conversions") {
   INFO("const int* ptr;");
   const auto& ptr_type = lexicon.get_qualified(
     Type_qualifiers::Const, lexicon.get_pointer(lexicon.int_type()));
-  auto& ptr = *unit.global_region()->declare_var(*lexicon.make_identifier("ptr"), ptr_type);
+  auto& ptr = *unit.global_region()->declare_var(lexicon.get_identifier("ptr"), ptr_type);
 
   // Removal of const is a non-implicit conversion
   INFO("const_cast<int* const>(ptr);");
@@ -129,7 +129,7 @@ TEST_CASE("CV Conversions") {
   INFO("int** ptr_ptr");
   const auto& ptr_ptr_type = lexicon.get_pointer(lexicon.get_pointer(lexicon.int_type()));
   auto& ptr_ptr = *unit.global_region()->declare_var(
-    *lexicon.make_identifier("ptr_ptr"), ptr_ptr_type);
+    lexicon.get_identifier("ptr_ptr"), ptr_ptr_type);
 
   INFO("(int**) -> (int* const* const)");
   lexicon.make_qualification(
@@ -145,7 +145,7 @@ TEST_CASE("CV Conversions") {
   );
 
   INFO("const int var = 0;");
-  auto& var = *unit.global_region()->declare_var(*lexicon.make_identifier("var"), 
+  auto& var = *unit.global_region()->declare_var(lexicon.get_identifier("var"), 
     lexicon.get_qualified(Type_qualifiers::Const, lexicon.int_type()));
 
   // Pretend can be used to explicitly reperesent automatic type adjustment as detailed

--- a/tests/unit-tests/simple.cpp
+++ b/tests/unit-tests/simple.cpp
@@ -12,9 +12,9 @@ TEST_CASE("global constant variable can be printed") {
 
   impl::Scope* global_scope = unit.global_scope();
 
-  const Name* name = lexicon.make_identifier("bufsz");
+  auto& name = lexicon.get_identifier("bufsz");
   auto& type = lexicon.get_qualified(Type_qualifiers::Const, lexicon.int_type());
-  impl::Var* var = global_scope->make_var(*name, type);
+  impl::Var* var = global_scope->make_var(name, type);
   var->init = lexicon.make_literal(lexicon.int_type(), "1024");
 
   std::stringstream ss;
@@ -32,9 +32,9 @@ TEST_CASE("Can create and print line numbers")
 
   impl::Scope* global_scope = unit.global_scope();
 
-  const Name* name = lexicon.make_identifier("bufsz");
+  auto& name = lexicon.get_identifier("bufsz");
   auto& type = lexicon.get_qualified(Type_qualifiers::Const, lexicon.int_type());
-  impl::Var* var = global_scope->make_var(*name, type);
+  impl::Var* var = global_scope->make_var(name, type);
   var->init = lexicon.make_literal(lexicon.int_type(), "1024");
 
   Source_location loc{ Line_number{1}, Column_number{2}, File_index{1} };


### PR DESCRIPTION
The patch that moved the `Name` hierarchy out of the `Expr` hierarchy left the factory functions as member of `expr_factory`.  This patch sequesters them in a dedicated factory type (`name_factory`), and:

- rename the `make_xxx` name factory functions to `get_xxx`

- change their return type to immutable reference to interface classes, instead of mutable pointer to implementation classes

These changes represent source-level breaking changes, but the fixes are mechanical.