### PR TITLE
Symbolic truth values

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -329,7 +329,7 @@ namespace ipr::impl {
    struct Expr : impl::Node<Interface> {
       Optional<ipr::Type> typing;
 
-      Expr(Optional<ipr::Type> t = { }) : typing{ t } { }
+      constexpr Expr(Optional<ipr::Type> t = { }) : typing{ t } { }
       const ipr::Type& type() const final { return typing.get(); }
    };
 
@@ -2319,7 +2319,9 @@ namespace ipr::impl {
       const ipr::Type& enum_type() const final;
       const ipr::Type& namespace_type() const final;
 
-      const ipr::Expr& nullptr_value() const final;
+      const ipr::Symbol& false_value() const final;
+      const ipr::Symbol& true_value() const final;
+      const ipr::Symbol& nullptr_value() const final;
 
       const ipr::Array& get_array(const ipr::Type&, const ipr::Expr&);
 

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -1899,7 +1899,10 @@ namespace ipr {
       virtual const Type& enum_type() const = 0;               // "enum" or "enum class"
       virtual const Type& namespace_type() const = 0;          // "namespace"
 
-      virtual const Expr& nullptr_value() const = 0;           // "nullptr"      -- technically not a parameter
+      virtual const Symbol& false_value() const = 0;           // Boolean symbolic constant 'false'
+      virtual const Symbol& true_value() const = 0;            // Boolean symbolic constant 'true'
+      
+      virtual const Symbol& nullptr_value() const = 0;         // "nullptr"      -- technically not a parameter
                                                                // to the C++ abstract machine, but provided as
                                                                // example of symbolic value representation.
 

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -56,6 +56,7 @@ namespace ipr::impl {
            "class",
            "double",
            "enum",
+           "false",
            "float",
            "int",
            "long",
@@ -65,6 +66,7 @@ namespace ipr::impl {
            "nullptr",
            "short",
            "signed char",
+           "true",
            "typename",
            "union",
            "unsigned char",
@@ -159,6 +161,10 @@ namespace ipr::impl {
       constexpr Builtin double_type { "double" };
       constexpr Builtin longdouble_type { "long double" };
       constexpr Builtin ellipsis_type { "..." };
+
+      // Truth value symbolic constants.
+      constexpr Symbol false_cst { known_word("false"), bool_type };
+      constexpr Symbol true_cst { known_word("true"), bool_type };
    }
 }
 
@@ -2050,7 +2056,9 @@ namespace ipr::impl {
       const ipr::Type& Lexicon::enum_type() const { return impl::enum_type; }
       const ipr::Type& Lexicon::namespace_type() const { return impl::namespace_type; }
 
-      const ipr::Expr& Lexicon::nullptr_value() const { return null; }
+      const ipr::Symbol& Lexicon::false_value() const { return impl::false_cst; }
+      const ipr::Symbol& Lexicon::true_value() const { return impl::true_cst; }
+      const ipr::Symbol& Lexicon::nullptr_value() const { return null; }
 
       template<class T>
       T* Lexicon::finish_type(T* t) {


### PR DESCRIPTION
This patch adds symbolic representation for `false` and `true` as built-in core values.