### PR TITLE
Upgrade representation of exception specification

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -1754,7 +1754,7 @@ namespace ipr::impl {
       impl::Decltype* make_decltype(const ipr::Expr&);
       impl::Tor* make_tor(const ipr::Product&, const ipr::Sum&);
       impl::Function* make_function(const ipr::Product&, const ipr::Type&,
-                                    const ipr::Sum&, const ipr::Linkage&);
+                                    const ipr::Expr&, const ipr::Linkage&);
       impl::Pointer* make_pointer(const ipr::Type&);
       impl::Product* make_product(const ipr::Sequence<ipr::Type>&);
       impl::Ptr_to_member* make_ptr_to_member(const ipr::Type&,
@@ -2332,12 +2332,12 @@ namespace ipr::impl {
       const ipr::Decltype& get_decltype(const ipr::Expr&);
 
       const ipr::Function& get_function(const ipr::Product&,
-                                          const ipr::Type&, const ipr::Sum&);
+                                          const ipr::Type&, const ipr::Expr&);
       const ipr::Function& get_function(const ipr::Product&,
                                           const ipr::Type&);
       const ipr::Function& get_function(const ipr::Product&,
                                           const ipr::Type&,
-                                          const ipr::Sum&,
+                                          const ipr::Expr&,
                                           const ipr::Linkage&);
       const ipr::Function& get_function(const ipr::Product&,
                                           const ipr::Type&,

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -149,9 +149,9 @@ namespace ipr {
                                 // -- Quaternary --
    // Similar to Unary<>, Binary<> and Ternary<>.  Quaternary nodes are,
    // however rare in diversity.  Examples include function types.
-   template<class Cat, class First = const Product&,
-            class Second = const Type&, class Third = const Type&,
-            class Fourth = const Linkage&>
+   template<class Cat, class First = const Expr&,
+            class Second = const Expr&, class Third = const Expr&,
+            class Fourth = const Expr&>
    struct Quaternary : Cat {
       using Arg1_type = First;
       using Arg2_type = Second;
@@ -601,7 +601,8 @@ namespace ipr {
    // however, we've made a special node for template.  ISO C++ specifies
    // that function types have language linkages and two function types
    // with different language linkages are different.
-   struct Function : Quaternary<Category<Category_code::Function, Type>> {
+   struct Function : Quaternary<Category<Category_code::Function, Type>,
+                                const Product&, const Type&, const Expr&, const Linkage&> {
       // Parameter-type-list of a function of this type.  In full
       // generality, this also describes template signature.
       Arg1_type source() const { return first(); }

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -1008,7 +1008,7 @@ namespace ipr::impl {
 
       impl::Function*
       type_factory::make_function(const ipr::Product& s, const ipr::Type& t,
-                                  const ipr::Sum& e, const ipr::Linkage& l)
+                                  const ipr::Expr& e, const ipr::Linkage& l)
       {
          using rep = impl::Function::Rep;
          return functions.insert(rep{ s, t, e, l }, quaternary_compare());
@@ -2098,22 +2098,21 @@ namespace ipr::impl {
 
       const ipr::Function&
       Lexicon::get_function(const ipr::Product& p, const ipr::Type& t,
-                            const ipr::Sum& s, const ipr::Linkage& l) {
+                            const ipr::Expr& s, const ipr::Linkage& l) {
          return *finish_type(types.make_function(p, t, s, l));
       }
 
       const ipr::Function&
       Lexicon::get_function(const ipr::Product& p, const ipr::Type& t,
-                            const ipr::Sum& s) {
+                            const ipr::Expr& s) {
          return get_function(p, t, s, cxx_linkage());
       }
 
       const ipr::Function&
       Lexicon::get_function(const ipr::Product& p, const ipr::Type& t,
                             const ipr::Linkage& l) {
-         ref_sequence<ipr::Type> ex;
-         ex.push_back(&ellipsis_type());
-         return get_function(p, t, get_sum(ex), l);
+         // A function type without explicit exception specification is `noexcept(false)`.
+         return get_function(p, t, false_value(), l);
       }
 
       const ipr::Function&

--- a/src/io.cxx
+++ b/src/io.cxx
@@ -1117,7 +1117,7 @@ namespace ipr {
          pp << token('(');
          pp << map.parameters();
          pp << token(')');
-         pp << xpr_exception_spec(t.throws());
+         pp << xpr_exception_spec{ t.throws() };
 
          pp << xpr_initializer(map.result());
       }
@@ -1282,13 +1282,13 @@ namespace ipr {
       struct Visitor : pp_base {
          Visitor(Printer& p) : pp_base{ p } { }
 
-         void visit(const Type& t)
+         void visit(const Type& t) final
          {
             pp << xpr_identifier("throw")
                << token('(') << xpr_type(t) << token(')');
          }
 
-         void visit(const Expr& e)
+         void visit(const Expr& e) final
          {
             pp << xpr_identifier("noexcept")
                << token('(') << xpr_expr(e) << token(')');
@@ -1391,7 +1391,7 @@ namespace ipr {
       void visit(const Function& f) final
       {
          pp << token('(') << f.source().operand() << token(')')
-            << xpr_exception_spec(f.throws())
+            << xpr_exception_spec{ f.throws() }
             << xpr_type(f.target());
       }
 

--- a/src/io.cxx
+++ b/src/io.cxx
@@ -199,8 +199,7 @@ namespace ipr {
 
 
    struct xpr_exception_spec {
-      const Type& type;
-      explicit xpr_exception_spec(const Type& t) : type(t) { }
+      const Expr& spec;
    };
    static Printer& operator<<(Printer&, xpr_exception_spec);
 
@@ -1280,8 +1279,26 @@ namespace ipr {
    static Printer&
    operator<<(Printer& printer, xpr_exception_spec x)
    {
-      return  printer << token(' ') << xpr_identifier("throw")
-                      << token('(') << xpr_type(x.type) << token(')');
+      struct Visitor : pp_base {
+         Visitor(Printer& p) : pp_base{ p } { }
+
+         void visit(const Type& t)
+         {
+            pp << xpr_identifier("throw")
+               << token('(') << xpr_type(t) << token(')');
+         }
+
+         void visit(const Expr& e)
+         {
+            pp << xpr_identifier("noexcept")
+               << token('(') << xpr_expr(e) << token(')');
+         }
+      };
+
+      printer << token(' ');
+      Visitor v { printer };
+      x.spec.accept(v);
+      return printer;
    }
 
    struct xpr_base_classes {


### PR DESCRIPTION
Back in 2004, only types could be mentioned in function exception specification.  That ability was later known as _dynamic exception specification_.   The IPR representation at the time opted to integrate that directly in the type system even when it wasn't at the ISO C++ level.  Throwing anything was modeled by the ellipsis type `...`.

Very late in the C++11 development process, `noexcept` was introduced for specifying that a function call execution could throw something or not (without mentioning what the type of that thing could be).  While the operand (at the source level) can be an arbitrary expression, when fully evaluated, the value of the operand be only be `false` or `true`.

This patch adds ability to specify `noexcept`-ness in the type system.

Fixes #150