### PR TITLE
`nullptr` symbol is constexpr

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -2381,16 +2381,11 @@ namespace ipr::impl {
       const ipr::Auto& get_auto();
 
    private:
-      void record_builtin_type(const ipr::As_type&);
-
       stable_farm<impl::Token> tokens;
       type_factory types;
       util::rb_tree::container<ref_sequence<ipr::Expr>> expr_seqs;
       util::rb_tree::container<ref_sequence<ipr::Type>> type_seqs;
-      util::rb_tree::container<node_ref<ipr::As_type>> builtin_map;
       stable_farm<impl::Auto> autos;
-
-      const impl::Symbol null;
 
       template<class T> T* finish_type(T*);
    };

--- a/tests/unit-tests/simple.cpp
+++ b/tests/unit-tests/simple.cpp
@@ -2,6 +2,7 @@
 
 #include <ipr/impl>
 #include <ipr/io>
+#include <ipr/traversal>
 #include <sstream>
 
 TEST_CASE("global constant variable can be printed") {
@@ -58,5 +59,22 @@ TEST_CASE("linkages are deduplicated") {
   auto& l1 = lexicon.cxx_linkage();
   auto& l2 = lexicon.cxx_linkage();
   CHECK(&l1 == &l2);
+}
+
+TEST_CASE("nullptr defines its own type") {
+  using namespace ipr;
+  impl::Lexicon lexicon { };
+  auto& null = lexicon.nullptr_value();
+  auto& type = lexicon.get_decltype(null);
+  CHECK(physically_same(type, null.type()));
+}
+
+TEST_CASE("Truth values have type bool") {
+  using namespace ipr;
+  impl::Lexicon lexicon { };
+  auto& vrai = lexicon.true_value();
+  auto& faux = lexicon.false_value();
+  CHECK(physically_same(vrai.type(), lexicon.bool_type()));
+  CHECK(physically_same(faux.type(), lexicon.bool_type()));
 }
 


### PR DESCRIPTION
This patch makes the symbolic representation of `nullptr` a constexpr object.  It also removes dead code.