### PR TITLE
Remove `name_factory::get_type_id`

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -136,6 +136,17 @@ namespace ipr::impl {
       Arg3_type third() const final { return rep.third; }
       Arg4_type fourth() const final { return rep.fourth; }
    };
+
+   using Comment = Unary_node<Comment>;
+
+   using Identifier = Unary_node<ipr::Identifier>;
+   using Suffix = Unary_node<ipr::Suffix>;
+   using Operator = Unary_node<ipr::Operator>;
+   using Conversion = Unary_node<ipr::Conversion>;
+   using Ctor_name = Unary_node<ipr::Ctor_name>;
+   using Dtor_name = Unary_node<ipr::Dtor_name>;
+   using Guide_name = Unary_node<ipr::Guide_name>;
+   using Type_id = Unary_node<ipr::Type_id>;
 }
 
 namespace ipr::util {
@@ -366,17 +377,26 @@ namespace ipr::impl {
       const ipr::Name& name() const final { return id.get(); }
    };
 
+   template<typename T>
+   struct Composite : impl::Node<T> {
+      constexpr Composite() : id{*this} { }
+      const ipr::Type& type() const final { return impl::typename_type(); }
+      const ipr::Name& name() const final { return id; }
+   private:
+      impl::Type_id id;
+   };
+
    // -- impl::Unary_type
    template<typename T>
-   using Unary_type = Unary<Type<T>>;
+   using Unary_type = Unary<Composite<T>>;
 
    // -- impl::Binary_type
    template<typename T>
-   using Binary_type = Binary<Type<T>>;
+   using Binary_type = Binary<Composite<T>>;
 
    // -- impl::Ternary_type
    template<typename T>
-   using Ternary_type = Ternary<Type<T>>;
+   using Ternary_type = Ternary<Composite<T>>;
 }
 
 namespace ipr::impl{
@@ -471,7 +491,7 @@ namespace ipr::impl {
    // in "type envelop" and return the nth type as being the
    // type of the nth declaration in the sequence.
    template<class Seq>
-   struct typed_sequence : impl::Type<ipr::Product>,
+   struct typed_sequence : impl::Composite<ipr::Product>,
                            ipr::Sequence<ipr::Type> {
       using Index = typename Sequence<ipr::Type>::Index;
       Seq seq;
@@ -1214,12 +1234,11 @@ namespace ipr::impl {
       }
    };
 
-
    using Array = Binary_type<ipr::Array>;
    using Decltype = Unary_type<ipr::Decltype>;
    using As_type = Binary_type<ipr::As_type>;
    using Tor = Binary_type<ipr::Tor>;
-   using Function = Quaternary<Type<ipr::Function>>;
+   using Function = Quaternary<Composite<ipr::Function>>;
    using Pointer = Unary_type<ipr::Pointer>;
    using Product = Unary_type<ipr::Product>;
    using Ptr_to_member = Binary_type<ipr::Ptr_to_member>;
@@ -1228,17 +1247,6 @@ namespace ipr::impl {
    using Rvalue_reference = Unary_type<ipr::Rvalue_reference>;
    using Sum = Unary_type<ipr::Sum>;
    using Forall = Binary_type<ipr::Forall>;
-
-   using Comment = Unary_node<Comment>;
-
-   using Identifier = Unary_node<ipr::Identifier>;
-   using Suffix = Unary_node<ipr::Suffix>;
-   using Operator = Unary_node<ipr::Operator>;
-   using Conversion = Unary_node<ipr::Conversion>;
-   using Ctor_name = Unary_node<ipr::Ctor_name>;
-   using Dtor_name = Unary_node<ipr::Dtor_name>;
-   using Guide_name = Unary_node<ipr::Guide_name>;
-   using Type_id = Unary_node<ipr::Type_id>;
 
    using Phantom = Expr<ipr::Phantom>;
    using Eclipsis = Expr<ipr::Eclipsis>;
@@ -1730,7 +1738,7 @@ namespace ipr::impl {
 
    };
 
-   struct Auto : impl::Type<ipr::Auto> {
+   struct Auto : impl::Composite<ipr::Auto> {
    };
 
    struct Closure : impl::Udt<ipr::Closure> {
@@ -1973,7 +1981,6 @@ namespace ipr::impl {
       const ipr::Suffix& get_suffix(const ipr::Identifier&);
       const ipr::Operator& get_operator(const ipr::String&);
       const ipr::Operator& get_operator(util::word_view);
-      const ipr::Type_id& get_type_id(const ipr::Type&);
       const ipr::Conversion& get_conversion(const ipr::Type&);
       const ipr::Ctor_name& get_ctor_name(const ipr::Type&);
       const ipr::Dtor_name& get_dtor_name(const ipr::Type&);
@@ -1990,7 +1997,6 @@ namespace ipr::impl {
       util::rb_tree::container<impl::Operator> ops;
       util::rb_tree::container<impl::Guide_name> guide_ids;
       util::rb_tree::container<impl::Rname> rnames;
-      util::rb_tree::container<impl::Type_id> type_ids;
    };
 
    struct expr_factory : name_factory {
@@ -2386,8 +2392,6 @@ namespace ipr::impl {
       util::rb_tree::container<ref_sequence<ipr::Expr>> expr_seqs;
       util::rb_tree::container<ref_sequence<ipr::Type>> type_seqs;
       stable_farm<impl::Auto> autos;
-
-      template<class T> T* finish_type(T*);
    };
 
    template<typename T>

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -1381,11 +1381,6 @@ namespace ipr::impl {
          return *dtors.insert(t, unary_compare());
       }
 
-      const ipr::Type_id& name_factory::get_type_id(const ipr::Type& t)
-      {
-         return *type_ids.insert(t, unary_compare());
-      }
-
       const ipr::Conversion& name_factory::get_conversion(const ipr::Type& t)
       {
          return *convs.insert(t, unary_compare());
@@ -2035,17 +2030,6 @@ namespace ipr::impl {
       const ipr::Symbol& Lexicon::true_value() const { return impl::true_cst; }
       const ipr::Symbol& Lexicon::nullptr_value() const { return impl::nullptr_cst; }
 
-      template<class T>
-      T* Lexicon::finish_type(T* t) {
-         if (not t->typing.is_valid())
-            t->typing = impl::any_type;
-
-         if (not t->id.is_valid())
-            t->id = get_type_id(*t);
-
-         return t;
-      }
-
       const ipr::Template_id&
       Lexicon::get_template_id(const ipr::Name& t, const ipr::Expr_list& a) {
          return *expr_factory::make_template_id(t, a);
@@ -2053,7 +2037,7 @@ namespace ipr::impl {
 
       const ipr::Array&
       Lexicon::get_array(const ipr::Type& t, const ipr::Expr& b) {
-         return *finish_type(types.make_array(t, b));
+         return *types.make_array(t, b);
       }
 
       const ipr::As_type&
@@ -2063,20 +2047,20 @@ namespace ipr::impl {
 
       const ipr::As_type&
       Lexicon::get_as_type(const ipr::Expr& e, const ipr::Linkage& l) {
-         return *finish_type(types.make_as_type(e, l));
+         return *types.make_as_type(e, l);
       }
 
       const ipr::Decltype&
       Lexicon::get_decltype(const ipr::Expr& e) {
          if (physically_same(e, impl::nullptr_cst))
             return impl::nullptr_cst.type();
-         return *finish_type(types.make_decltype(e));
+         return *types.make_decltype(e);
       }
 
       const ipr::Function&
       Lexicon::get_function(const ipr::Product& p, const ipr::Type& t,
                             const ipr::Expr& s, const ipr::Linkage& l) {
-         return *finish_type(types.make_function(p, t, s, l));
+         return *types.make_function(p, t, s, l);
       }
 
       const ipr::Function&
@@ -2099,45 +2083,43 @@ namespace ipr::impl {
 
       const ipr::Pointer&
       Lexicon::get_pointer(const ipr::Type& t) {
-         return *finish_type(types.make_pointer(t));
+         return *types.make_pointer(t);
       }
 
       const ipr::Product&
       Lexicon::get_product(const ref_sequence<ipr::Type>& s) {
-         return *finish_type
-            (types.make_product(*type_seqs.insert(s, unary_lexicographic_compare())));
+         return *types.make_product(*type_seqs.insert(s, unary_lexicographic_compare()));
       }
 
       const ipr::Ptr_to_member&
       Lexicon::get_ptr_to_member(const ipr::Type& s, const ipr::Type& t) {
-         return *finish_type(types.make_ptr_to_member(s, t));
+         return *types.make_ptr_to_member(s, t);
       }
 
       const ipr::Qualified&
       Lexicon::get_qualified(ipr::Type_qualifiers cv, const ipr::Type& t) {
          assert (cv != ipr::Type_qualifiers::None);
-         return *finish_type(types.make_qualified(cv, t));
+         return *types.make_qualified(cv, t);
       }
 
       const ipr::Reference&
       Lexicon::get_reference(const ipr::Type& t) {
-         return *finish_type(types.make_reference(t));
+         return *types.make_reference(t);
       }
 
       const ipr::Rvalue_reference&
       Lexicon::get_rvalue_reference(const ipr::Type& t) {
-         return *finish_type(types.make_rvalue_reference(t));
+         return *types.make_rvalue_reference(t);
       }
 
       const ipr::Sum&
       Lexicon::get_sum(const ref_sequence<ipr::Type>& s) {
-         return *finish_type
-            (types.make_sum(*type_seqs.insert(s, unary_lexicographic_compare())));
+         return *types.make_sum(*type_seqs.insert(s, unary_lexicographic_compare()));
       }
 
       const ipr::Forall&
       Lexicon::get_forall(const ipr::Product& p, const ipr::Type& t) {
-         return *finish_type(types.make_forall(p, t));
+         return *types.make_forall(p, t);
       }
 
       impl::Class*
@@ -2164,10 +2146,7 @@ namespace ipr::impl {
 
       impl::Mapping*
       Lexicon::make_mapping(const ipr::Region& r, Mapping_level l) {
-         auto x = expr_factory::make_mapping(r, l);
-         // Note: the parameters form a Product type needing its type set
-         x->parms.parms.scope.decls.typing = typename_type();
-         return x;
+         return expr_factory::make_mapping(r, l);
       }
 
       impl::Parameter*
@@ -2178,9 +2157,7 @@ namespace ipr::impl {
 
       const ipr::Auto& Lexicon::get_auto()
       {
-         auto t = make(autos).with_type(typename_type());
-         t->id = &get_identifier("auto");
-         return *t;
+         return *autos.make();
       }
 
       // -- impl::Interface_unit --


### PR DESCRIPTION
A `Type_id` name is unique by the virtue of being associated with a unique type.  We don't need a separate uniquing factory function for that.  Furthermore, uses of `Type_id` names is mostly internal, for technical reasons.  That factory function is gone with this patch.  That exposes further simplification opportunities of the existing implementation codebase - in preparation for making linkage part of all types.