### PR TITLE
Remove `Rname`

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -568,7 +568,6 @@ namespace ipr::impl {
       const ipr::Sequence<ipr::Expr>& body() const final { return scope; }
       const ipr::Scope& bindings() const final { return scope; }
       const location_span& span() const final { return extent; }
-      const ipr::Expr& owner() const final { return owned_by.get(); }
       bool global() const final { return false; }
 
       explicit homogeneous_region(const ipr::Region& p) : parent(p) { }
@@ -629,42 +628,37 @@ namespace ipr::impl {
 }
 
 namespace ipr::impl {
-                              // -- impl::Rname --
-   struct Rname : Ternary<Node<ipr::Rname>> {
-      explicit Rname(Rep);
-
-      // It was not strictly necessary to actually define this class
-      // and the function type().  See the comments in <ipr/interface>.
-      const ipr::Type& type() const;
-   };
+      struct Parameter_list;
 
                               // -- impl::Parameter --
    struct Parameter final : unique_decl<ipr::Parameter> {
-      const ipr::Name& id;
-      const impl::Rname& abstract_name;
-      util::ref<const ipr::Parameter_list> where;
       Optional<ipr::Expr> init;
-
-      Parameter(const ipr::Name&, const impl::Rname&);
+      Parameter(const ipr::Name&, const ipr::Type&, Decl_position);
       const ipr::Name& name() const final { return id; }
-      const ipr::Type& type() const final;
+      const ipr::Type& type() const final { return typing; }
       const ipr::Region& home_region() const final { return where.get().region(); }
-      Decl_position position() const final;
+      Mapping_level level() const final { return where.get().level(); }
+      Decl_position position() const final { return pos; }
       Optional<ipr::Expr> initializer() const final { return init; }
+   private:
+      const ipr::Name& id;
+      const ipr::Type& typing;
+      util::ref<const ipr::Parameter_list> where;
+      const Decl_position pos;
+      friend struct Parameter_list;
    };
 
                               // -- impl::Parameter_list --
    struct Parameter_list : impl::Node<ipr::Parameter_list> {
-      homogeneous_region<impl::Parameter> parms;
-      const Mapping_level nesting;
-
       Parameter_list(const ipr::Region&, Mapping_level);
       const ipr::Product& type() const final;
       const ipr::Region& region() const final;
       Mapping_level level() const final { return nesting; }
       const ipr::Sequence<ipr::Parameter>& elements() const final;
-
-      impl::Parameter* add_member(const ipr::Name&, const impl::Rname&);
+      impl::Parameter* add_member(const ipr::Name&, const ipr::Type&);
+   private:
+      homogeneous_region<impl::Parameter> parms;
+      const Mapping_level nesting;
    };
 }
 
@@ -1421,15 +1415,18 @@ namespace ipr::impl {
    using Lshift_assign = Classic_binary_expr<ipr::Lshift_assign>;
 
    struct Mapping : impl::Expr<ipr::Mapping> {
-      impl::Parameter_list parms;
+      impl::Parameter_list inputs;
       util::ref<const ipr::Type> value_type;
       util::ref<const ipr::Expr> body;
 
       Mapping(const ipr::Region&, Mapping_level);
-      const ipr::Parameter_list& parameters() const final { return parms; }
+      const ipr::Parameter_list& parameters() const final { return inputs; }
       const ipr::Type& target() const final { return value_type.get(); }
       const ipr::Expr& result() const final { return body.get(); }
-      impl::Parameter* param(const ipr::Name&, const ipr::Rname&);
+      impl::Parameter* param(const ipr::Name& n, const ipr::Type& t)
+      {
+          return inputs.add_member(n, t);
+      }
    };
 
    using Member_init = Binary_expr<ipr::Member_init>;
@@ -1632,7 +1629,6 @@ namespace ipr::impl {
       const ipr::Sequence<ipr::Expr>& body() const final { return expr_seq; }
       const ipr::Scope& bindings() const final { return scope; }
       const location_span& span() const final { return extent; }
-      const ipr::Expr& owner() const final { return owned_by.get(); }
       bool global() const final { return not parent.is_valid(); }
 
       impl::Region* make_subregion();
@@ -2039,8 +2035,6 @@ namespace ipr::impl {
       const ipr::Ctor_name& get_ctor_name(const ipr::Type&);
       const ipr::Dtor_name& get_dtor_name(const ipr::Type&);
       const ipr::Guide_name& get_guide_name(const ipr::Template&);
-      const ipr::Rname& get_rname(Mapping_level, Decl_position, const ipr::Type&);
-
    private:
       util::string_pool strings;
       util::rb_tree::container<impl::Identifier> ids;
@@ -2050,7 +2044,6 @@ namespace ipr::impl {
       util::rb_tree::container<impl::Dtor_name> dtors;
       util::rb_tree::container<impl::Operator> ops;
       util::rb_tree::container<impl::Guide_name> guide_ids;
-      util::rb_tree::container<impl::Rname> rnames;
    };
 
    struct expr_factory : name_factory {
@@ -2164,9 +2157,6 @@ namespace ipr::impl {
       New* make_new(Optional<ipr::Expr_list>, const ipr::Construction&, Optional<ipr::Type> = {});
       Conditional* make_conditional(const ipr::Expr&, const ipr::Expr&,
                                     const ipr::Expr&, Optional<ipr::Type> = {});
-
-      const ipr::Rname& rname_for_next_param(const Mapping&, const ipr::Type&);
-
       Mapping* make_mapping(const ipr::Region&, Mapping_level);
       Lambda* make_lambda(const ipr::Region&, Mapping_level);
 
@@ -2426,8 +2416,6 @@ namespace ipr::impl {
                                           const ipr::Type&);
 
       impl::Mapping* make_mapping(const ipr::Region&, Mapping_level = { });
-      impl::Parameter* make_parameter(const ipr::Name&, const ipr::Type&,
-                                       impl::Mapping&);
 
       impl::Class* make_class(const ipr::Region&);
       impl::Enum* make_enum(const ipr::Region&, Enum::Kind);

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -305,7 +305,6 @@ namespace ipr {
       using Location_span = std::pair<Unit_location, Unit_location>;
       virtual const Location_span& span() const = 0;
       virtual const Region& enclosing() const = 0;
-      virtual const Expr& owner() const = 0;
       virtual const Sequence<Expr>& body() const = 0;
       virtual const Scope& bindings() const = 0;
       virtual bool global() const = 0;                   // is this region the global region?
@@ -456,23 +455,6 @@ namespace ipr {
    // For example, "const T*" is a Type_id , so is "int (T&)".
    struct Type_id : Unary<Category<Category_code::Type_id, Name>, const Type&> {
       Arg_type type_expr() const { return operand(); }
-   };
-
-                                // -- Rname --
-   // This is the abstract, alpha-renaming independent, representation of
-   // a parameter (of either a function or a template) in its de Brujin
-   // level form.  Here we include type in the abstract-name.
-   // The "level" is the nesting-depth, starting from 1, of the parameter.
-   // the "position" is its position, starting from 0, in the
-   // parameter-list at a given level.
-   struct Rname : Ternary<Category<Category_code::Rname, Name>,
-                          const Type&, Mapping_level, Decl_position> {
-      // Although the type() of an Rname is its first operand, we don't define
-      // that function here, for it would involve a two indirections to
-      // to give the result.  Consequently we define it in the implementation
-      // part.
-      Arg2_type level() const { return second(); }
-      Arg3_type position() const { return third(); }
    };
 
                                 // -- Overload --
@@ -1780,6 +1762,7 @@ namespace ipr {
    // A parameter is uniquely characterized by its position in
    // a parameter list.
    struct Parameter : Category<Category_code::Parameter, Decl> {
+      virtual Mapping_level level() const = 0;
       virtual Decl_position position() const = 0;
       const Region& lexical_region() const final { return home_region(); }
       Optional<Expr> default_value() const { return initializer(); }
@@ -1922,7 +1905,6 @@ namespace ipr {
       virtual void visit(const Ctor_name&);
       virtual void visit(const Dtor_name&);
       virtual void visit(const Guide_name&);
-      virtual void visit(const Rname&);
 
       virtual void visit(const Type&) = 0;
       virtual void visit(const Array&);

--- a/include/ipr/synopsis
+++ b/include/ipr/synopsis
@@ -67,8 +67,6 @@ namespace ipr {
    struct Ctor_name;             // constructor name                   T::T
    struct Dtor_name;             // destructor name                   T::~T
    struct Guide_name;            // deduction guide name 
-   struct Rname;                 // de Bruijn (index, position),
-                                 // find better name
 
    // --------------------------------------------------------
    // -- results of nullar expression constructor constants --

--- a/src/io.cxx
+++ b/src/io.cxx
@@ -341,24 +341,6 @@ namespace ipr {
          {
             pp << xpr_identifier("#dtor");
          }
-
-         // -- parameter-canonical-name
-         //    #(level, position)
-         // The (template) parameter is indicated in a generalized
-         // de Bruijn nottation, where "level" is the level of
-         // template-parameter list where the parameter was bound
-         // (starting with 0 for the outermost level, and increasing
-         // by one as the levels nest), and "position" is the position
-         // of the parameter in the parameter list where it was bound
-         // (starting 0 for the first parameter).
-         void visit(const Rname& rn) final
-         {
-            pp << xpr_identifier("#(")
-               << rn.level()
-               << token(", ")
-               << rn.position()
-               << token(')');
-         }
       };
    }
 

--- a/src/traversal.cxx
+++ b/src/traversal.cxx
@@ -147,12 +147,6 @@ ipr::Visitor::visit(const Guide_name& n)
    visit(as<Name>(n));
 }
 
-void
-ipr::Visitor::visit(const Rname& n)
-{
-   visit(as<Name>(n));
-}
-
 // -- Types visiting hooks --
 
 void


### PR DESCRIPTION
Back in 2004,  `Rname` was introduced as a mathematical device to handle the situation where function declarations and template declarations are matched/unified without regard to the names of the parameters.  With the move to differentiating between core expressions (which are unified) and located expressions, it is no longer necessary to have `Rname` around.  Removed with this patch.  I took the opportunity to further simplify the implementation codebase.  This is a source-level breaking change.