### PR TITLE
`default` is a symbolic value

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -2053,6 +2053,7 @@ namespace ipr::impl {
 
       // Return a symbol with a given name and type.
       const ipr::Symbol& get_symbol(const ipr::Name&, const ipr::Type&);
+      const ipr::Symbol& get_label(const ipr::Identifier&);
 
       Annotation* make_annotation(const ipr::String&, const ipr::Literal&);
 
@@ -2376,6 +2377,7 @@ namespace ipr::impl {
       const ipr::Symbol& false_value() const final;
       const ipr::Symbol& true_value() const final;
       const ipr::Symbol& nullptr_value() const final;
+      const ipr::Symbol& default_value() const final;
 
       const ipr::Array& get_array(const ipr::Type&, const ipr::Expr&);
 

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -1533,12 +1533,16 @@ namespace ipr {
 
                                 // -- Labeled_stmt --
    // This node is for labeled-statement:
-   //   - identifier : statement
-   //   - case constant-expression : statement
-   //   - default : statement
-   // IPR represents that "label()" as an expressions so that it can
+   //   a. identifier : statement
+   //   b. case constant-expression : statement
+   //   c. default : statement
+   // IPR represents that `label() as an expression so that it can
    // handle "identifier", "case cst-expr" and "default", where cst-expr
    // is an arbitrary constant-expression.
+   // In scenario (a), the `label()` is a Symbol whose `name()` is the identifier.
+   // The Symbol's `type()` is `void`.
+   // In scenario (b), the `label()` is represented directly by the constant-expression.
+   // In scenario (c), the `label()` is should be `Lexicon::default_value()`. 
    struct Labeled_stmt : Binary<Category<Category_code::Labeled_stmt, Stmt>,
                                 const Expr&, const Stmt&> {
       const Expr& label() const { return first(); }
@@ -1870,6 +1874,8 @@ namespace ipr {
       virtual const Symbol& nullptr_value() const = 0;         // "nullptr"      -- technically not a parameter
                                                                // to the C++ abstract machine, but provided as
                                                                // example of symbolic value representation.
+      virtual const Symbol& default_value() const = 0;         // "default" - as initializer for defaulted definition
+                                                               //             and as default value for case in labeled statements.
 
       virtual const Linkage& cxx_linkage() const = 0;          // constant for 'extern "C++"'
       virtual const Linkage& c_linkage() const = 0;            // constant for 'extern "C"'

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -54,6 +54,7 @@ namespace ipr::impl {
            "char32_t",
            "char8_t",
            "class",
+           "default",
            "double",
            "enum",
            "false",
@@ -131,6 +132,7 @@ namespace ipr::impl {
       constexpr Builtin union_type { "union" };
       constexpr Builtin enum_type { "enum" };
       constexpr Builtin namespace_type { "namespace" };
+      constexpr Builtin auto_type { "auto" };
       constexpr Builtin void_type { "void" };
       constexpr Builtin bool_type { "bool" };
       constexpr Builtin char_type { "char" };
@@ -156,6 +158,9 @@ namespace ipr::impl {
       // Truth value symbolic constants.
       constexpr Symbol false_cst { known_word("false"), bool_type };
       constexpr Symbol true_cst { known_word("true"), bool_type };
+
+      // Universal defaulter constant.
+      constexpr Symbol default_cst { known_word("default"), auto_type };
    }
 
    const ipr::Type& typename_type() { return impl::any_type; }
@@ -1424,6 +1429,13 @@ namespace ipr::impl {
          return *sym;
       }
 
+      const ipr::Symbol& expr_factory::get_label(const ipr::Identifier& n)
+      {
+         if (physically_same(n, known_word("default")))
+            return impl::default_cst;
+         return get_symbol(n, impl::void_type);
+      }
+
       impl::Phantom*
       expr_factory::make_phantom() {
          return phantoms.make();
@@ -2011,6 +2023,7 @@ namespace ipr::impl {
       const ipr::Symbol& Lexicon::false_value() const { return impl::false_cst; }
       const ipr::Symbol& Lexicon::true_value() const { return impl::true_cst; }
       const ipr::Symbol& Lexicon::nullptr_value() const { return impl::nullptr_cst; }
+      const ipr::Symbol& Lexicon::default_value() const { return impl::default_cst; }
 
       const ipr::Template_id&
       Lexicon::get_template_id(const ipr::Name& t, const ipr::Expr_list& a) {


### PR DESCRIPTION
This patch adds two things:
1. Labels as symbolic values of type `void`. Use `get_label(lbl)` to get the symbolic representation of `lbl` as a label.

2. `default` is a universal defaulter: It can be used as the initializer in a defaulted function definition, or as the default operand to `case` in a _labeled-statement_.  In both cases, use `Lexicon::default_value()`.