### PR TITLE
Fix #114

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -2148,8 +2148,7 @@ namespace ipr::impl {
       Scope_ref* make_scope_ref(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
       Rshift* make_rshift(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
       Rshift_assign* make_rshift_assign(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
-      Template_id* make_template_id(const ipr::Name&,
-                                    const ipr::Expr_list&);
+      Template_id* make_template_id(const ipr::Expr&, const ipr::Expr_list&);
       Static_cast* make_static_cast(const ipr::Type&, const ipr::Expr&);
       Widen* make_widen(const ipr::Expr&, const ipr::Type&, const ipr::Type&);
       Binary_fold* make_binary_fold(Category_code, const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
@@ -2333,7 +2332,7 @@ namespace ipr::impl {
       const ipr::Linkage& cxx_linkage() const final;
       const ipr::Linkage& c_linkage() const final;
 
-      const ipr::Template_id& get_template_id(const ipr::Name&,
+      const ipr::Template_id& get_template_id(const ipr::Expr&,
                                                 const ipr::Expr_list&);
 
       const ipr::Literal& get_literal(const ipr::Type&, util::word_view);

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -412,7 +412,7 @@ namespace ipr {
    //    template-expr<template-argument-list>
    // which 'applies' a template to a template-argument list.
    struct Template_id : Binary<Category<Category_code::Template_id, Name>,
-                               const Name&, const Expr_list&> {
+                               const Expr&, const Expr_list&> {
       Arg1_type template_name() const { return first(); }
       Arg2_type args() const { return second(); }
    };

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -1921,8 +1921,7 @@ namespace ipr::impl {
       }
 
       impl::Template_id*
-      expr_factory::make_template_id(const ipr::Name& n,
-                                     const ipr::Expr_list& args) {
+      expr_factory::make_template_id(const ipr::Expr& n, const ipr::Expr_list& args) {
          using Rep = impl::Template_id::Rep;
          return template_ids.insert(Rep{ n, args }, binary_compare());
       }
@@ -2031,7 +2030,7 @@ namespace ipr::impl {
       const ipr::Symbol& Lexicon::delete_value() const { return impl::delete_cst; }
 
       const ipr::Template_id&
-      Lexicon::get_template_id(const ipr::Name& t, const ipr::Expr_list& a) {
+      Lexicon::get_template_id(const ipr::Expr& t, const ipr::Expr_list& a) {
          return *expr_factory::make_template_id(t, a);
       }
 


### PR DESCRIPTION
That bug report observed that it is no longer possible -- after the `Name` refactoring -- to build a `Template_id` where the template declaration is designated by an expression.  Something that was previously possible thanks to the original simpler design for `Name` as part of the `Expr` hierarchy.  Fixed with this patch.

Fixes #114