### PR TITLE
`this` is  a symbolic value

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -2054,6 +2054,8 @@ namespace ipr::impl {
       // Return a symbol with a given name and type.
       const ipr::Symbol& get_symbol(const ipr::Name&, const ipr::Type&);
       const ipr::Symbol& get_label(const ipr::Identifier&);
+      // Return a symbolic value for `this` with a given type.
+      const ipr::Symbol& get_this(const ipr::Type&);
 
       Annotation* make_annotation(const ipr::String&, const ipr::Literal&);
 

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -68,6 +68,7 @@ namespace ipr::impl {
            "nullptr",
            "short",
            "signed char",
+           "this",
            "true",
            "typename",
            "union",
@@ -1438,6 +1439,11 @@ namespace ipr::impl {
          if (physically_same(n, known_word("default")))
             return impl::default_cst;
          return get_symbol(n, impl::void_type);
+      }
+
+      const ipr::Symbol& expr_factory::get_this(const ipr::Type& t)
+      {
+         return get_symbol(known_word("this"), t);
       }
 
       impl::Phantom*


### PR DESCRIPTION
The `this` implicit parameter is a `Symbol` that is valid within the context of non-static members.