### PR TITLE
Remove unused field `owned_by`

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -561,7 +561,6 @@ namespace ipr::impl {
       using Index = typename Sequence<Member>::Index;
       const ipr::Region& parent;
       location_span extent;
-      Optional<ipr::Expr> owned_by { };
       homogeneous_scope<Member> scope;
 
       const ipr::Region& enclosing() const final { return parent; }
@@ -1621,7 +1620,6 @@ namespace ipr::impl {
       using location_span = ipr::Region::Location_span;
       Optional<ipr::Region> parent;
       location_span extent;
-      util::ref<const ipr::Expr> owned_by;
       impl::Scope scope;
       impl::ref_sequence<ipr::Expr> expr_seq;         // all the expressions making up the body.
 
@@ -1694,7 +1692,6 @@ namespace ipr::impl {
       Udt(const ipr::Region* pr, const ipr::Type& t) : body(pr)
       {
          this->typing = &t;
-         body.owned_by = this;
       }
 
       const ipr::Name& name() const final { return id.get(); }

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -551,9 +551,7 @@ namespace ipr::impl {
 
       Block::Block(const ipr::Region& pr)
             : lexical_region(&pr)
-      {
-         lexical_region.owned_by = this;
-      }
+      { }
 
       // ---------------
       // -- impl::For --
@@ -720,9 +718,7 @@ namespace ipr::impl {
 
       Enum::Enum(const ipr::Region& r, Kind k)
             : body(r), enum_kind(k)
-      {
-         body.owned_by = this;
-      }
+      { }
 
       const ipr::Type& Enum::type() const { return impl::enum_type; }
 
@@ -752,9 +748,8 @@ namespace ipr::impl {
 
       Class::Class(const ipr::Region& pr, const ipr::Type& t)
             : impl::Udt<ipr::Class>(&pr, t),
-              base_subobjects(pr) {
-         base_subobjects.owned_by = this;
-      }
+              base_subobjects(pr)
+      { }
 
       const ipr::Sequence<ipr::Base_type>&
       Class::bases() const {
@@ -1334,7 +1329,7 @@ namespace ipr::impl {
       // --------------------------------
 
       Region::Region(Optional<ipr::Region> pr)
-            : parent{pr}, owned_by{}
+            : parent{pr}
       { }
 
 


### PR DESCRIPTION
This field is set in all implementations of `ipr::Region` but never used after a few refactoring.