### PR TITLE
Generalize types of statement constituents

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -2428,11 +2428,10 @@ namespace ipr::impl {
       impl::Goto* make_goto(const ipr::Expr&);
       impl::Return* make_return(const ipr::Expr&);
       impl::Do* make_do();
-      impl::If* make_if(const ipr::Expr&, const ipr::Stmt&);
-      impl::If* make_if(const ipr::Expr&, const ipr::Stmt&, const ipr::Stmt&);
+      impl::If* make_if(const ipr::Expr&, const ipr::Expr&);
+      impl::If* make_if(const ipr::Expr&, const ipr::Expr&, const ipr::Expr&);
       impl::Switch* make_switch();
-      impl::Labeled_stmt* make_labeled_stmt(const ipr::Expr&,
-                                             const ipr::Stmt&);
+      impl::Labeled_stmt* make_labeled_stmt(const ipr::Expr&, const ipr::Expr&);
       impl::While* make_while();
       impl::For* make_for();
       impl::For_in* make_for_in();

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -1544,9 +1544,9 @@ namespace ipr {
    // In scenario (b), the `label()` is represented directly by the constant-expression.
    // In scenario (c), the `label()` is should be `Lexicon::default_value()`. 
    struct Labeled_stmt : Binary<Category<Category_code::Labeled_stmt, Stmt>,
-                                const Expr&, const Stmt&> {
+                                const Expr&, const Expr&> {
       const Expr& label() const { return first(); }
-      const Stmt& stmt() const { return second(); }
+      const Expr& stmt() const { return second(); }
    };
 
                                 // -- Block --
@@ -1574,7 +1574,7 @@ namespace ipr {
                                 // -- If
    // A classic if-statement.
    struct If : Ternary<Category<Category_code::If, Stmt>,
-                       const Expr&, const Stmt&, Optional<Stmt>> {
+                       const Expr&, const Expr&, Optional<Expr>> {
       Arg1_type condition() const { return first(); }
       Arg2_type consequence() const { return second(); }
       Arg3_type alternative() const { return third(); }
@@ -1583,7 +1583,7 @@ namespace ipr {
                                 // -- Switch --
    // A classic switch-statement.
    struct Switch : Binary<Category<Category_code::Switch, Stmt>,
-                          const Expr&, const Stmt&> {
+                          const Expr&, const Expr&> {
       Arg1_type condition() const { return first(); }
       Arg2_type body() const { return second(); }
    };
@@ -1591,14 +1591,14 @@ namespace ipr {
                                 // -- While --
    // A classic while-statement
    struct While : Binary<Category<Category_code::While, Stmt>,
-                         const Expr&, const Stmt&> {
+                         const Expr&, const Expr&> {
       Arg1_type condition() const { return first(); }
       Arg2_type body() const { return second(); }
    };
 
                                 // -- Do --
    // A classic do-statement
-   struct Do : Binary<Category<Category_code::Do, Stmt>, const Expr&, const Stmt&> {
+   struct Do : Binary<Category<Category_code::Do, Stmt>, const Expr&, const Expr&> {
       Arg1_type condition() const { return first(); }
       Arg2_type body() const { return second(); }
    };
@@ -1609,14 +1609,14 @@ namespace ipr {
       virtual const Expr& initializer() const = 0;
       virtual const Expr& condition() const = 0;
       virtual const Expr& increment() const = 0;
-      virtual const Stmt& body() const = 0;
+      virtual const Expr& body() const = 0;
    };
 
                                 // -- For_in --
    struct For_in : Category<Category_code::For_in, Stmt> {
       virtual const Var& variable() const = 0;
       virtual const Expr& sequence() const = 0;
-      virtual const Stmt& body() const = 0;
+      virtual const Expr& body() const = 0;
    };
 
                                 // -- Break --

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -650,13 +650,14 @@ namespace ipr::impl {
          return dos.make();
       }
 
-      impl::If*
-      stmt_factory::make_if(const ipr::Expr& c, const ipr::Stmt& s) {
+      impl::If* stmt_factory::make_if(const ipr::Expr& c, const ipr::Expr& s)
+      {
          return ifs.make(c, s, nullptr);
       }
 
       impl::If*
-      stmt_factory::make_if(const ipr::Expr& c, const ipr::Stmt& t, const ipr::Stmt& f) {
+      stmt_factory::make_if(const ipr::Expr& c, const ipr::Expr& t, const ipr::Expr& f)
+      {
          return ifs.make(c, t, &f);
       }
 
@@ -665,8 +666,7 @@ namespace ipr::impl {
          return switches.make();
       }
 
-      impl::Labeled_stmt*
-      stmt_factory::make_labeled_stmt(const ipr::Expr& l, const ipr::Stmt& s)
+      impl::Labeled_stmt* stmt_factory::make_labeled_stmt(const ipr::Expr& l, const ipr::Expr& s)
       {
          return labeled_stmts.make(l, s);
       }


### PR DESCRIPTION
With the introduction of `ipr::Directive`, it  becomes necessary to widen the types of components of certain statements to fully represent all kinds of Standard C++ constructs at the statement level.