### PR TITLE
Remove `ipr::This`

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -1370,11 +1370,6 @@ namespace ipr::impl {
    using Phantom = Expr<ipr::Phantom>;
    using Eclipsis = Expr<ipr::Eclipsis>;
 
-   struct This : impl::Expr<ipr::This> {
-      Optional<ipr::Decl> owner;
-      Optional<ipr::Decl> context() const final { return owner; }
-   };
-
    struct Symbol final : Unary_expr<ipr::Symbol> {
       explicit constexpr Symbol(const ipr::Name& n) : Unary_expr<ipr::Symbol>{ n } { }
       constexpr Symbol(const ipr::Name& n, const ipr::Type& t)
@@ -2196,7 +2191,6 @@ namespace ipr::impl {
       const ipr::Phantom* make_phantom(const ipr::Type&);
 
       Eclipsis* make_eclipsis(const ipr::Type&);
-      This* make_this();
 
       // Returns an IPR node for a typed literal expression.
       Literal* make_literal(const ipr::Type&, const ipr::String&);
@@ -2302,7 +2296,6 @@ namespace ipr::impl {
 
       stable_farm<impl::Phantom> phantoms;
       stable_farm<impl::Eclipsis> eclipses;
-      stable_farm<impl::This> these;
 
       util::rb_tree::container<impl::Symbol> symbols;
       stable_farm<impl::Alignof> alignofs;

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -754,20 +754,6 @@ namespace ipr {
    // was omitted, hence the name.
    struct Eclipsis : Category<Category_code::Eclipsis> { };
 
-                                 // -- This --
-   // Representation of the `this' implicit parameter for non-static member functions.
-   // An earlier design sought to treat `this' no different from any other function parameter declaration, in part
-   // to account for multimethods and uniform function call syntax in the same framework.  The current
-   // design makes `this' explicit in the semantics graph in part based on recent ISO C++ extensions.
-   // The `this' parameter used to make sense only in the context of non-static member functions, so its
-   // enclosing context was always a function declaration.  Recent versions of C++ introduced default initializers
-   // for non-static data members that can make use of `this', so the function declaration context has to be
-   // inferred based on the constructor that makes uses of the default initializer and is completely unknown at
-   // point of the specification of the default member initializer.
-   struct This : Category<Category_code::This> {
-      virtual Optional<Decl> context() const = 0;  // declaration of the enclosing member function, if any.
-    };
-
    // Semantic description of the variety of lambda capture specifications:
    //   - default captures: indicated by the squiggles "=" (by value), and "&" (by reference) at source level
    //   - implicit object: indicated by "this" (by reference), and "*this" (by value) at source level
@@ -1951,7 +1937,6 @@ namespace ipr {
       virtual void visit(const Scope&);
       virtual void visit(const Phantom&);
       virtual void visit(const Eclipsis&);
-      virtual void visit(const This&);
       virtual void visit(const Lambda&);
 
       virtual void visit(const Symbol&);

--- a/include/ipr/node-category
+++ b/include/ipr/node-category
@@ -53,7 +53,6 @@ Rname,                              // ipr::Rname
 
 Phantom,                            // ipr::Phantom
 Eclipsis,                           // ipr::Eclipsis
-This,                               // ipr::This
 Lambda,                             // ipr::Lambda
 
 Symbol,                             // ipr::Symbol

--- a/include/ipr/synopsis
+++ b/include/ipr/synopsis
@@ -74,7 +74,6 @@ namespace ipr {
    struct Phantom;               // placeholder for arrays of unknown bounds,
                                  // rethrow, empty parts of a For, etc...
    struct Eclipsis;              // the `...' in a unary fold
-   struct This;                  // the special `this' reserved word for the address on the implicit object 
    struct Lambda;                // Lambda expression, packing an environment and a code pointer
 
    // -------------------------------------------------------

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -1456,11 +1456,6 @@ namespace ipr::impl {
          return eclipses.make(&t);
       }
 
-      impl::This* expr_factory::make_this()
-      {
-         return these.make();
-      }
-
       impl::Address*
       expr_factory::make_address(const ipr::Expr& e, Optional<ipr::Type> t)
       {

--- a/src/io.cxx
+++ b/src/io.cxx
@@ -381,7 +381,6 @@ namespace ipr {
                pp << xpr_primary_expr(t.expr());
          }
          void visit(const Phantom&) final { } // nothing to print
-         void visit(const This&) final { pp << xpr_identifier{"this"}; }
          void visit(const Enclosure& e) final
          {
             static constexpr const char* syntax[] = { "\0\0", "()", "{}", "[]", "<>" };

--- a/src/traversal.cxx
+++ b/src/traversal.cxx
@@ -293,11 +293,6 @@ void ipr::Visitor::visit(const Eclipsis& e)
    visit(as<Expr>(e));
 }
 
-void ipr::Visitor::visit(const This& e)
-{
-   visit(as<Expr>(e));
-}
-
 void ipr::Visitor::visit(const Lambda& e)
 {
    visit(as<Expr>(e));


### PR DESCRIPTION
Use `impl::Lexicon::get_this()` to construct the symbolic representation for Standard C++'s  `this`.