### PR TITLE
Clean up `impl::Udt`

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -1764,14 +1764,8 @@ namespace ipr::impl {
    struct Udt : impl::Type<Interface> {
       Region body;
       Optional<ipr::Name> id;
-      util::ref<const ipr::Type> typing;
-      Udt(const ipr::Region* pr, const ipr::Type& t) : body(pr)
-      {
-         this->typing = &t;
-      }
-
+      explicit Udt(const ipr::Region* pr) : body(pr) { }
       const ipr::Name& name() const final { return id.get(); }
-      const ipr::Type& type() const final { return typing.get(); }
       const ipr::Region& region() const final { return body; }
 
       impl::Alias*
@@ -1845,17 +1839,22 @@ namespace ipr::impl {
       impl::Enumerator* add_member(const ipr::Name&);
    };
 
-   using Union = Udt<ipr::Union>;
-   using Namespace = Udt<ipr::Namespace>;
+   struct Union : Udt<ipr::Union> {
+      explicit Union(const ipr::Region&);
+      const ipr::Type& type() const final;
+   };
+   
+   struct Namespace : Udt<ipr::Namespace> {
+      explicit Namespace(const ipr::Region*);
+      const ipr::Type& type() const final;
+   };
 
    struct Class : impl::Udt<ipr::Class> {
       homogeneous_region<impl::Base_type> base_subobjects;
-
-      Class(const ipr::Region&, const ipr::Type&);
-
+      explicit Class(const ipr::Region&);
+      const ipr::Type& type() const final;
       const ipr::Sequence<ipr::Base_type>& bases() const final;
       impl::Base_type* declare_base(const ipr::Type&);
-
    };
 
    struct Auto : impl::Composite<ipr::Auto> {
@@ -1863,8 +1862,8 @@ namespace ipr::impl {
 
    struct Closure : impl::Udt<ipr::Closure> {
       impl::obj_list<impl::Capture> captures;
-
-      Closure(const ipr::Region&, const ipr::Type&);
+      explicit Closure(const ipr::Region&);
+      const ipr::Type& type() const final;
       const ipr::Sequence<ipr::Capture>& members() const final { return captures; }
    };
 
@@ -1902,7 +1901,7 @@ namespace ipr::impl {
       impl::Enum* make_enum(const ipr::Region&, Enum::Kind);
       impl::Class* make_class(const ipr::Region&);
       impl::Union* make_union(const ipr::Region&);
-      impl::Namespace* make_namespace(const ipr::Region*);
+      impl::Namespace* make_namespace(const ipr::Region&);
       impl::Closure* make_closure(const ipr::Region&);
    private:
       util::rb_tree::container<impl::extended_type> extendeds;
@@ -2518,7 +2517,7 @@ namespace ipr::impl {
       using Interface = T;
       unit_base(impl::Lexicon& l)
             : context{ l },
-               global_ns{ nullptr, context.namespace_type() }
+               global_ns{nullptr}
       {
          global_ns.id = &context.get_identifier("");
       }
@@ -2527,7 +2526,7 @@ namespace ipr::impl {
          v.visit(*this);
       }
 
-      const ipr::Global_scope& global_namespace() const final {
+      const ipr::Namespace& global_namespace() const final {
          return global_ns;
       }
 
@@ -2541,7 +2540,7 @@ namespace ipr::impl {
 
    private:
       impl::Lexicon& context;
-      impl::Udt<ipr::Global_scope> global_ns;
+      impl::Namespace global_ns;
       ref_sequence<ipr::Module> modules_imported;
    };
 

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -1809,7 +1809,7 @@ namespace ipr {
    struct Translation_unit {
       struct Visitor;
       virtual void accept(Visitor&) const = 0;
-      virtual const ipr::Global_scope& global_namespace() const = 0;
+      virtual const ipr::Namespace& global_namespace() const = 0;
       virtual const Sequence<Module>& imported_modules() const = 0;
    };
 
@@ -1882,8 +1882,6 @@ namespace ipr {
                                 // -- Built-in type constants --
 
    struct Primitive : As_type { };
-
-   struct Global_scope : Namespace { };
 
    struct Empty_stmt : Expr_stmt { };
 
@@ -2065,7 +2063,6 @@ namespace ipr {
       virtual void visit(const Var&);
       virtual void visit(const EH_parameter&);
 
-      virtual void visit(const Global_scope&);
       virtual void visit(const Empty_stmt&);
    };
 

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -716,14 +716,32 @@ namespace ipr::impl {
          return e;
       }
 
-      // -----------------
-      // -- impl::Class --
-      // -----------------
+      // -- impl::Union
+      Union::Union(const ipr::Region& r) : Udt<ipr::Union>{&r} { }
 
-      Class::Class(const ipr::Region& pr, const ipr::Type& t)
-            : impl::Udt<ipr::Class>(&pr, t),
+      const ipr::Type& Union::type() const
+      { 
+         return impl::builtin(Fundamental::Union); 
+      }
+
+      // -- impl::Namespace
+      Namespace::Namespace(const ipr::Region* r) : Udt<ipr::Namespace>{r} { }
+
+      const ipr::Type& Namespace::type() const 
+      { 
+         return impl::builtin(Fundamental::Namespace); 
+      }
+
+      // -- impl::Class --
+      Class::Class(const ipr::Region& pr)
+            : impl::Udt<ipr::Class>(&pr),
               base_subobjects(pr)
       { }
+
+      const ipr::Type& Class::type() const 
+      { 
+         return impl::builtin(Fundamental::Class); 
+      }
 
       const ipr::Sequence<ipr::Base_type>&
       Class::bases() const {
@@ -737,9 +755,14 @@ namespace ipr::impl {
       }
 
       // -- impl::Closure --
-      Closure::Closure(const ipr::Region& r, const ipr::Type& t)
-         : impl::Udt<ipr::Closure>(&r, t)
+      Closure::Closure(const ipr::Region& r)
+         : impl::Udt<ipr::Closure>(&r)
       { }
+
+      const ipr::Type& Closure::type() const
+      { 
+         return impl::builtin(Fundamental::Class); 
+      }
 
       // --------------------------
       // -- impl::Parameter_list --
@@ -1082,22 +1105,22 @@ namespace ipr::impl {
 
       impl::Class* type_factory::make_class(const ipr::Region& pr)
       {
-         return classes.make(pr, impl::builtin(Fundamental::Class));
+         return classes.make(pr);
       }
 
       impl::Union* type_factory::make_union(const ipr::Region& pr)
       {
-         return unions.make(&pr, impl::builtin(Fundamental::Union));
+         return unions.make(pr);
       }
 
-      impl::Namespace* type_factory::make_namespace(const ipr::Region* pr)
+      impl::Namespace* type_factory::make_namespace(const ipr::Region& pr)
       {
-         return namespaces.make(pr, impl::builtin(Fundamental::Namespace));
+         return namespaces.make(&pr);
       }
 
       impl::Closure* type_factory::make_closure(const ipr::Region& r)
       {
-         return closures.make(r, impl::builtin(Fundamental::Class));
+         return closures.make(r);
       }
 
       // ---------------------

--- a/src/traversal.cxx
+++ b/src/traversal.cxx
@@ -1000,15 +1000,6 @@ void ipr::Visitor::visit(const EH_parameter& d)
 }
 
 //
-// Similarly, the global namespace constant is visited as-if Namespace.
-//
-void
-ipr::Visitor::visit(const Global_scope& s)
-{
-   visit(as<Namespace>(s));
-}
-
-//
 // Similar observation holds for the null-statement.
 //
 void

--- a/tests/unit-tests/simple.cpp
+++ b/tests/unit-tests/simple.cpp
@@ -78,3 +78,18 @@ TEST_CASE("Truth values have type bool") {
   CHECK(physically_same(faux.type(), lexicon.bool_type()));
 }
 
+TEST_CASE("User-defined types have defined types") {
+  using namespace ipr;
+  impl::Lexicon lexicon { };
+  impl::Translation_unit unit { lexicon };
+  auto& global = unit.global_namespace();
+  auto union_udt = lexicon.make_union(global.region());
+  CHECK(physically_same(union_udt->type(), lexicon.union_type()));
+  auto class_udt = lexicon.make_class(global.region());
+  CHECK(physically_same(class_udt->type(), lexicon.class_type()));
+  auto enum_udt = lexicon.make_enum(global.region(), Enum::Kind::Legacy);
+  CHECK(physically_same(enum_udt->type(), lexicon.enum_type()));
+  auto namespace_udt = lexicon.make_namespace(global.region());
+  CHECK(physically_same(namespace_udt->type(), lexicon.namespace_type()));
+}
+


### PR DESCRIPTION
In preparation for simplifying how declarations are created and entered in declarative regions.