### PR TITLE
Remove `ipr::Empty_stmt`

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -2002,7 +2002,6 @@ namespace ipr::impl {
    using Ctor_body = Binary<Stmt<Expr<ipr::Ctor_body>>>;
    using Do = Controlled_stmt<ipr::Do>;
    using Expr_stmt = type_from_operand<Stmt<ipr::Expr_stmt>>;
-   using Empty_stmt = type_from_operand<Stmt<ipr::Empty_stmt>>;
    using Goto = type_from_operand<Stmt<ipr::Goto>>;
    using If = Ternary<Stmt<Expr<ipr::If>>>;
    using Labeled_stmt = type_from_second<Stmt<ipr::Labeled_stmt>>;
@@ -2412,7 +2411,6 @@ namespace ipr::impl {
    struct stmt_factory : expr_factory, dir_factory {
       impl::Break* make_break(const ipr::Type&);
       impl::Continue* make_continue(const ipr::Type&);
-      impl::Empty_stmt* make_empty_stmt(const ipr::Type&);
       impl::Block* make_block(const ipr::Region&, Optional<ipr::Type> = { });
       impl::Ctor_body* make_ctor_body(const ipr::Expr_list&,
                                        const ipr::Block&);
@@ -2431,7 +2429,6 @@ namespace ipr::impl {
    protected:
       stable_farm<impl::Break> breaks;
       stable_farm<impl::Continue> continues;
-      stable_farm<impl::Empty_stmt> empty_stmts;
       stable_farm<impl::Block> blocks;
       stable_farm<impl::Expr_stmt> expr_stmts;
       stable_farm<impl::Goto> gotos;

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -1879,11 +1879,6 @@ namespace ipr {
       virtual const Linkage& cxx_linkage() const = 0;          // constant for 'extern "C++"'
       virtual const Linkage& c_linkage() const = 0;            // constant for 'extern "C"'
    };
-                                // -- Built-in type constants --
-
-   struct Primitive : As_type { };
-
-   struct Empty_stmt : Expr_stmt { };
 
                                 // -- Visitor --
    struct Visitor {
@@ -2062,8 +2057,6 @@ namespace ipr {
       virtual void visit(const Typedecl&);
       virtual void visit(const Var&);
       virtual void visit(const EH_parameter&);
-
-      virtual void visit(const Empty_stmt&);
    };
 
                                 // -- Translation_unit::Visitor --

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -614,11 +614,6 @@ namespace ipr::impl {
          return make(continues).with_type(t);
       }
 
-      impl::Empty_stmt*
-      stmt_factory::make_empty_stmt(const ipr::Type& t) {
-         return empty_stmts.make(*make_phantom(t));
-      }
-
       impl::Block*
       stmt_factory::make_block(const ipr::Region& pr, Optional<ipr::Type> t) {
          return make(blocks, pr).with_type(t);

--- a/src/traversal.cxx
+++ b/src/traversal.cxx
@@ -999,15 +999,6 @@ void ipr::Visitor::visit(const EH_parameter& d)
    visit(as<Decl>(d));
 }
 
-//
-// Similar observation holds for the null-statement.
-//
-void
-ipr::Visitor::visit(const Empty_stmt& s)
-{
-   visit(as<Expr_stmt>(s));
-}
-
 void
 ipr::Translation_unit::Visitor::visit(const Module_unit& u)
 {


### PR DESCRIPTION
At some point in mid 2000s, I introduced  `Empty_stmt` as a way to "optimize" the representation of empty statement.  However, it turns out to introduce irregularity and confusion.  Removed by this patch.  Similarly, `Primitive` is removed.