### PR TITLE
Add files to CMakeLists.txt so they show up in Visual Studio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,8 +40,6 @@ target_sources(${PROJECT_NAME}
         ${PROJECT_SOURCE_DIR}/include/ipr/traversal
         ${PROJECT_SOURCE_DIR}/include/ipr/utility
         ${PROJECT_SOURCE_DIR}/3rdparty/doctest/doctest.h
-        ${PROJECT_SOURCE_DIR}/README.md
-        ${PROJECT_SOURCE_DIR}/STYLE.md
 )
 
 set_target_properties(${PROJECT_NAME}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,13 +25,32 @@ target_include_directories(${PROJECT_NAME}
       ${PROJECT_SOURCE_DIR}/include
 )
 
+target_sources(${PROJECT_NAME}
+    PRIVATE
+        ${PROJECT_SOURCE_DIR}/include/ipr/ancillary
+        ${PROJECT_SOURCE_DIR}/include/ipr/attribute
+        ${PROJECT_SOURCE_DIR}/include/ipr/cxx-form
+        ${PROJECT_SOURCE_DIR}/include/ipr/impl
+        ${PROJECT_SOURCE_DIR}/include/ipr/interface
+        ${PROJECT_SOURCE_DIR}/include/ipr/io
+        ${PROJECT_SOURCE_DIR}/include/ipr/lexer
+        ${PROJECT_SOURCE_DIR}/include/ipr/location
+        ${PROJECT_SOURCE_DIR}/include/ipr/node-category
+        ${PROJECT_SOURCE_DIR}/include/ipr/synopsis
+        ${PROJECT_SOURCE_DIR}/include/ipr/traversal
+        ${PROJECT_SOURCE_DIR}/include/ipr/utility
+        ${PROJECT_SOURCE_DIR}/3rdparty/doctest/doctest.h
+        ${PROJECT_SOURCE_DIR}/README.md
+        ${PROJECT_SOURCE_DIR}/STYLE.md
+)
+
 set_target_properties(${PROJECT_NAME}
    PROPERTIES
       CXX_STANDARD 20
       CXX_STANDARD_REQUIRED ON
 	   CXX_EXTENSIONS OFF
 )
-				
+
 target_compile_options(${PROJECT_NAME}
    PRIVATE
       $<$<CXX_COMPILER_ID:MSVC>:


### PR DESCRIPTION
Visual Studio requires explicit listing of files when you generate a solution
This adds the headers and the .md files to the ipr project
The block in the CMakeLists.txt file could be enclosed in a 
`if (CMAKE_GENERATOR MATCHES "Visual Studio")`
if there is a worry that could effect other build systems but it should not