### PR TITLE
Fix arena::remaining_header_count

### DIFF
--- a/include/ipr/utility
+++ b/include/ipr/utility
@@ -411,7 +411,7 @@ namespace ipr::util {
       util::string* allocate(size_type);
       auto remaining_header_count() const
       {
-         return next_header - &mem->storage[0];
+         return mem->storage + bufsz - next_header;
       }
 
       struct pool;


### PR DESCRIPTION
The implementation now matches the stated goal of the function.
Without this fix, we get segmentation fault/access violation once we ran out of space in the buffer, as original `remaing_header_count` will keep returning bigger and bigger number as the `next_header` is advanced forward in the buffer.
