### PR TITLE
Make Parameter_list type more precise

### DIFF
--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -1346,6 +1346,7 @@ namespace ipr {
    struct Parameter_list : Category<Category_code::Parameter_list> {
       virtual const Region& region() const = 0;
       virtual Mapping_level level() const = 0;
+      const Product& type() const override = 0;
       virtual const Sequence<Parameter>& elements() const = 0;
       auto begin() const { return elements().begin(); }
       auto end() const { return elements().end(); }


### PR DESCRIPTION
The implementation always have Product as its type.
Making the type more precise in the interface can simplify
user code making some casts redundant.