### PR TITLE
Add `ipr::Instantiation`

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -1528,6 +1528,17 @@ namespace ipr::impl {
    // A Where node where the attendant() is not a scope.
    using Where_no_decl = Binary_node<ipr::Where>;
 
+   struct Instantiation : impl::Node<ipr::Instantiation> {
+      Optional<ipr::Expr> result;
+      Instantiation(const ipr::Expr& e, const ipr::Substitution& s) : expr{e}, subst{s} { }
+      const ipr::Expr& pattern() const final { return expr; }
+      const ipr::Substitution& substitution() const final { return subst; }
+      Optional<ipr::Expr> instance() const final { return result; }
+   private:
+      const ipr::Expr& expr;
+      const ipr::Substitution& subst;
+   };
+
    struct Binary_fold : Classic_binary_expr<ipr::Binary_fold> {
       Category_code fold_op;
 
@@ -1543,6 +1554,26 @@ namespace ipr::impl {
    };
 
    using Conditional = Ternary<Classic<Expr<ipr::Conditional>>>;
+
+   // An elementary substitution is a subsitution the domain of which is a singleton.
+   struct Elementary_substitution : ipr::Substitution {
+      Elementary_substitution(const ipr::Parameter& p, const ipr::Expr& v) : parm{p}, value{v} { }
+      const ipr::Expr& operator[](const ipr::Parameter& p) const final
+      {
+         return physically_same(p, parm) ? parm : value;
+      }
+   private:
+      const ipr::Parameter& parm;
+      const ipr::Expr& value;
+   };
+
+   // A general substitution is a substitution the domain of which has cardinality greater than one.
+   struct General_substitution : ipr::Substitution {
+      const ipr::Expr& operator[](const ipr::Parameter&) const final;
+      General_substitution& subst(const ipr::Parameter&, const ipr::Expr&);
+   private:
+      std::map<const ipr::Parameter*, const ipr::Expr*> mapping;
+   };
 
    struct Template : impl::Decl<ipr::Template> {
       util::ref<impl::Mapping> init;
@@ -2279,12 +2310,15 @@ namespace ipr::impl {
       Binary_fold* make_binary_fold(Category_code, const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
       Where* make_where(const ipr::Region&);
       Where_no_decl* make_where(const ipr::Expr&, const ipr::Expr&);
+      impl::Instantiation* make_instantiation(const ipr::Expr&, const ipr::Substitution&);
       New* make_new(Optional<ipr::Expr_list>, const ipr::Construction&, Optional<ipr::Type> = {});
       Conditional* make_conditional(const ipr::Expr&, const ipr::Expr&,
                                     const ipr::Expr&, Optional<ipr::Type> = {});
       Mapping* make_mapping(const ipr::Region&, Mapping_level);
       Lambda* make_lambda(const ipr::Region&, Mapping_level);
 
+      Elementary_substitution* make_elementary_substitution(const ipr::Parameter&, const ipr::Expr&);
+      General_substitution* make_general_substitution();
    private:
       // Language linkage nodes.
       util::rb_tree::container<impl::Linkage> linkages;
@@ -2377,12 +2411,16 @@ namespace ipr::impl {
       stable_farm<impl::Binary_fold> folds;
       stable_farm<impl::Where_no_decl> where_nodecls;
       stable_farm<impl::Where> wheres;
+      stable_farm<impl::Instantiation> insts;
 
       stable_farm<impl::New> news;
       stable_farm<impl::Coercion> coercions;
       stable_farm<impl::Conditional> conds;
       stable_farm<impl::Mapping> mappings;
       stable_farm<impl::Lambda> lambdas;
+
+      stable_farm<impl::Elementary_substitution> elem_substs;
+      stable_farm<impl::General_substitution> gen_substs;
    };
 
    struct dir_factory {

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -1309,6 +1309,27 @@ namespace ipr {
       const Type& type() const final { return main().type(); }
    };
 
+                                // -- Substitution --
+   // A "Substitution" is a mapping of a parameter to an expression (its value). 
+   struct Substitution {
+      virtual const Expr& operator[](const Parameter&) const = 0;
+   };
+
+                                // -- Instantiation --
+   // An instantiation is a computation that substitutes parameters into an expression.
+   // While an implicit specialization of a template is a notorious example of an instantiation,
+   // just about any expression can be instantiated.  For example, a hidden friend function 
+   // defined in a class template is typically instantiated, even though it is not itself a 
+   // function template; the branches of a `constexpr if` are instantiated.  Consequently,
+   // an Instantiarion is different from a Template_id (a Name).
+   // The result of an instantiation may be cached on the side, or directly stored in this node.
+   struct Instantiation : Category<Category_code::Instantiation> {
+      virtual const Expr& pattern() const = 0;
+      virtual const Substitution& substitution() const = 0;
+      virtual Optional<Expr> instance() const  = 0;
+      const Type& type() const final { return instance().get().type(); }
+   };
+
                                 // -- New --
    // This node represents a new-expression:
    //    ::_opt new new-placement_opt new-type-id new-initializer_opt
@@ -1637,23 +1658,6 @@ namespace ipr {
    struct Handler : Category<Category_code::Handler, Stmt> {
       virtual const EH_parameter& exception() const = 0;
       virtual const Block& body() const = 0;
-   };
-
-                                // -- Substitution --
-   // A "Substitution" is a mapping of a parameter to an expression
-   // (its value).  It is mainly convenient for representing individual
-   // template-argument used to instantiate a template.  Thus, a
-   // template-argument list is a sequence of Substitutions.
-   struct Substitution {
-      Substitution(const Parameter& p, const Expr& x)
-            : var(&p), expr(&x) { }
-
-      const Parameter& param() const { return *var; }
-      const Expr& value() const { return *expr; }
-
-   private:
-      const Parameter* var;
-      const Expr* expr;
    };
 
                                 // -- Decl --
@@ -2015,6 +2019,7 @@ namespace ipr {
       virtual void visit(const Widen&);
       virtual void visit(const Binary_fold&);
       virtual void visit(const Where&);
+      virtual void visit(const Instantiation&);
 
       virtual void visit(const Conditional&);
       virtual void visit(const New&);

--- a/include/ipr/node-category
+++ b/include/ipr/node-category
@@ -137,6 +137,7 @@ Minus,                              // ipr::Minus
 Minus_assign,                       // ipr::Minus_assign
 Binary_fold,                        // ipr::Binary_fold
 Where,                              // ipr::Where
+Instantiation,                      // ipr::Instantiation
 
 New,                                // ipr::New
 Conditional,                        // ipr::Conditional

--- a/include/ipr/synopsis
+++ b/include/ipr/synopsis
@@ -169,6 +169,7 @@ namespace ipr {
    struct Mapping;               // function
    struct Rewrite;               // Semantics by translation -- unwise, but the committee can't help it
    struct Where;                 // expression with local bindings or restrictions
+   struct Instantiation;         // Substitution into a parameterized expression
 
    // --------------------------------------------------------
    // -- result of trinary expression constructor constants --

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -1167,6 +1167,20 @@ namespace ipr::impl {
 
       Category_code Binary_fold::operation() const { return fold_op; }
 
+      // -- impl::General_substitution
+      const ipr::Expr& General_substitution::operator[](const ipr::Parameter& p) const
+      {
+         if (auto where = mapping.find(&p); where != mapping.end())
+            return *where->second;
+         return p;
+      }
+
+      General_substitution& General_substitution::subst(const ipr::Parameter& p, const ipr::Expr& v)
+      {
+         mapping.insert_or_assign(&p, &v);
+         return *this;
+      }
+
       // -------------------
       // -- impl::Mapping --
       // -------------------
@@ -1968,6 +1982,12 @@ namespace ipr::impl {
          return where_nodecls.make(main, attendant);
       }
 
+      impl::Instantiation*
+      expr_factory::make_instantiation(const ipr::Expr& e, const ipr::Substitution& s)
+      {
+         return insts.make(e, s);
+      }
+
       impl::New*
       expr_factory::make_new(Optional<ipr::Expr_list> where, const ipr::Construction& expr, Optional<ipr::Type> t)
       {
@@ -1991,6 +2011,16 @@ namespace ipr::impl {
          return lambdas.make(r, l);
       }
 
+      impl::Elementary_substitution* 
+      expr_factory::make_elementary_substitution(const ipr::Parameter& p, const ipr::Expr& v)
+      {
+         return elem_substs.make(p, v);
+      }
+
+      impl::General_substitution* expr_factory::make_general_substitution()
+      {
+         return gen_substs.make();
+      }
 
       // -- impl::Lexicon --
 

--- a/src/traversal.cxx
+++ b/src/traversal.cxx
@@ -774,6 +774,11 @@ void ipr::Visitor::visit(const Where& e)
    visit(as<Expr>(e));
 }
 
+void ipr::Visitor::visit(const Instantiation& e)
+{
+   visit(as<Expr>(e));
+}
+
 void
 ipr::Visitor::visit(const Conditional& e)
 {


### PR DESCRIPTION
To capture the description of an instantiation of a templated expression, along with the substitution used and the result of the instantiation.