### PR TITLE
Base type of an enum

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -1857,6 +1857,7 @@ namespace ipr::impl {
    };
 
    struct Enum : impl::Type<ipr::Enum> {
+      Optional<ipr::Type> underlying;
       homogeneous_region<impl::Enumerator, obj_sequence> body;
       Optional<ipr::Name> id;
       const Kind enum_kind;
@@ -1867,6 +1868,7 @@ namespace ipr::impl {
       const ipr::Region& region() const final;
       const Sequence<ipr::Enumerator>& members() const final;
       Kind kind() const final;
+      Optional<ipr::Type> base() const final { return underlying; }
       impl::Enumerator* add_member(const ipr::Name&);
    };
 

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -707,12 +707,15 @@ namespace ipr {
    // An enumeration is an object-type whose members are named constants
    // the definitions of which as part of the definition of the enumeration
    // itself.  By historical accident, enumerators are not "properly scoped".
+   // The underlying type of the enumeration is given by `base()`, when explicitly
+   // specified or inferred from the enumerator list.
    struct Enum : Category<Category_code::Enum, Udt<Enumerator>> {
       enum class Kind : std::uint8_t {     // The kind of enum.
          Legacy,                      // traditional C-style enum
          Scoped                       // scoped enum (C++11)
       };
       virtual Kind kind() const = 0;
+      virtual Optional<Type> base() const = 0;
    };
 
                                 // -- Auto --


### PR DESCRIPTION
Provide accessor for the underlying type of an enumeration.

Partially addresses #22 .