### PR TITLE
Remove `Base_type`

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -1211,25 +1211,6 @@ namespace ipr::impl {
       }
    };
 
-   struct Base_type final : unique_decl<ipr::Base_type> {
-      const ipr::Type& base;
-      const ipr::Region& where;
-      const Decl_position scope_pos;
-      ipr::DeclSpecifiers spec;
-
-      Base_type(const ipr::Type&, const ipr::Region&, Decl_position);
-      const ipr::Type& type() const final { return base; }
-      // FIXME: for a base-class subobject, the home region and lexical
-      //        region are slightly different.  The home region should be that
-      //        of the class this is a base class, whereas the lexical region
-      //        should be the actual lexical region where the base type was specified.
-      const ipr::Region& lexical_region() const final { return where; }
-      const ipr::Region& home_region() const final { return where; }
-      Decl_position position() const final { return scope_pos; }
-      Optional<ipr::Expr> initializer() const final;
-      DeclSpecifiers specifiers() const final { return spec; }
-   };
-
    struct Enumerator final : unique_decl<ipr::Enumerator> {
       const ipr::Name& id;
       const ipr::Enum& typing;
@@ -1881,12 +1862,31 @@ namespace ipr::impl {
       const ipr::Type& type() const final;
    };
 
+   // Non-virtual base class subobject
+   struct Exclusive_subobject : ipr::Base_subobject {
+      explicit Exclusive_subobject(const ipr::Type& t) : base{t} { }
+      const ipr::Type& type() const final { return base; }
+      Subobject_specifier specifier() const final { return Subobject_specifier::Exclusive; }
+   private:
+      const ipr::Type& base;
+   };
+
+   // Virtual base class subobject
+   struct Shared_subobject : ipr::Base_subobject {
+      explicit Shared_subobject(const ipr::Type& t) : base{t} { }
+      const ipr::Type& type() const final { return base; }
+      Subobject_specifier specifier() const final { return Subobject_specifier::Shared; }
+   private:
+      const ipr::Type& base;
+   };
+
    struct Class : impl::Udt<ipr::Class> {
-      homogeneous_region<impl::Base_type> base_subobjects;
       explicit Class(const ipr::Region&);
       const ipr::Type& type() const final;
-      const ipr::Sequence<ipr::Base_type>& bases() const final;
-      impl::Base_type* declare_base(const ipr::Type&);
+      const ipr::Sequence<ipr::Base_subobject>& bases() const final { return subobjects; }
+      Class& add_subobject(const ipr::Base_subobject&);
+   private:
+      impl::ref_sequence<ipr::Base_subobject> subobjects;
    };
 
    struct Auto : impl::Composite<ipr::Auto> {
@@ -1929,6 +1929,8 @@ namespace ipr::impl {
       const ipr::Sum& get_sum(const ipr::Sequence<ipr::Type>&);
       const ipr::Forall& get_forall(const ipr::Product&, const ipr::Type&);
       const ipr::Auto& get_auto();
+      const ipr::Base_subobject& get_exclusive_base(const ipr::Type&);
+      const ipr::Base_subobject& get_shared_base(const ipr::Type&);
 
       impl::Enum* make_enum(const ipr::Region&, Enum::Kind);
       impl::Class* make_class(const ipr::Region&);
@@ -1951,6 +1953,8 @@ namespace ipr::impl {
       util::rb_tree::container<impl::Rvalue_reference> refrefs;
       util::rb_tree::container<impl::Sum> sums;
       util::rb_tree::container<impl::Forall> foralls;
+      util::rb_tree::container<impl::Exclusive_subobject> exclusives;
+      util::rb_tree::container<impl::Shared_subobject> shareds;
       stable_farm<impl::Decltype> decltypes;
       stable_farm<impl::Enum> enums;
       stable_farm<impl::Class> classes;

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -692,10 +692,23 @@ namespace ipr {
       const Sequence<Decl>& members() const final { return scope().elements(); }
    };
 
+   // Specifier of semantics for base-class subobjects.
+   enum class Subobject_specifier : std::uint8_t {
+      Exclusive,                    // Each subobject is unshared, default in ISO C++
+      Shared,                       // "virtual" subobject shared along inheritance chain
+   };
+
+                                // -- Base_subobject --
+   // Each base-specifier in a base-clause morally declares an unnamed subobject.
+   struct Base_subobject {
+      virtual const Type& type() const = 0;
+      virtual Subobject_specifier specifier() const = 0;
+   };
+
                                 // -- Class --
    struct Class : Category<Category_code::Class, Udt<Decl>> {
       const Sequence<Decl>& members() const final { return scope().elements(); }
-      virtual const Sequence<Base_type>& bases() const = 0;
+      virtual const Sequence<Base_subobject>& bases() const = 0;
    };
 
                                 // -- Union --
@@ -1744,21 +1757,6 @@ namespace ipr {
       const Region& lexical_region() const final { return home_region(); }
    };
 
-                                // -- Base_type --
-   // Each base-specifier in a base-clause morally declares an unnamed
-   // subobject.  We represent that subobject declaration by a Base_type.
-   // For consistency with other non-static members, the name of that
-   // subobject is pretended to be the same as that of the base-class
-   // so that when it appears in a member-initializer list, it can
-   // conveniently be thought of as initialization of that subobject.
-   struct Base_type : Category<Category_code::Base_type, Decl> {
-      // A base-object is, by definition, unnamed.  However, it
-      // is convenient to refer to it by the name of the corresponding
-      // type -- in C++ tradition.
-      const Name& name() const final { return type().name(); }
-      virtual Decl_position position() const = 0;
-   };
-
                                 // -- Parameter --
    // A parameter is uniquely characterized by its position in
    // a parameter list.
@@ -2055,7 +2053,6 @@ namespace ipr {
 
       virtual void visit(const Decl&) = 0;
       virtual void visit(const Alias&);
-      virtual void visit(const Base_type&);
       virtual void visit(const Bitfield&);
       virtual void visit(const Enumerator&);
       virtual void visit(const Field&);

--- a/include/ipr/node-category
+++ b/include/ipr/node-category
@@ -169,7 +169,6 @@ Switch,                             // ipr::Switch
 While,                              // ipr::While
 
 Alias,                              // ipr::Alias
-Base_type,                          // ipr::Base_type
 Enumerator,                         // ipr::Enumerator
 Field,                              // ipr::Field
 Bitfield,                           // ipr::Bitfield

--- a/include/ipr/synopsis
+++ b/include/ipr/synopsis
@@ -213,7 +213,6 @@ namespace ipr {
    // -- result of declaration constructor constants --
    // -------------------------------------------------
    struct Alias;                 // alias-declaration
-   struct Base_type;             // base-class in class inheritance
    struct Enumerator;            // enumerator in enumeration-declaration
    struct Field;                 // field in union or class declaration
    struct Bitfield;              // bitfield

--- a/src/io.cxx
+++ b/src/io.cxx
@@ -1283,18 +1283,36 @@ namespace ipr {
    }
 
    struct xpr_base_classes {
-      const ipr::Sequence<ipr::Base_type>& bases;
-      explicit xpr_base_classes(const ipr::Sequence<ipr::Base_type>& b)
+      const ipr::Sequence<ipr::Base_subobject>& bases;
+      explicit xpr_base_classes(const ipr::Sequence<ipr::Base_subobject>& b)
             : bases(b) { }
    };
+
+   struct xpr_base {
+      const ipr::Base_subobject& base;
+   };
+
+   static Printer& operator<<(Printer& pp, xpr_base x)
+   {
+      switch (x.base.specifier()) {
+      case Subobject_specifier::Exclusive:
+         break;      // nothing
+      case Subobject_specifier::Shared:
+         pp << xpr_identifier("virtual");
+         break;
+      default:
+         pp << xpr_identifier("<???>");
+      }
+      return pp << xpr_type(x.base.type());
+   }
 
    static Printer&
    operator<<(Printer& pp, xpr_base_classes x)
    {
-      const Sequence<Base_type>& bases = x.bases;
+      auto& bases = x.bases;
       if (not bases.empty()) {
          pp << token('(');
-         comma_separated<xpr_decl>(pp, bases);
+         comma_separated<xpr_base>(pp, bases);
          pp << token(')');
       }
       return pp;
@@ -1833,11 +1851,6 @@ namespace ipr {
                << xpr_identifier("bitfield")
                << token('(') << xpr_expr(b.precision()) << token(')')
                << xpr_type(b.type());
-         }
-
-         void visit(const Base_type& b) final
-         {
-            pp << b.specifiers() << xpr_type(b.type());
          }
 
          void visit(const Fundecl& f) final

--- a/src/io.cxx
+++ b/src/io.cxx
@@ -29,7 +29,7 @@ namespace ipr {
       auto worker = [&pp, first = true](auto& x) mutable {
          if (not first)
             pp << ", ";
-         pp << F(x);
+         pp << F{x};
          first = false;
       };
       std::for_each(s.begin(), s.end(), worker);

--- a/src/traversal.cxx
+++ b/src/traversal.cxx
@@ -940,12 +940,6 @@ ipr::Visitor::visit(const Alias& d)
 }
 
 void
-ipr::Visitor::visit(const Base_type& d)
-{
-   visit(as<Decl>(d));
-}
-
-void
 ipr::Visitor::visit(const Bitfield& d)
 {
    visit(as<Decl>(d));

--- a/tests/unit-tests/conversions.cpp
+++ b/tests/unit-tests/conversions.cpp
@@ -64,7 +64,7 @@ TEST_CASE("Class Conversions") {
   INFO("struct Derived : Base {};");
   auto& base = *lexicon.make_class(*unit.global_region());
   auto& derived = *lexicon.make_class(*unit.global_region());
-  derived.declare_base(base);
+  derived.add_subobject(lexicon.get_exclusive_base(base));
 
   INFO("Base* b;");
   INFO("Derived* d;");


### PR DESCRIPTION
One of the early semantic design decisions of the IPR was to view base-class types as declaring anonymous fields of the derived classes, as documented in the C++ ARM (original C++ semantics documentation).  Over the years, that approach has felt at odd with other semantic aspect of the declarative model of the IPR.  This patch removes `Base_type` as a `Decl`, and instead replaces it with just a specifier for base class layout indicator for semantic interpretations in later interpretations (e,g. object layout, object initialization, etc).

Fixes #65