### PR TITLE
restore ipr::Region::owner(), added a usage example

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -722,7 +722,7 @@ namespace ipr::impl {
       const ipr::Sequence<ipr::Parameter>& elements() const final;
       impl::Parameter* add_member(const ipr::Name&, const ipr::Type&);
 
-      // or friend Mapping and Lambda (and possibly, Callable_species, though it is not an expr)
+      // Need access by Mapping, Lambda and whomever creates Callable_species
       homogeneous_region<impl::Parameter> parms;
    private:
       const Mapping_level nesting;
@@ -789,7 +789,7 @@ namespace ipr::cxx_form::impl {
       Simple_indirector* make_simple_indirector();
       Member_indirector* make_member_indirector();
       Id_species* make_id_species();
-      Callable_species* make_callable_species();
+      Callable_species* make_callable_species(const ipr::Region& parent, Mapping_level level);
       Array_species* make_array_species();
       Parenthesized_species* make_parenthesized_species();
    private:

--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -646,7 +646,7 @@ namespace ipr::impl {
       const ipr::Sequence<ipr::Expr>& body() const final { return scope; }
       const ipr::Scope& bindings() const final { return scope; }
       const location_span& span() const final { return extent; }
-      const ipr::Expr& owner() const final { return owned_by.get(); }
+      Optional<ipr::Expr> owner() const final { return owned_by.get(); }
       bool global() const final { return false; }
    };
 }
@@ -1738,7 +1738,7 @@ namespace ipr::impl {
       const ipr::Sequence<ipr::Expr>& body() const final { return expr_seq; }
       const ipr::Scope& bindings() const final { return scope; }
       const location_span& span() const final { return extent; }
-      const ipr::Expr& owner() const final { return owned_by.get(); }
+      Optional<ipr::Expr> owner() const final { return owned_by.get(); }
       bool global() const final { return not parent.is_valid(); }
 
       impl::Region* make_subregion();

--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -634,6 +634,7 @@ namespace ipr::impl {
       using location_span = ipr::Region::Location_span;
       const ipr::Region& parent;
       location_span extent;
+      Optional<ipr::Expr> owned_by { };
       homogeneous_scope<Member, Seq> scope;
 
       explicit homogeneous_region(const ipr::Region& p) : parent(p) { }
@@ -645,6 +646,7 @@ namespace ipr::impl {
       const ipr::Sequence<ipr::Expr>& body() const final { return scope; }
       const ipr::Scope& bindings() const final { return scope; }
       const location_span& span() const final { return extent; }
+      const ipr::Expr& owner() const final { return owned_by.get(); }
       bool global() const final { return false; }
    };
 }
@@ -691,7 +693,7 @@ namespace ipr::impl {
 }
 
 namespace ipr::impl {
-      struct Parameter_list;
+   struct Parameter_list;
 
                               // -- impl::Parameter --
    struct Parameter final : unique_decl<ipr::Parameter> {
@@ -719,8 +721,10 @@ namespace ipr::impl {
       Mapping_level level() const final { return nesting; }
       const ipr::Sequence<ipr::Parameter>& elements() const final;
       impl::Parameter* add_member(const ipr::Name&, const ipr::Type&);
-   private:
+
+      // or friend Mapping and Lambda (and possibly, Callable_species, though it is not an expr)
       homogeneous_region<impl::Parameter> parms;
+   private:
       const Mapping_level nesting;
    };
 }
@@ -1726,6 +1730,7 @@ namespace ipr::impl {
       using location_span = ipr::Region::Location_span;
       Optional<ipr::Region> parent;
       location_span extent;
+      util::ref<const ipr::Expr> owned_by { };
       impl::Scope scope;
       impl::ref_sequence<ipr::Expr> expr_seq;         // all the expressions making up the body.
 
@@ -1733,6 +1738,7 @@ namespace ipr::impl {
       const ipr::Sequence<ipr::Expr>& body() const final { return expr_seq; }
       const ipr::Scope& bindings() const final { return scope; }
       const location_span& span() const final { return extent; }
+      const ipr::Expr& owner() const final { return owned_by.get(); }
       bool global() const final { return not parent.is_valid(); }
 
       impl::Region* make_subregion();
@@ -1794,7 +1800,10 @@ namespace ipr::impl {
    struct Udt : impl::Type<Interface> {
       Region body;
       Optional<ipr::Name> id;
-      explicit Udt(const ipr::Region* pr) : body(pr) { }
+      explicit Udt(const ipr::Region* pr) : body(pr)
+      { 
+         body.owned_by = this;
+      }
       const ipr::Name& name() const final { return id.get(); }
       const ipr::Region& region() const final { return body; }
 

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -305,7 +305,7 @@ namespace ipr {
       using Location_span = std::pair<Unit_location, Unit_location>;
       virtual const Location_span& span() const = 0;
       virtual const Region& enclosing() const = 0;
-      virtual const Expr& owner() const = 0;
+      virtual Optional<Expr> owner() const = 0;
       virtual const Sequence<Expr>& body() const = 0;
       virtual const Scope& bindings() const = 0;
       virtual bool global() const = 0;                   // is this region the global region?

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -305,6 +305,7 @@ namespace ipr {
       using Location_span = std::pair<Unit_location, Unit_location>;
       virtual const Location_span& span() const = 0;
       virtual const Region& enclosing() const = 0;
+      virtual const Expr& owner() const = 0;
       virtual const Sequence<Expr>& body() const = 0;
       virtual const Scope& bindings() const = 0;
       virtual bool global() const = 0;                   // is this region the global region?

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -525,7 +525,9 @@ namespace ipr::impl {
 
       Block::Block(const ipr::Region& pr)
             : lexical_region(&pr)
-      { }
+      {
+         lexical_region.owned_by = this;
+      }
 
       impl::Handler* Block::new_handler(const ipr::Name& n, const ipr::Type& t)
       {
@@ -687,7 +689,9 @@ namespace ipr::impl {
 
       Enum::Enum(const ipr::Region& r, Kind k)
             : body(r), enum_kind(k)
-      { }
+      {
+         body.owned_by = this;
+      }
 
       const ipr::Type& Enum::type() const { return impl::builtin(Fundamental::Enum); }
 
@@ -731,7 +735,9 @@ namespace ipr::impl {
       Class::Class(const ipr::Region& pr)
             : impl::Udt<ipr::Class>(&pr),
               base_subobjects(pr)
-      { }
+      {
+         base_subobjects.owned_by = this;
+      }
 
       const ipr::Type& Class::type() const 
       { 
@@ -1187,11 +1193,15 @@ namespace ipr::impl {
 
       Mapping::Mapping(const ipr::Region& pr, Mapping_level d)
             : inputs{pr, d}, value_type{}, body{}
-      { }
+      {
+         inputs.parms.owned_by = this;
+      }
 
       // -- impl::Lambda
       Lambda::Lambda(const ipr::Region& r, Mapping_level l) : parms{r, l}, lam_spec{}
-      { }
+      {
+         parms.parms.owned_by = this;
+      }
 
       // -------------------------------
       // -- impl::Scope --

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -214,6 +214,11 @@ namespace ipr::cxx_form::impl {
       return id_species.make();
    }
 
+   Callable_species* form_factory::make_callable_species(const ipr::Region& parent, Mapping_level level)
+   {
+      return callable_species.make(parent, level);
+   }
+
    Array_species* form_factory::make_array_species()
    {
       return array_species.make();

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -161,7 +161,7 @@ namespace ipr::impl {
       // alias for that type, i.e. `std::nullptr_t` is a Decl, not a type.
       struct Nullptr : impl::Node<ipr::Symbol> {
          constexpr Nullptr() : typing{*this} { }
-         const ipr::Name& operand() const final { return known_word("nullptr)"); }
+         const ipr::Name& operand() const final { return known_word("nullptr"); }
          const ipr::Decltype& type() const final { return typing; }
       private:
          impl::Decltype typing;

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -5,6 +5,7 @@ add_executable(${TEST_BINARY}
    conversions.cxx
    simple.cxx
    words.cxx
+   region-owner.cxx
 )
 
 target_link_libraries(${TEST_BINARY}

--- a/tests/unit-tests/region-owner.cxx
+++ b/tests/unit-tests/region-owner.cxx
@@ -4,25 +4,21 @@
 #include <ipr/impl>
 #include <ipr/utility>
 
-const ipr::Type* get_enclosing_udt_if_any(const ipr::Region& current_region)
+const ipr::Region& nearest_namespace_or_block_region(const ipr::Region& current_region)
 {
+    using namespace ipr;
     auto* region = &current_region;
     for (;;)
     {
-        switch (region->owner().category)
-        {
-        case ipr::Category_code::Class:
-        case ipr::Category_code::Enum:
-        case ipr::Category_code::Union:
-            return ipr::util::view<ipr::Type>(region->owner());
+        auto& owner = region->owner();
 
-        case ipr::Category_code::Block:
-        case ipr::Category_code::Namespace:
-            return nullptr;
+        if (auto* block = ipr::util::view<Block>(owner))
+            return block->region();
+        if (auto* ns = ipr::util::view<Namespace>(owner))
+            return ns->region();
 
-        default:
-            region = &region->enclosing();
-        }
+        // keep going up
+        region = &region->enclosing();
     }
 }
 
@@ -33,10 +29,29 @@ TEST_CASE("Region-owner user") {
   impl::Interface_unit unit{lexicon, module};
 
   // the helper above does not consider namespace to be udt type
-  auto* not_found = get_enclosing_udt_if_any(*unit.global_region());
-  CHECK(not_found == nullptr);
+  auto& r1 = nearest_namespace_or_block_region(*unit.global_region());
+  CHECK(&r1 == unit.global_region());
 
   auto& clazz = *lexicon.make_class(*unit.global_region());
-  auto* found = get_enclosing_udt_if_any(clazz.region());
-  CHECK(found == &clazz);
+  auto& r2 = nearest_namespace_or_block_region(clazz.region());
+  CHECK(&r1 == unit.global_region());
+}
+
+TEST_CASE("Callable species")
+{
+  using namespace ipr;
+  impl::Lexicon lexicon{};
+  impl::Module module{lexicon};
+  impl::Interface_unit unit{lexicon, module};
+
+  auto& region = *unit.global_region();
+  auto nesting = Mapping_level{0};
+
+  auto& spread = *lexicon.make_specifiers_spread();
+  auto& callable = *region.make_callable_species(region, nesting);
+  callable.inputs.parms.owned_by = &spread;
+  spread.proc_seq.push_back(&callable);
+
+  auto& r = nearest_namespace_or_block_region(callable.inputs.region());
+  CHECK(&r == unit.global_region());
 }

--- a/tests/unit-tests/region-owner.cxx
+++ b/tests/unit-tests/region-owner.cxx
@@ -10,7 +10,7 @@ const ipr::Region& nearest_namespace_or_block_region(const ipr::Region& current_
     auto* region = &current_region;
     for (;;)
     {
-        auto& owner = region->owner();
+        auto& owner = region->owner().get();
 
         if (auto* block = ipr::util::view<Block>(owner))
             return block->region();

--- a/tests/unit-tests/region-owner.cxx
+++ b/tests/unit-tests/region-owner.cxx
@@ -1,0 +1,42 @@
+#include "doctest/doctest.h"
+
+#include <ipr/traversal>
+#include <ipr/impl>
+#include <ipr/utility>
+
+const ipr::Type* get_enclosing_udt_if_any(const ipr::Region& current_region)
+{
+    auto* region = &current_region;
+    for (;;)
+    {
+        switch (region->owner().category)
+        {
+        case ipr::Category_code::Class:
+        case ipr::Category_code::Enum:
+        case ipr::Category_code::Union:
+            return ipr::util::view<ipr::Type>(region->owner());
+
+        case ipr::Category_code::Block:
+        case ipr::Category_code::Namespace:
+            return nullptr;
+
+        default:
+            region = &region->enclosing();
+        }
+    }
+}
+
+TEST_CASE("Region-owner user") {
+  using namespace ipr;
+  impl::Lexicon lexicon{};
+  impl::Module module{lexicon};
+  impl::Interface_unit unit{lexicon, module};
+
+  // the helper above does not consider namespace to be udt type
+  auto* not_found = get_enclosing_udt_if_any(*unit.global_region());
+  CHECK(not_found == nullptr);
+
+  auto& clazz = *lexicon.make_class(*unit.global_region());
+  auto* found = get_enclosing_udt_if_any(clazz.region());
+  CHECK(found == &clazz);
+}

--- a/tests/unit-tests/region-owner.cxx
+++ b/tests/unit-tests/region-owner.cxx
@@ -34,7 +34,7 @@ TEST_CASE("Region-owner user") {
 
   auto& clazz = *lexicon.make_class(*unit.global_region());
   auto& r2 = nearest_namespace_or_block_region(clazz.region());
-  CHECK(&r1 == unit.global_region());
+  CHECK(&r2 == unit.global_region());
 }
 
 TEST_CASE("Callable species")


### PR DESCRIPTION
* Restored owner to region.
* Added a test with a use case

There are three implementation nodes that host a Parameter_list.
Mapping and Lambda will setup the Paramater_list region owner to themselves.
Callable_species will leave the owner null. This requires more thinking.
Issue: https://github.com/GabrielDosReis/ipr/issues/268
