### PR TITLE
Add `ipr::Phased_evaluation`

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -1428,6 +1428,11 @@ namespace ipr::impl {
    using Demotion = Unary_expr<ipr::Demotion>;
    using Deref = Classic_unary_expr<ipr::Deref>;
 
+   struct Asm : impl::Unary_node<ipr::Asm> {
+      explicit Asm(const ipr::String&);
+      const ipr::Type& type() const final;
+   };
+
    struct Expr_list : impl::Node<ipr::Expr_list> {
       typed_sequence<ref_sequence<ipr::Expr>> seq;
 
@@ -1990,28 +1995,12 @@ namespace ipr::impl {
    };
 
    // -- Implementation of directives --
-   struct Asm : impl::Directive<ipr::Asm, Phases::Code_generation> {
-      explicit Asm(const ipr::String&);
-      const ipr::String& text() const final { return txt; }
-   private:
-      const ipr::String& txt;
-   };
-
    struct Specifiers_spread : impl::Directive<ipr::Specifiers_spread, Phases::Elaboration> {
       impl::ref_sequence<cxx_form::Proclamator> proc_seq;
       ipr::DeclSpecifiers specs { };
 
       const ipr::Sequence<cxx_form::Proclamator>& targets() const final { return proc_seq; }
       ipr::DeclSpecifiers specifiers() const final { return specs; }
-   };
-
-   struct Static_assert : impl::Directive<ipr::Static_assert, Phases::Elaboration> {
-      Static_assert(const ipr::Expr&, Optional<ipr::String>);
-      const ipr::Expr& condition() const final { return cond; }
-      Optional<ipr::String> message() const final { return txt; }
-   private:
-      const ipr::Expr& cond;
-      Optional<ipr::String> txt;
    };
 
    struct Structured_binding : impl::Directive<ipr::Structured_binding, Phases::Elaboration> {
@@ -2049,6 +2038,16 @@ namespace ipr::impl {
       const ipr::Scope& nominated_scope() const final { return scope; }
    private:
       const ipr::Scope& scope;
+   };
+
+   // -- impl::Phased_evaluation
+   struct Phased_evaluation : impl::Node<ipr::Phased_evaluation> {
+      Phased_evaluation(const ipr::Expr& x, Phases f) : expr{x}, ph{f} { }
+      Phases phases() const final { return ph; }
+      const ipr::Expr& expression() const final { return expr; }
+   private:
+      const ipr::Expr& expr;
+      Phases ph;
    };
 
    struct Pragma : impl::Directive<ipr::Pragma, Phases::All> {
@@ -2209,6 +2208,12 @@ namespace ipr::impl {
       const ipr::Scope& second() const final { return region.bindings(); }
    };
 
+   // -- impl::Static_assert
+   struct Static_assert : impl::Binary_node<ipr::Static_assert> {
+      Static_assert(const ipr::Expr&, Optional<ipr::String>);
+      const ipr::Type& type() const final;
+   };
+
    struct name_factory {
       const ipr::String& get_string(util::word_view);
       const ipr::Identifier& get_identifier(const ipr::String&);
@@ -2254,7 +2259,6 @@ namespace ipr::impl {
       // Returns an IPR node for a typed literal expression.
       Literal* make_literal(const ipr::Type&, const ipr::String&);
       Literal* make_literal(const ipr::Type&, util::word_view);
-
 
       Address* make_address(const ipr::Expr&, Optional<ipr::Type> = {});
       Array_delete* make_array_delete(const ipr::Expr&);
@@ -2349,6 +2353,12 @@ namespace ipr::impl {
 
       Elementary_substitution* make_elementary_substitution(const ipr::Parameter&, const ipr::Expr&);
       General_substitution* make_general_substitution();
+
+   protected:
+      // Note: These factory functions are not to be called directly.  See impl::Lexicon for their equivalent.
+      impl::Asm* make_asm_expr(const ipr::String&);
+      impl::Static_assert* make_static_assert_expr(const ipr::Expr&, Optional<ipr::String> = { });
+
    private:
       // Language linkage nodes.
       util::rb_tree::container<impl::Linkage> linkages;
@@ -2366,6 +2376,7 @@ namespace ipr::impl {
       stable_farm<impl::Address> addresses;
       stable_farm<impl::Annotation> annotations;
       stable_farm<impl::Array_delete> array_deletes;
+      stable_farm<impl::Asm> asms;
       stable_farm<impl::Complement> complements;
       stable_farm<impl::Delete> deletes;
       stable_farm<impl::Demotion> demotions;
@@ -2441,6 +2452,7 @@ namespace ipr::impl {
       stable_farm<impl::Binary_fold> folds;
       stable_farm<impl::Where_no_decl> where_nodecls;
       stable_farm<impl::Where> wheres;
+      stable_farm<impl::Static_assert> asserts;
       stable_farm<impl::Instantiation> insts;
 
       stable_farm<impl::New> news;
@@ -2454,23 +2466,21 @@ namespace ipr::impl {
    };
 
    struct dir_factory {
-      impl::Asm* make_asm(const ipr::String&, const ipr::Type&);
       impl::Specifiers_spread* make_specifiers_spread();
-      impl::Static_assert* make_static_assert(const ipr::Expr&, Optional<ipr::String> = { });
       impl::Structured_binding* make_structured_binding();
       impl::single_using_declaration* make_using_declaration(const ipr::Scope_ref&,
                                                                ipr::Using_declaration::Designator::Mode);
       impl::Using_declaration* make_using_declaration();
       impl::Using_directive* make_using_directive(const ipr::Scope&, const ipr::Type&);
+      impl::Phased_evaluation* make_phased_evaluation(const ipr::Expr&, Phases);
       impl::Pragma* make_pragma();
    private:
-      stable_farm<impl::Asm> asms;
       stable_farm<impl::Specifiers_spread> spreads;
-      stable_farm<impl::Static_assert> asserts;
       stable_farm<impl::Structured_binding> bindings;
       stable_farm<impl::single_using_declaration> singles;
       stable_farm<impl::Using_declaration> usings;
       stable_farm<impl::Using_directive> dirs;
+      stable_farm<impl::Phased_evaluation> phaseds;
       stable_farm<impl::Pragma> pragmas;
    };
 
@@ -2566,6 +2576,9 @@ namespace ipr::impl {
       const ipr::Symbol& nullptr_value() const final;
       const ipr::Symbol& default_value() const final;
       const ipr::Symbol& delete_value() const final;
+
+      impl::Phased_evaluation* make_asm(const ipr::String&);
+      impl::Phased_evaluation* make_static_assert(const ipr::Expr&, Optional<ipr::String>);
 
       impl::Mapping* make_mapping(const ipr::Region&, Mapping_level = { });
 

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -863,6 +863,15 @@ namespace ipr {
       const Expr& storage() const { return operand(); }
    };
 
+                                // -- Asm --
+   // An ISO C++ asm-declaration, an expression in IPR.
+   // When evaluated, this expression produces executable instructions or 
+   // affects linking behavior. Its type is `void`.
+   // Note: A node of this type is typically an operand of `Phased_evaluation`.
+   struct Asm : Unary<Category<Category_code::Asm>, const String&> {
+      const String& text() const { return operand(); }
+   };
+
                                 // -- Complement --
    // Complement-expression -- "~expr"
    struct Complement : Unary<Category<Category_code::Complement, Classic>> { };
@@ -1323,6 +1332,16 @@ namespace ipr {
       const Type& type() const final { return main().type(); }
    };
 
+                                // -- Static_assert --
+   // A static assertion: failure of the `condition()` halts the elaboration phase.
+   // No runtime code is ever generated.  Its type is `bool`.
+   // Note: A node of this type is typically an operand of `Phased_evaluation`.
+   struct Static_assert : Binary<Category<Category_code::Static_assert>,
+                                 const Expr&, Optional<String>> {
+      const Expr& condition() const { return first(); }
+      virtual Optional<String> message() const { return second(); }
+   };
+
                                 // -- Substitution --
    // A "Substitution" is a mapping of a parameter to an expression (its value). 
    struct Substitution {
@@ -1405,13 +1424,16 @@ namespace ipr {
       constexpr Directive(Category_code c) : Expr{ c } { }
    };
 
-                                // -- Asm --
-   // An asm-declaration, a directive in IPR.
-   // This directive affects only code generation, where it might inject
-   // executable instructions or affect the linker behavior.
-   // Its type should be set to "void".
-   struct Asm : Category<Category_code::Asm, Directive> {
-      virtual const String& text() const = 0;
+
+                                // -- Directive --
+   // Certain expressions are evaluated at designated phased of translation of a C++ program.
+   // For example, static_assert-declaration (a declaration in ISO C++, but an expression
+   // in IPR) is evaluated at compile-time.  On the other hand, an asm-declaration (again a
+   // declaration in ISO C++, but an expression in the IPR) is generally evaluated at 
+   // code-generation time.
+   struct Phased_evaluation : Category<Category_code::Phased_evaluation, Directive> {
+      const Type& type() const final { return expression().type(); }
+      virtual const Expr& expression() const = 0;
    };
 
                                 // -- Specifiers_spread --
@@ -1422,15 +1444,6 @@ namespace ipr {
    struct Specifiers_spread : Category<Category_code::Specifiers_spread, Directive> {
       virtual DeclSpecifiers specifiers() const = 0;
       virtual const Sequence<cxx_form::Proclamator>& targets() const = 0;
-   };
-
-                                // -- Static_assert --
-   // A static assertion: a directive that halts the elaboration phase.
-   // No runtime code is ever generated.
-   // Its type should be set to "bool". 
-   struct Static_assert : Category<Category_code::Static_assert, Directive> {
-      virtual const Expr& condition() const = 0;
-      virtual Optional<String> message() const = 0;
    };
 
                                 // -- Structured_binding --
@@ -1954,6 +1967,7 @@ namespace ipr {
       virtual void visit(const Symbol&);
       virtual void visit(const Address&);
       virtual void visit(const Array_delete&);
+      virtual void visit(const Asm&);
       virtual void visit(const Complement&);
       virtual void visit(const Delete&);
       virtual void visit(const Demotion&);
@@ -2033,6 +2047,7 @@ namespace ipr {
       virtual void visit(const Widen&);
       virtual void visit(const Binary_fold&);
       virtual void visit(const Where&);
+      virtual void visit(const Static_assert&);
       virtual void visit(const Instantiation&);
 
       virtual void visit(const Conditional&);
@@ -2040,12 +2055,11 @@ namespace ipr {
       virtual void visit(const Mapping&);
 
       virtual void visit(const Directive&) = 0;
-      virtual void visit(const Asm&);
       virtual void visit(const Specifiers_spread&);
-      virtual void visit(const Static_assert&);
       virtual void visit(const Structured_binding&);
       virtual void visit(const Using_declaration&);
       virtual void visit(const Using_directive&);
+      virtual void visit(const Phased_evaluation&);
       virtual void visit(const Pragma&);
 
       virtual void visit(const Stmt&) = 0;

--- a/include/ipr/node-category
+++ b/include/ipr/node-category
@@ -57,6 +57,7 @@ Lambda,                             // ipr::Lambda
 Symbol,                             // ipr::Symbol
 Address,                            // ipr::Address
 Array_delete,                       // ipr::Array_delete
+Asm,                                // ipr::Asm
 Complement,                         // ipr::Complement
 Delete,                             // ipr::Delete
 Demotion,                           // ipr::Demotion
@@ -137,19 +138,19 @@ Minus,                              // ipr::Minus
 Minus_assign,                       // ipr::Minus_assign
 Binary_fold,                        // ipr::Binary_fold
 Where,                              // ipr::Where
+Static_assert,                      // ipr::Static_assert
 Instantiation,                      // ipr::Instantiation
 
 New,                                // ipr::New
 Conditional,                        // ipr::Conditional
 Scope,                              // ipr::Scope
 
-Asm,                                // ipr::Asm
 Deduction_guide,                    // ipr::Deduction_guide
 Specifiers_spread,                  // ipr::Specifiers_spread
-Static_assert,                      // ipr::Static_assert
 Structured_binding,                 // ipr::Structured_binding
 Using_declaration,                  // ipr::Using_declaration
 Using_directive,                    // ipr::Using_directive
+Phased_evaluation,                  // ipr::Phased_evaluation
 Pragma,                             // ipr::Pragma
 
 Block,                              // ipr::Block

--- a/include/ipr/synopsis
+++ b/include/ipr/synopsis
@@ -82,6 +82,7 @@ namespace ipr {
    struct Symbol;                // self-evaluating symbolic values: 'int' or 'nullptr'
    struct Address;               // address-of                          &a
    struct Array_delete;          // array delete-expression     delete[] p
+   struct Asm;                   // asm-declaration
    struct Complement;            // bitwise complement                  ~m
    struct Delete;                // delete-expression             delete p
    struct Demotion;              // inverse of an integral or floating-point
@@ -169,6 +170,7 @@ namespace ipr {
    struct Mapping;               // function
    struct Rewrite;               // Semantics by translation -- unwise, but the committee can't help it
    struct Where;                 // expression with local bindings or restrictions
+   struct Static_assert;         // static-assert declaration
    struct Instantiation;         // Substitution into a parameterized expression
 
    // --------------------------------------------------------
@@ -200,13 +202,12 @@ namespace ipr {
    // -----------------------------------------------
    // -- result of directive constructor constants --
    // -----------------------------------------------
-   struct Asm;                   // asm-declaration
    struct Deduction_guide;       // deduction-guide declaration
    struct Specifiers_spread;     // spread of decls-sequence-seq over a sequence of declarators
-   struct Static_assert;         // static-assert declaration
    struct Structured_binding;    // structured-binding declaration
    struct Using_declaration;     // using-declaration
    struct Using_directive;       // using-directive
+   struct Phased_evaluation;     // evaluation at designated phases of translation
    struct Pragma;                // language-level pragma directive
  
    // -------------------------------------------------

--- a/src/traversal.cxx
+++ b/src/traversal.cxx
@@ -316,6 +316,11 @@ ipr::Visitor::visit(const Array_delete& e)
    visit(as<Classic>(e));
 }
 
+void ipr::Visitor::visit(const Asm& e)
+{
+   visit(as<Expr>(e));
+}
+
 void
 ipr::Visitor::visit(const Complement& e)
 {
@@ -774,6 +779,12 @@ void ipr::Visitor::visit(const Where& e)
    visit(as<Expr>(e));
 }
 
+void
+ipr::Visitor::visit(const Static_assert& e)
+{
+   visit(as<Expr>(e));
+}
+
 void ipr::Visitor::visit(const Instantiation& e)
 {
    visit(as<Expr>(e));
@@ -799,19 +810,7 @@ ipr::Visitor::visit(const Mapping& s)
 
 // -- Directives visiting hooks --
 
-void
-ipr::Visitor::visit(const Asm& d)
-{
-   visit(as<Directive>(d));
-}
-
 void ipr::Visitor::visit(const Specifiers_spread& d)
-{
-   visit(as<Directive>(d));
-}
-
-void
-ipr::Visitor::visit(const Static_assert& d)
 {
    visit(as<Directive>(d));
 }
@@ -828,6 +827,11 @@ void ipr::Visitor::visit(const Using_declaration& d)
 
 void
 ipr::Visitor::visit(const Using_directive& d)
+{
+   visit(as<Directive>(d));
+}
+
+void ipr::Visitor::visit(const Phased_evaluation& d)
 {
    visit(as<Directive>(d));
 }

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -7,6 +7,7 @@ add_executable(${TEST_BINARY}
    words.cxx
    region-owner.cxx
    warehouse.cxx
+   phased-eval.cxx
 )
 
 target_link_libraries(${TEST_BINARY}

--- a/tests/unit-tests/phased-eval.cxx
+++ b/tests/unit-tests/phased-eval.cxx
@@ -1,0 +1,22 @@
+#include "doctest/doctest.h"
+
+#include <ipr/impl>
+
+using namespace ipr;
+
+TEST_CASE("asm-declaration")
+{
+    impl::Lexicon lexicon { };
+
+    auto& s = lexicon.get_string("yo!");
+    auto insn = lexicon.make_asm(s);
+    CHECK(physically_same(insn->type(), lexicon.void_type()));
+}
+
+TEST_CASE("static_assert-declaration")
+{
+    impl::Lexicon lexicon { };
+    auto cond = lexicon.make_not(lexicon.false_value(), lexicon.bool_type());
+    auto assert = lexicon.make_static_assert(*cond, lexicon.get_string("wait! what?"));
+    CHECK(physically_same(assert->type(), lexicon.bool_type()));
+}


### PR DESCRIPTION
Both _asm-declaration_ and _static\_assert-declaration_ are now uniformly represented as phased evaluation of the generalized expressions `ipr::Asm` and `ipr::Static_assert`.

This unified description comes at the cost of an indirection going from a `Directive` to an `Expr`.  However, it allows for other type expressions (e.g. parameterized _prolongation_ s) to be described in the same scheme.  Furthermore, an `if constexpr` and an `if consteval` are now just phased evaluation of ordinary _if-statement_.  Similarly, static initialization can also be described as a phased evaluation.