### PR TITLE
Refactor `Mapping` [1/n]

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -1517,12 +1517,9 @@ namespace ipr::impl {
 
    struct Mapping : impl::Expr<ipr::Mapping> {
       impl::Parameter_list inputs;
-      util::ref<const ipr::Type> value_type;
       util::ref<const ipr::Expr> body;
-
       Mapping(const ipr::Region&, Mapping_level);
       const ipr::Parameter_list& parameters() const final { return inputs; }
-      const ipr::Type& target() const final { return value_type.get(); }
       const ipr::Expr& result() const final { return body.get(); }
       impl::Parameter* param(const ipr::Name& n, const ipr::Type& t)
       {

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -1218,7 +1218,6 @@ namespace ipr {
    // and Forall otherwise.
    struct Mapping : Category<Category_code::Mapping> {
       virtual const Parameter_list& parameters() const = 0;
-      virtual const Type& target() const = 0;
       virtual const Expr& result() const = 0;
    };
 

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -1196,12 +1196,9 @@ namespace ipr::impl {
          return *this;
       }
 
-      // -------------------
-      // -- impl::Mapping --
-      // -------------------
-
+      // -- impl::Mapping
       Mapping::Mapping(const ipr::Region& pr, Mapping_level d)
-            : inputs{pr, d}, value_type{}, body{}
+            : inputs{pr, d}, body{}
       {
          inputs.parms.owned_by = this;
       }


### PR DESCRIPTION
This patch is the first in a series to refactor the interface and implementation of `Mapping`.

This PR removes `ipr::Mapping::target()` and its implementation.
A mapping should just be an expression that maps a set of inputs to an output.  The type of the output should be set and retrieved from the entity for which a `Mapping` is used as initializer, thereby reducing redundancy.

This patch is potentially a source breaching change for users that set and retrieve `target()`.