### PR TITLE
Refactor `Mapping` [2/n]

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -744,6 +744,16 @@ namespace ipr::impl {
    private:
       const Mapping_level nesting;
    };
+
+   // -- impl::Parameterization
+   template<typename T, typename Base>
+   struct Parameterization : Base {
+      impl::Parameter_list inputs;
+      util::ref<const T> body;
+      Parameterization(const ipr::Region& r, Mapping_level l) : inputs{r, l} { }
+      const ipr::Parameter_list& parameters() const final { return inputs; }
+      const T& result() const final { return body.get(); }
+   };
 }
 
 namespace ipr::cxx_form::impl {
@@ -1398,11 +1408,9 @@ namespace ipr::impl {
       { typing = t; }
    };
 
-   struct Lambda : impl::Node<ipr::Lambda> {
+   struct Lambda : impl::Parameterization<ipr::Expr, impl::Node<ipr::Lambda>> {
       util::ref<const ipr::Closure> typing;
       Optional<ipr::Type> value_type;
-      impl::Parameter_list parms;
-      util::ref<const ipr::Expr> body;
       Optional<ipr::Expr> decl_constraint;
       impl::ref_sequence<ipr::Attribute> attrs;
       impl::ref_sequence<ipr::Capture_specification> env_spec;
@@ -1412,9 +1420,7 @@ namespace ipr::impl {
       Lambda(const ipr::Region&, Mapping_level);
       const ipr::Closure& type() const final { return typing.get(); }
       Optional<ipr::Type> target() const final { return value_type; }
-      const ipr::Parameter_list& parameters() const final { return parms; }
       Optional<ipr::Expr> requirement() const final { return decl_constraint; }
-      const ipr::Expr& result() const final { return body.get(); }
       const ipr::Sequence<ipr::Attribute>& attributes() const final { return attrs; }
       Optional<ipr::Expr> eh_specification() const final { return eh; }
       Lambda_specifiers specifiers() const final { return lam_spec; }
@@ -1515,12 +1521,8 @@ namespace ipr::impl {
    using Lshift = Classic_binary_expr<ipr::Lshift>;
    using Lshift_assign = Classic_binary_expr<ipr::Lshift_assign>;
 
-   struct Mapping : impl::Expr<ipr::Mapping> {
-      impl::Parameter_list inputs;
-      util::ref<const ipr::Expr> body;
+   struct Mapping : impl::Parameterization<ipr::Expr, impl::Expr<ipr::Mapping>> {
       Mapping(const ipr::Region&, Mapping_level);
-      const ipr::Parameter_list& parameters() const final { return inputs; }
-      const ipr::Expr& result() const final { return body.get(); }
       impl::Parameter* param(const ipr::Name& n, const ipr::Type& t)
       {
           return inputs.add_member(n, t);

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -94,6 +94,13 @@ namespace ipr {
    // Position of a declaration in its declarative region
    enum class Decl_position : std::size_t { };
 
+   // A parameterization is an abstraction over an entity, charted by a collection of parameters.
+   template<typename T>
+   struct Parameterization {
+      virtual const Parameter_list& parameters() const = 0;
+      virtual const T& result() const = 0;
+   };
+
                                 // -- Unary<> --
    // A unary-expression is a specification of an operation that takes
    // only one operand, an expression.  By extension, a unary-node is a
@@ -785,12 +792,10 @@ namespace ipr {
    };
 
                                 // -- Lambda --
-   struct Lambda : Category<Category_code::Lambda> {
+   struct Lambda : Category<Category_code::Lambda>, Parameterization<Expr> {
       virtual const Closure& type() const override = 0;           // a lambda is of a (unique) closure type
       virtual Optional<Type> target() const = 0;                  // return type, optionally specified at source level
-      virtual const Parameter_list& parameters() const = 0;
       virtual Optional<Expr> requirement() const = 0;             // declaration constraint possibly involving parameters
-      virtual const Expr& result() const = 0;                     // body of the lambda
       virtual const Sequence<Attribute>& attributes() const = 0;  // optional attribute-list applying to the lambda
       virtual Optional<Expr> eh_specification() const = 0;
       virtual Lambda_specifiers specifiers() const = 0;
@@ -1216,9 +1221,7 @@ namespace ipr {
    // This node represents a parameterized expression.
    // Its type is a Function in case of parameterized classic expression,
    // and Forall otherwise.
-   struct Mapping : Category<Category_code::Mapping> {
-      virtual const Parameter_list& parameters() const = 0;
-      virtual const Expr& result() const = 0;
+   struct Mapping : Category<Category_code::Mapping>, Parameterization<Expr> {
    };
 
                                 // -- Member_init --

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -1198,15 +1198,16 @@ namespace ipr::impl {
 
       // -- impl::Mapping
       Mapping::Mapping(const ipr::Region& pr, Mapping_level d)
-            : inputs{pr, d}, body{}
+            : impl::Parameterization<ipr::Expr, impl::Expr<ipr::Mapping>>{pr, d}
       {
          inputs.parms.owned_by = this;
       }
 
       // -- impl::Lambda
-      Lambda::Lambda(const ipr::Region& r, Mapping_level l) : parms{r, l}, lam_spec{}
+      Lambda::Lambda(const ipr::Region& r, Mapping_level l)
+         : impl::Parameterization<ipr::Expr, impl::Node<ipr::Lambda>>{r, l}, lam_spec{}
       {
-         parms.parms.owned_by = this;
+         inputs.parms.owned_by = this;
       }
 
       // -------------------------------


### PR DESCRIPTION
Capture structural commonality of parameterized entities once in the form of `Parameterization`.  Remove boilerplate.