### PR TITLE
Default visit of `Annotation`

### DIFF
--- a/src/traversal.cxx
+++ b/src/traversal.cxx
@@ -51,8 +51,10 @@ ipr::Missing_overrider::operator()(const ipr::Node& n) const
 }
 
 // -- ipr::Visitor --
-void
-ipr::Visitor::visit(const Annotation&) { }
+void ipr::Visitor::visit(const Annotation& a)
+{
+   visit(as<Node>(a));
+}
 
 void
 ipr::Visitor::visit(const Region& r)


### PR DESCRIPTION
As an `ipr::Node`.
Spotted by @jimspr