### PR TITLE
`<ipr/synopsis>` should have no dependency

### DIFF
--- a/include/ipr/synopsis
+++ b/include/ipr/synopsis
@@ -8,8 +8,6 @@
 #ifndef IPR_SYNOPSIS_INCLUDED
 #define IPR_SYNOPSIS_INCLUDED
 
-#include <ipr/ancillary>
-
 namespace ipr {
    struct Node;                  // universal base class for all IPR nodes
 


### PR DESCRIPTION
It is just a set of forward declarations of classes with brief commentary.