### PR TITLE
Use `Unary` and `Binary` for `Attribute`

### DIFF
--- a/include/ipr/ancillary
+++ b/include/ipr/ancillary
@@ -10,6 +10,7 @@
 
 #include <cstdint>
 #include <ipr/utility>
+#include <ipr/synopsis>
 
 namespace ipr {
    // ---------------------------
@@ -99,6 +100,58 @@ namespace ipr {
       Brace,                     // "{}"
       Bracket,                   // "[]"
       Angle,                     // "<>"
+   };
+
+                                // -- Unary<> --
+   // A unary-expression is a specification of an operation that takes
+   // only one operand, an expression.  By extension, a unary-node is a
+   // node category that is essentially determined only by one node,
+   // its "operand".  Usually, such an operand node is a classic expression.
+   // Occasionally, it can be a type (e.g. sizeof (T)), we don't want to
+   // loose that information, therefore we add a template-parameter
+   // (the second) to indicate the precise type of the operand.  The first
+   // template-parameter designates the actual node subcategory this class
+   // provides an interface for.
+   template<class Cat, class Operand = const Expr&>
+   struct Unary : Cat {
+      using Arg_type = Operand;
+      virtual Operand operand() const = 0;
+   };
+
+                                // -- Binary<> --
+   // In full generality, a binary-expression is an expression that
+   // consists in (a) an operator, and (b) two operands.  In Standard
+   // C++, the two operands often are of the same type (and if they are not,
+   // they are implicitly converted).  In IPR, they need not be
+   // of the same type.  This generality allows representations of
+   // cast-expressions which are conceptually binary-expressions -- they
+   // take a type and an expression.  Also, a function call is
+   // conceptually a binary-expression that applies a function to
+   // a list of arguments.  By extension, a binary node is any node that
+   // is essentially dermined by two nodes, its "operands".
+   // As for Unary<> nodes, we indicate the operands' type information
+   // through the template-parameters First and Second.
+   template<class Cat, class First = const Expr&, class Second = const Expr&>
+   struct Binary : Cat {
+      using Arg1_type = First;
+      using Arg2_type = Second;
+      virtual First first() const = 0;
+      virtual Second second() const = 0;
+   };
+
+                                // -- Ternary<> --
+   // Similar to Unary<> and Binary<> categories.  This is for
+   // ternary-expressions, or more generally for ternary nodes.
+   // An example of a ternary node is a Conditional node.
+   template<class Cat, class First = const Expr&,
+            class Second = const Expr&, class Third = const Expr&>
+   struct Ternary : Cat {
+      using Arg1_type = First;
+      using Arg2_type = Second;
+      using Arg3_type = Third;
+      virtual First first() const = 0;
+      virtual Second second() const = 0;
+      virtual Third third() const = 0;
    };
 
                                 // -- Sequence<> --

--- a/include/ipr/attribute
+++ b/include/ipr/attribute
@@ -46,45 +46,47 @@ namespace ipr {
    };
 
    // A simple token used as attribute.
-   struct BasicAttribute : Attribute {
-      virtual const Token& token() const = 0;
+   struct BasicAttribute : Unary<Attribute, const Token&> {
+      const Token& token() const { return operand(); }
    };
 
    // An attribute of the form `token1 :: token2'
-   struct ScopedAttribute : Attribute {
-      virtual const Token& scope() const = 0;
-      virtual const Token& member() const = 0;
+   struct ScopedAttribute : Binary<Attribute, const Token&, const Token&> {
+      const Token& scope() const { return first(); }
+      const Token& member() const { return second(); }
    };
 
    // An attribute of the form `token : attribute'.
-   struct LabeledAttribute : Attribute {
-      virtual const Token& label() const = 0;
-      virtual const Attribute& attribute() const = 0;
+   struct LabeledAttribute : Binary<Attribute, const Token&, const Attribute&> {
+      const Token& label() const { return first(); }
+      const Attribute& attribute() const { return second(); }
    };
 
    // An attribute of the form `f(args)'.
-   struct CalledAttribute : Attribute {
-      virtual const Attribute& function() const = 0;
-      virtual const Sequence<Attribute>& arguments() const = 0;
+   struct CalledAttribute : Binary<Attribute, const Attribute&,
+                                   const Sequence<Attribute>&> {
+      const Attribute& function() const { return first(); }
+      const Sequence<Attribute>& arguments() const { return second(); }
    };
 
    // An attribute of the form `attribute...'
-   struct ExpandedAttribute : Attribute {
-      virtual const Token& expander() const = 0;
-      virtual const Attribute& operand() const = 0;
+   struct ExpandedAttribute : Binary<Attribute, const Token&, const Attribute&> {
+      const Token& expander() const { return first(); }
+      const Attribute& operand() const { return second(); }
    };
 
    // An attribute of the form `[[using check: memory(3), type(2)]]'
-   struct FactoredAttribute : Attribute {
-      virtual const Token& factor() const = 0;
-      virtual const Sequence<Attribute>& terms() const = 0;
+   struct FactoredAttribute : Binary<Attribute, const Token&,
+                                     const Sequence<Attribute>&> {
+      const Token& factor() const { return first(); }
+      const Sequence<Attribute>& terms() const { return second(); }
    };
 
    // An attribute of the form `[[ expr ]]', where `expr' is the elaboration result
    // of parsing and semantics analysis of the enclosed token sequence.  This is a 
    // common non-standard form of attribute.
-   struct ElaboratedAttribute : Attribute {
-      virtual const Expr& elaboration() const = 0;
+   struct ElaboratedAttribute : Unary<Attribute, const Expr&> {
+      const Expr& elaboration() const { return operand(); }
    };
 
    struct Attribute::Visitor {

--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -869,71 +869,31 @@ namespace ipr::impl {
       void accept(typename T::Visitor& v) const final { v.visit(*this); }
    };
 
+   template<typename T>
+   using Unary_attribute = impl::Unary<impl::Attribute<T>>;
+   template<typename T>
+   using Binary_attribute = impl::Binary<impl::Attribute<T>>;
+
    // -- implementation of ipr::BasicAttribute
-   struct BasicAttribute : impl::Attribute<ipr::BasicAttribute> {
-      explicit BasicAttribute(const ipr::Token& t) : tok{ t } { }
-      const ipr::Token& token() const final { return tok; }
-   private:
-      const ipr::Token& tok;
-   };
+   using BasicAttribute = Unary_attribute<ipr::BasicAttribute>;
 
    // -- implementation of ipr::ScopedAttribute
-   struct ScopedAttribute : impl::Attribute<ipr::ScopedAttribute> {
-      ScopedAttribute(const ipr::Token& s, const ipr::Token& m) : first{ s }, second{ m } { }
-      const ipr::Token& scope() const final { return first; }
-      const ipr::Token& member() const final { return second; }
-   private:
-      const ipr::Token& first;
-      const ipr::Token& second;
-   };
+   using ScopedAttribute = Binary_attribute<ipr::ScopedAttribute>;
 
    // -- implementation of ipr::LabeledAttribute
-   struct LabeledAttribute : impl::Attribute<ipr::LabeledAttribute> {
-      LabeledAttribute(const ipr::Token& l, const ipr::Attribute& a) : lbl{ l }, attr{ a } { }
-      const ipr::Token& label() const final { return lbl; }
-      const ipr::Attribute& attribute() const final { return attr; }
-   private:
-      const ipr::Token& lbl;
-      const ipr::Attribute& attr;
-   };
+   using LabeledAttribute = Binary_attribute<ipr::LabeledAttribute>;
 
    // -- implementation of ipr::CalledAttribute
-   struct CalledAttribute : impl::Attribute<ipr::CalledAttribute> {
-      CalledAttribute(const ipr::Attribute& f, const ipr::Sequence<ipr::Attribute>& s) : fun{ f }, args{ s } { }
-      const ipr::Attribute& function() const final { return fun; }
-      const ipr::Sequence<ipr::Attribute>& arguments() const final { return args; }
-   private:
-      const ipr::Attribute& fun;
-      const ipr::Sequence<ipr::Attribute>& args;
-   };
+   using CalledAttribute = Binary_attribute<ipr::CalledAttribute>;
 
    // -- implementation of ipr::ExpandedAttribute
-   struct ExpandedAttribute : impl::Attribute<ipr::ExpandedAttribute> {
-      ExpandedAttribute(const ipr::Token& t, const ipr::Attribute& a) : tok{ t }, attr{ a } { }
-      const ipr::Token& expander() const final { return tok; }
-      const ipr::Attribute& operand() const final { return attr; }
-   private:
-      const ipr::Token& tok;
-      const ipr::Attribute& attr;
-   };
+   using ExpandedAttribute = Binary_attribute<ipr::ExpandedAttribute>;
 
    // -- implementation of ipr::FactoredAttribute
-   struct FactoredAttribute : impl::Attribute<ipr::FactoredAttribute> {
-      FactoredAttribute(const ipr::Token& t, const ipr::Sequence<ipr::Attribute>& s) : tok{ t }, seq{ s } { }
-      const ipr::Token& factor() const final { return tok; }
-      const ipr::Sequence<ipr::Attribute>& terms() const final { return seq; }
-   private:
-      const ipr::Token& tok;
-      const ipr::Sequence<ipr::Attribute>& seq;
-   };
+   using FactoredAttribute = Binary_attribute<ipr::FactoredAttribute>;
 
    // -- implementation of ipr::ElaboratedAttribute
-   struct ElaboratedAttribute : impl::Attribute<ipr::ElaboratedAttribute> {
-      explicit ElaboratedAttribute(const ipr::Expr& x) : expr{ x } { }
-      const ipr::Expr& elaboration() const final { return expr; }
-   private:
-      const ipr::Expr& expr;
-   };
+   using ElaboratedAttribute = Unary_attribute<ipr::ElaboratedAttribute>;
 
    // -- Attributes factory --
    struct attr_factory {

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -101,58 +101,6 @@ namespace ipr {
       virtual const T& result() const = 0;
    };
 
-                                // -- Unary<> --
-   // A unary-expression is a specification of an operation that takes
-   // only one operand, an expression.  By extension, a unary-node is a
-   // node category that is essentially determined only by one node,
-   // its "operand".  Usually, such an operand node is a classic expression.
-   // Occasionally, it can be a type (e.g. sizeof (T)), we don't want to
-   // loose that information, therefore we add a template-parameter
-   // (the second) to indicate the precise type of the operand.  The first
-   // template-parameter designates the actual node subcategory this class
-   // provides an interface for.
-   template<class Cat, class Operand = const Expr&>
-   struct Unary : Cat {
-      using Arg_type = Operand;
-      virtual Operand operand() const = 0;
-   };
-
-                                // -- Binary<> --
-   // In full generality, a binary-expression is an expression that
-   // consists in (a) an operator, and (b) two operands.  In Standard
-   // C++, the two operands often are of the same type (and if they are not,
-   // they are implicitly converted).  In IPR, they need not be
-   // of the same type.  This generality allows representations of
-   // cast-expressions which are conceptually binary-expressions -- they
-   // take a type and an expression.  Also, a function call is
-   // conceptually a binary-expression that applies a function to
-   // a list of arguments.  By extension, a binary node is any node that
-   // is essentially dermined by two nodes, its "operands".
-   // As for Unary<> nodes, we indicate the operands' type information
-   // through the template-parameters First and Second.
-   template<class Cat, class First = const Expr&, class Second = const Expr&>
-   struct Binary : Cat {
-      using Arg1_type = First;
-      using Arg2_type = Second;
-      virtual First first() const = 0;
-      virtual Second second() const = 0;
-   };
-
-                                // -- Ternary<> --
-   // Similar to Unary<> and Binary<> categories.  This is for
-   // ternary-expressions, or more generally for ternary nodes.
-   // An example of a ternary node is a Conditional node.
-   template<class Cat, class First = const Expr&,
-            class Second = const Expr&, class Third = const Expr&>
-   struct Ternary : Cat {
-      using Arg1_type = First;
-      using Arg2_type = Second;
-      using Arg3_type = Third;
-      virtual First first() const = 0;
-      virtual Second second() const = 0;
-      virtual Third third() const = 0;
-   };
-
                                 // -- DeclSpecifiers --
    enum class DeclSpecifiers : std::uint32_t {
       None       = 0,


### PR DESCRIPTION
@JimSpr observed that `ipr::Attribute` hierarchy wasn't using the structural templates `Unary` and `Binary`.  Fixed with this patch