### PR TITLE
Rework indirector form hierarchy

### DIFF
--- a/include/ipr/cxx-form
+++ b/include/ipr/cxx-form
@@ -40,37 +40,53 @@ namespace ipr::cxx_form {
 
     // Base class for objects representing ptr-operator (C++ grammar).
     // While the source-level grammar of ISO C++ does not allow attributes on
-    // reference-style ptr-operator, the representation make room for that possibility.
+    // reference-style ptr-operator, the representation adopted here makes room for that possibility.
     // Hence all `Indirector` objects have an `attributes()` operation.
     // At the input source level, `Indirector`s precede the name being declared in the declarator.
     struct Indirector {
-        enum class Mode {
-            Deref,                  // "*" as ptr-operator in a declarator
-            Bind,                   // "&" as ptr-operator in a declarator
-            Move                    // "&&" as ptr-operator in a declarator
-        };
-        struct Simple;
-        struct Member;
+        struct Pointer;             // pointer indirector
+        struct Reference;           // reference indirector
+        struct Member;              // non-static member indirector
         virtual const Sequence<Attribute>& attributes() const = 0;
         virtual void accept(Indirector_visitor&) const = 0;
     };
 
-    // A simple `Indirector` object is a ptr-operator that specifies a simple indirection:
-    //     pointer, lvalue reference, or an rvalue reference
-    struct Indirector::Simple : Indirector {
-        virtual Mode mode() const = 0;
+    // A `Pointer` indirector object is a simple possibly cv-qualified pointer indirection.
+    // And object of this type corresponds to the instance of the ptr-operator C++ grammar:
+    //      `*` attribute-specifier-seq_opt cv-qualifier-seq_opt
+    struct Indirector::Pointer : Indirector {
+        virtual Type_qualifiers qualifiers() const = 0;
+    };
+
+    // Syntactic indication of reference binding flavor.
+    enum class Reference_flavor {
+        Lvalue,                     // "&" ptr-operator in an indirector
+        Rvalue                      // "&&" ptr-operator in an indirector
+    };
+
+    // A `Reference` indirector object is a reference indirection.
+    // An object of this type corresponds to an instance of any of the following alternatives
+    // of the ptr-operator C++ grammar production:
+    //     `&` attribute-specifier-seq_opt
+    //     `&&` attribute-specifier-seq_opt
+    struct Indirector::Reference : Indirector {
+        virtual Reference_flavor flavor() const = 0;
     };
 
     // A member `Indirector` object represents a ptr-operator that specifies a pointer to member.
+    // An object of this type corresponds to an instance of the following alternative of the
+    // ptr-operator C++ grammar production:
+    //     nested-named-specifier `*` attribute-specifier-seq_opt cv-qualifier-seq_opt
     struct Indirector::Member : Indirector {
-        virtual const Scope_ref& scope() const = 0;
+        virtual const Expr& scope() const = 0;
         virtual Type_qualifiers qualifiers() const = 0;
     };
 
     // Traversal of Indirector objects is facilitated by visitor classes deriving
     // from this interface.
     struct Indirector_visitor {
-        virtual void visit(const Indirector::Simple&) = 0;
+        virtual void visit(const Indirector::Pointer&) = 0;
+        virtual void visit(const Indirector::Reference&) = 0;
         virtual void visit(const Indirector::Member&) = 0;
     };
 

--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -774,9 +774,9 @@ namespace ipr::cxx_form::impl {
    };
 
    struct Member_indirector : impl::Indirector<cxx_form::Indirector::Member> {
-      util::ref<const ipr::Scope_ref> whole;
+      util::ref<const ipr::Expr> whole;
       ipr::Type_qualifiers cv_quals { };
-      const ipr::Scope_ref& scope() const final { return whole.get(); }
+      const ipr::Expr& scope() const final { return whole.get(); }
       ipr::Type_qualifiers qualifiers() const final { return cv_quals; }
    };
 

--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -763,9 +763,14 @@ namespace ipr::cxx_form::impl {
       void accept(Indirector_visitor& v) const final { v.visit(static_cast<const T&>(*this)); }
    };
 
-   struct Simple_indirector : impl::Indirector<cxx_form::Indirector::Simple> {
-      Mode indirection { };
-      Mode mode() const final { return indirection; }
+   struct Pointer_indirector : impl::Indirector<cxx_form::Indirector::Pointer> {
+      ipr::Type_qualifiers cv_quals { };
+      ipr::Type_qualifiers qualifiers() const final { return cv_quals; }
+   };
+
+   struct Reference_indirector : impl::Indirector<cxx_form::Indirector::Reference> {
+      Reference_flavor how { };
+      Reference_flavor flavor() const final { return how; }
    };
 
    struct Member_indirector : impl::Indirector<cxx_form::Indirector::Member> {
@@ -812,14 +817,16 @@ namespace ipr::cxx_form::impl {
    };
 
    struct form_factory {
-      Simple_indirector* make_simple_indirector();
+      Pointer_indirector* make_pointer_indirector();
+      Reference_indirector* make_reference_indirector();
       Member_indirector* make_member_indirector();
       Id_species* make_id_species();
       Callable_species* make_callable_species(const ipr::Region& parent, Mapping_level level);
       Array_species* make_array_species();
       Parenthesized_species* make_parenthesized_species();
    private:
-      ipr::impl::stable_farm<Simple_indirector> simple_indirectors;
+      ipr::impl::stable_farm<Pointer_indirector> pointer_indirectors;
+      ipr::impl::stable_farm<Reference_indirector> reference_indirectors;
       ipr::impl::stable_farm<Member_indirector> member_indirectors;
       ipr::impl::stable_farm<Id_species> id_species;
       ipr::impl::stable_farm<Callable_species> callable_species;

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -197,9 +197,14 @@ namespace ipr::cxx_form::impl {
       : inputs{ parent, level }
    { }
 
-   Simple_indirector* form_factory::make_simple_indirector()
+   Pointer_indirector* form_factory::make_pointer_indirector()
    {
-      return simple_indirectors.make();
+      return pointer_indirectors.make();
+   }
+
+   Reference_indirector* form_factory::make_reference_indirector()
+   {
+      return reference_indirectors.make();
    }
 
    Member_indirector* form_factory::make_member_indirector()


### PR DESCRIPTION
Split the class `cxx_form::Indirector::Simple` into two:
   - `cxx_form::Indirector::Pointer`, and
   - `cxx_form::Indirector::Reference`.

Adjust the return type of `cxx_form::Indirector::Member::whole()` to `Expr`.

This is a source breaking change.