### PR TITLE
Rework of declarator species

### DIFF
--- a/include/ipr/cxx-form
+++ b/include/ipr/cxx-form
@@ -30,11 +30,14 @@ namespace ipr::cxx_form {
     // -- an optional component representing the initializer.  The decl-specifier-seq
     // -- is a soup made of decl-specifier such as `static`, `extern`, etc. and simple-type
     // -- names such as `int`, and type qualifiers.  Compound types are made with
-    // -- type-constructors such as `*` (pointer) or `&` (reference), etc.  
+    // -- type-constructors such as `*` (pointer) or `&` (reference), `[N]` (array), etc.  
     // -- The type-constructors (which really imply some form of data indirection) are specified
     // -- along with the name being introduced, making up the declarator.
     // -- Pointer-style type-constructors are modeled by `Indirector`.
-    // -- Mapping-style type constructors (functions, arrays) are modeled by `Species_declarator`.
+    // -- Mapping-style type constructors (functions, arrays) are modeled by classes in
+    // -- `Morphism` hierarchy.
+    // -- Complete declarators that have mapping-style type contructors are modelled in the
+    // -- `Species_declarator` class hierarchy.
 
     struct Indirector_visitor;      // Base class of visitors for traversing `Indirector`s.
 
@@ -90,48 +93,82 @@ namespace ipr::cxx_form {
         virtual void visit(const Indirector::Member&) = 0;
     };
 
-    // A species declarator indicates the typical usage of a named being declared.
-    //   - Id: an id-expression
-    //   - Callable: a callable expression
-    //   - Array: a table expression
-    //   - Parenthesized: requires parenthesis to obey operator precedence rules
+    // -- Species and Morphisms
+    // A species declarator introduces a name along with typical usage of a named being declared.
+    // This usage pattern is captured by a suffix of `Morphism`s.  A `Morphism` is a form that
+    // specifies the type constuctor from the declared entity to the type of typical uses of that 
+    // entity in expressions.
+    //   - Function: a callable expression, the entity is typically called
+    //   - Array: a table expression, the entity is typically indexed
 
+    // -- Morphism and navigation
+    struct Morphism_visitor;
+
+    struct Morphism {
+        struct Function;                            // -- (T, int) & noexcept
+        struct Array;                               // -- [34][] [[S::A]]
+        virtual const Sequence<Attribute>& attributes() const = 0;
+        virtual void accept(Morphism_visitor&) const = 0;
+    };
+
+    struct Morphism_visitor {
+        virtual void visit(const Morphism::Function&) = 0;
+        virtual void visit(const Morphism::Array&) = 0;
+    };
+
+    // -- Species and navigation
     struct Species_visitor;
 
+    // A species declarator is either a name (possibly a pack), or a parenthesized term declarator, followed
+    // by a possibly empty sequence of morphisms.  For instance, in the declaration
+    //        bool (*pfs[8])(int)
+    // that declares pfs as an array of 8 pointers to functions taking an `int` returning a `bool`, the complete
+    // declarator `(*pfs[8])(int)` is a parenthesized species (`(*pfs[8])`) with the suffix consisting exactly of
+    // the singleton sequence of function morphism `(int)`.
+    // The term declarator `*pfs[8]` in turn has the indirectors is comprised of the single pointer indirector `*`,
+    // and of the id species `pfs` with array suffix `[8]`.
     struct Species_declarator {
-        struct Id;
-        struct Callable;
-        struct Array;
-        struct Parenthesized;
+        struct Id;                                  // possible packy id-expression -- a or X::m or ...f
+        struct Parenthesized;                       // parenthesized term declarator -- (*p)
+        virtual const Sequence<Morphism>& suffix() const = 0;
         virtual void accept(Species_visitor&) const = 0;
     };
 
+    // -- Declarator.
     // -- A declarator is either a term, or a species with a target type.
     // -- A term is a sequence of indirectors followed by a species.
     // -- A species indicates the typical usage syntactic structure of the named being declared.
 
     struct Declarator_visitor;
 
-    // Almost all ISO C++ declarators have an optional attribute-specifier-seq.
-    // The modeling here allows (trailing) attribute sequence on all declarators,
-    // given by the `attributes()` operation.
     struct Declarator {
-        struct Term;
-        struct Targeted;
-        virtual const Sequence<Attribute>& attributes() const = 0;
+        struct Term;                                // *p or (&a)[42]
+        struct Targeted;                            // *f(T& p) -> int
+        virtual const Species_declarator& species() const = 0;
         virtual void accept(Declarator_visitor&) const = 0;
     };
 
     // A term declarator is a sequence of `Indirector`s followed by a species declarator.
+    // An object of this type represents an instance of the first alternative of the C++ 
+    // grammar production for declarator:
+    //     ptr-declarator
+    // Examples:
+    //     (&a)[42]
+    //     *f(T) noexcept
     struct Declarator::Term : Declarator {
         virtual const Sequence<Indirector>& indirectors() const = 0;
-        virtual const Species_declarator& species() const = 0;
     };
 
     // A targeted declarator is a species declarator with a trailing return type,
     // given by the `target()` operation.
+    // An object of this type represents an instance of the second alternative of the C++
+    // grammar production for declarator:
+    //     noptr-declarator paramters-and-qualifiers trailing-return-type
+    // In particular, the `species()` of a targeted declarator has a function Morphism as 
+    // last element in its `suffix()`.  Furthermore, a targeted declarator lacks indirectors.
+    // Examples:
+    //    f(T a, U b) -> decltype(a + b)
     struct Declarator::Targeted : Declarator {
-        virtual const Species_declarator::Callable& species() const = 0;
         virtual const Type& target() const = 0;
     };
 
@@ -142,39 +179,48 @@ namespace ipr::cxx_form {
         virtual void visit(const Declarator::Targeted&) = 0;
     };
 
-    // An id-expression in the species declarator.  That name may be further subject to pack expansion
+    // An id-expression in the species declarator.  That name may be a pack, i.e. preceded by "...".
     struct Species_declarator::Id : Species_declarator {
         virtual const Expr& name() const = 0;
+        virtual const Sequence<Attribute>& attributes() const = 0;
     };
 
-    // A species declarator indicating something that can be called.  That something
-    // is described by the species in the `prefix()` sequence of species.
-    struct Species_declarator::Callable : Species_declarator {
-        virtual const Sequence<Species_declarator>& prefix() const = 0;
+    // A term declarator requiring parentheses to obey operator precedence rules, or just
+    // a redundant parentheses. An object of this type represents an instance of the fourth
+    // alternative of the C++ grammar for noptr-declarator:
+    //      `(` ptr-declarator `)`
+    // Example:
+    //      (a)
+    //      (*p)
+    struct Species_declarator::Parenthesized : Species_declarator {
+        virtual const Declarator::Term& term() const = 0;
+    };
+
+    // -- Function Morphism
+    // A morphism for a declarator indicating something that can be called.
+    // An object of this type captures the components introduced by an instance the second 
+    // alternative of the C++ grammar of noptr-delarator:
+    //    noptr-declarator parameters-and-qualifiers
+    struct Morphism::Function : Morphism {
         virtual const Parameter_list& parameters() const = 0;
         virtual Type_qualifiers qualifiers() const = 0;
         virtual Binding_mode binding_mode() const = 0;
         virtual Optional<Expr> throws() const = 0;
     };
 
-    // A species declarator indicating something that can be indexed.  That something
-    // is described by the species in the `prefix()` sequence of species.
-    struct Species_declarator::Array : Species_declarator {
-        virtual const Sequence<Species_declarator>& prefix() const = 0;
+    // -- Array Morphism
+    // A morphism for a declarator indicating something that can be indexed.
+    // An object of this type captures the components introduced by an instance the third
+    // alternative of the C++ grammar of noptr-delarator:
+    //    noptr-declarator `[` constant-expression_opt `]` attribute-specifier-seq_opt
+    struct Morphism::Array : Morphism {
         virtual Optional<Expr> bound() const = 0;
-    };
-
-    // A term declarator requiring parenthesis to obey operator precedence rules.
-    struct Species_declarator::Parenthesized : Species_declarator {
-        virtual const Declarator::Term& term() const = 0;
     };
 
     // Traversal of species objects is facilitated by visitor classes deriving
     // from this interface.
     struct Species_visitor {
         virtual void visit(const Species_declarator::Id&) = 0;
-        virtual void visit(const Species_declarator::Callable&) = 0;
-        virtual void visit(const Species_declarator::Array&) = 0;
         virtual void visit(const Species_declarator::Parenthesized&) = 0;
     };
 

--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -756,6 +756,7 @@ namespace ipr::impl {
 }
 
 namespace ipr::cxx_form::impl {
+   // -- implementation of ipr::cxx_form::Indirector
    template<typename T>
    struct Indirector : T {
       ipr::impl::ref_sequence<ipr::Attribute> attr_seq;
@@ -763,16 +764,19 @@ namespace ipr::cxx_form::impl {
       void accept(Indirector_visitor& v) const final { v.visit(static_cast<const T&>(*this)); }
    };
 
+   // -- implementation of ipr::cxx_form::Indirector::Pointer
    struct Pointer_indirector : impl::Indirector<cxx_form::Indirector::Pointer> {
       ipr::Type_qualifiers cv_quals { };
       ipr::Type_qualifiers qualifiers() const final { return cv_quals; }
    };
 
+   // -- implementation of ipr::cxx_form::Indirector::Reference
    struct Reference_indirector : impl::Indirector<cxx_form::Indirector::Reference> {
       Reference_flavor how { };
       Reference_flavor flavor() const final { return how; }
    };
 
+   // -- implementation of ipr::cxx_form::Indirector::Member
    struct Member_indirector : impl::Indirector<cxx_form::Indirector::Member> {
       util::ref<const ipr::Expr> whole;
       ipr::Type_qualifiers cv_quals { };
@@ -780,58 +784,72 @@ namespace ipr::cxx_form::impl {
       ipr::Type_qualifiers qualifiers() const final { return cv_quals; }
    };
 
+   // -- implementation of ipr::cxx_form::Morphism
    template<typename T>
-   struct Species : T {
-      void accept(Species_visitor& v) const final { v.visit(static_cast<const T&>(*this)); }
+   struct Morphism : T {
+      ipr::impl::ref_sequence<ipr::Attribute> attr_seq;
+      const ipr::Sequence<ipr::Attribute>& attributes() const final { return attr_seq; }
+      void accept(Morphism_visitor& v) const final { v.visit(static_cast<const T&>(*this)); }
    };
 
-   struct Id_species : impl::Species<cxx_form::Species_declarator::Id> {
-      util::ref<const ipr::Expr> expr;
-      const ipr::Expr& name() const final { return expr.get(); }
-   };
-
-   struct Callable_species : impl::Species<cxx_form::Species_declarator::Callable> {
-      ipr::impl::ref_sequence<cxx_form::Species_declarator> preceding_species;
+   // -- implementation of ipr::cxx_form::Morphism::Function
+   struct Function_morphism : impl::Morphism<cxx_form::Morphism::Function> {
       ipr::impl::Parameter_list inputs;
       Optional<ipr::Expr> eh_spec;
       Type_qualifiers cv_quals { };
       Binding_mode ref_qual { };
-      Callable_species(const ipr::Region&, Mapping_level);
-      const ipr::Sequence<cxx_form::Species_declarator>& prefix() const final { return preceding_species; }
+      Function_morphism(const ipr::Region&, Mapping_level);
       const ipr::Parameter_list& parameters() const final { return inputs; }
       Optional<ipr::Expr> throws() const final { return eh_spec; }
       Type_qualifiers qualifiers() const final { return cv_quals; }
       Binding_mode binding_mode() const final { return ref_qual; }
    };
 
-   struct Array_species : impl::Species<cxx_form::Species_declarator::Array> {
-      ipr::impl::ref_sequence<cxx_form::Species_declarator> preceding_species;
+   // -- implementation of ipr::cxx_form::Morphism::Array
+   struct Array_morphism : impl::Morphism<cxx_form::Morphism::Array> {
       Optional<ipr::Expr> array_bound;
-      const ipr::Sequence<cxx_form::Species_declarator>& prefix() const final { return preceding_species; }
       Optional<ipr::Expr> bound() const final { return array_bound; }
    };
 
+   // -- implementation of ipr::cxx_form::Species_declarator
+   template<typename T>
+   struct Species : T {
+      ipr::impl::ref_sequence<cxx_form::Morphism> morphisms;
+      const ipr::Sequence<cxx_form::Morphism>& suffix() const final { return morphisms; }
+      void accept(Species_visitor& v) const final { v.visit(static_cast<const T&>(*this)); }
+   };
+
+   // -- implementation of ipr::cxx_form::Species_declarator::Id
+   struct Id_species : impl::Species<cxx_form::Species_declarator::Id> {
+      util::ref<const ipr::Expr> expr;
+      ipr::impl::ref_sequence<ipr::Attribute> attr_seq;
+      const ipr::Sequence<ipr::Attribute>& attributes() const final { return attr_seq; }
+      const ipr::Expr& name() const final { return expr.get(); }
+   };
+
+   // -- implementation of ipr::cxx_form::Species_declarator::Parenthesized
    struct Parenthesized_species : impl::Species<cxx_form::Species_declarator::Parenthesized> {
       util::ref<const Declarator::Term> declarator;
       const Declarator::Term& term() const final { return declarator.get(); }
    };
 
+   // -- Factory of C++ declarator forms.
    struct form_factory {
       Pointer_indirector* make_pointer_indirector();
       Reference_indirector* make_reference_indirector();
       Member_indirector* make_member_indirector();
       Id_species* make_id_species();
-      Callable_species* make_callable_species(const ipr::Region& parent, Mapping_level level);
-      Array_species* make_array_species();
       Parenthesized_species* make_parenthesized_species();
+      Function_morphism* make_function_morphism(const ipr::Region& parent, Mapping_level level);
+      Array_morphism* make_array_morphism();
    private:
       ipr::impl::stable_farm<Pointer_indirector> pointer_indirectors;
       ipr::impl::stable_farm<Reference_indirector> reference_indirectors;
       ipr::impl::stable_farm<Member_indirector> member_indirectors;
       ipr::impl::stable_farm<Id_species> id_species;
-      ipr::impl::stable_farm<Callable_species> callable_species;
-      ipr::impl::stable_farm<Array_species> array_species;
       ipr::impl::stable_farm<Parenthesized_species> paren_species;
+      ipr::impl::stable_farm<Function_morphism> function_morphisms;
+      ipr::impl::stable_farm<Array_morphism> array_morphisms;
    };
 }
 

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -193,7 +193,7 @@ namespace ipr::util {
 }
 
 namespace ipr::cxx_form::impl {
-   Callable_species::Callable_species(const ipr::Region& parent, Mapping_level level)
+   Function_morphism::Function_morphism(const ipr::Region& parent, Mapping_level level)
       : inputs{ parent, level }
    { }
 
@@ -217,14 +217,14 @@ namespace ipr::cxx_form::impl {
       return id_species.make();
    }
 
-   Callable_species* form_factory::make_callable_species(const ipr::Region& parent, Mapping_level level)
+   Function_morphism* form_factory::make_function_morphism(const ipr::Region& parent, Mapping_level level)
    {
-      return callable_species.make(parent, level);
+      return function_morphisms.make(parent, level);
    }
 
-   Array_species* form_factory::make_array_species()
+   Array_morphism* form_factory::make_array_morphism()
    {
-      return array_species.make();
+      return array_morphisms.make();
    }
 
    Parenthesized_species* form_factory::make_parenthesized_species()

--- a/tests/unit-tests/region-owner.cxx
+++ b/tests/unit-tests/region-owner.cxx
@@ -37,7 +37,7 @@ TEST_CASE("Region-owner user") {
   CHECK(&r2 == unit.global_region());
 }
 
-TEST_CASE("Callable species")
+TEST_CASE("Function morphisms")
 {
   using namespace ipr;
   impl::Lexicon lexicon{};
@@ -48,7 +48,7 @@ TEST_CASE("Callable species")
   auto nesting = Mapping_level{0};
 
   auto& spread = *lexicon.make_specifiers_spread();
-  auto& callable = *region.make_callable_species(region, nesting);
+  auto& callable = *region.make_function_morphism(region, nesting);
   callable.inputs.parms.owned_by = &spread;
   spread.proc_seq.push_back(&callable);
 


### PR DESCRIPTION
This patch rewrites the data structures for declarator species, both correcting and simplifying the representations.  Now, a declarator species is either an `Species_declarator::Id` or a `Species_declarator::Parenthesized` followed by a suffix of `Morphism`s.  A `Morphism` indicates either an array or a function type constructor.