### PR TITLE
Refine C++ form for _declarator-id_

### DIFF
--- a/include/ipr/cxx-form
+++ b/include/ipr/cxx-form
@@ -128,10 +128,41 @@ namespace ipr::cxx_form {
     // The term declarator `*pfs[8]` in turn has the indirectors is comprised of the single pointer indirector `*`,
     // and of the id species `pfs` with array suffix `[8]`.
     struct Species_declarator {
-        struct Id;                                  // possible packy id-expression -- a or X::m or ...f
+        struct Unqualified_id;                      // -- int p;
+        struct Pack;                                // -- Ts... xs
+        struct Qualified_id;                        // -- int X<T>::count;
         struct Parenthesized;                       // parenthesized term declarator -- (*p)
         virtual const Sequence<Morphism>& suffix() const = 0;
         virtual void accept(Species_visitor&) const = 0;
+    };
+
+    // Base class for representing instances of the C++ production id-expression in the C++
+    // grammar for declarator-id.
+    struct Declarator_id : Species_declarator {
+        virtual const Sequence<Attribute>& attributes() const = 0;
+    };
+
+    // Representation of an unqualified-id in an instance of the C++ grammar production for declarator-id.
+    // The operation `name()` returns an optional value for use in representing instances of the C++
+    // grammar production for noptr-abstract-declarator.
+    struct Species_declarator::Unqualified_id : Declarator_id {
+        virtual Optional<ipr::Name> name() const = 0;
+    };
+
+    // Representation of a pack parameter in an instance of the C++ grammar production for declarator-id
+    // The operation `name()` returns an optional value for use in representing instances of the C++
+    // grammar production for noptr-abstract-abstract-declarator.
+    // Example:
+    //     ... x
+    struct Species_declarator::Pack : Declarator_id {
+        virtual Optional<ipr::Identifier> name() const = 0;
+    };
+
+    // Representation of a qualified-id in an instance of the C++ grammar production for declarator-id
+    // Such qualified-id are used in the out-of-class definition of an entity.
+    struct Species_declarator::Qualified_id : Declarator_id {
+        virtual const ipr::Expr& scope() const = 0;
+        virtual const ipr::Name& member() const = 0;
     };
 
     // -- Declarator.
@@ -143,7 +174,7 @@ namespace ipr::cxx_form {
 
     struct Declarator {
         struct Term;                                // *p or (&a)[42]
-        struct Targeted;                            // *f(T& p) -> int
+        struct Targeted;                            // f(T& p) -> int
         virtual const Species_declarator& species() const = 0;
         virtual void accept(Declarator_visitor&) const = 0;
     };
@@ -177,12 +208,6 @@ namespace ipr::cxx_form {
     struct Declarator_visitor {
         virtual void visit(const Declarator::Term&) = 0;
         virtual void visit(const Declarator::Targeted&) = 0;
-    };
-
-    // An id-expression in the species declarator.  That name may be a pack, i.e. preceded by "...".
-    struct Species_declarator::Id : Species_declarator {
-        virtual const Expr& name() const = 0;
-        virtual const Sequence<Attribute>& attributes() const = 0;
     };
 
     // A term declarator requiring parentheses to obey operator precedence rules, or just
@@ -220,7 +245,9 @@ namespace ipr::cxx_form {
     // Traversal of species objects is facilitated by visitor classes deriving
     // from this interface.
     struct Species_visitor {
-        virtual void visit(const Species_declarator::Id&) = 0;
+        virtual void visit(const Species_declarator::Unqualified_id&) = 0;
+        virtual void visit(const Species_declarator::Pack&) = 0;
+        virtual void visit(const Species_declarator::Qualified_id&) = 0;
         virtual void visit(const Species_declarator::Parenthesized&) = 0;
     };
 

--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -766,22 +766,28 @@ namespace ipr::cxx_form::impl {
 
    // -- implementation of ipr::cxx_form::Indirector::Pointer
    struct Pointer_indirector : impl::Indirector<cxx_form::Indirector::Pointer> {
-      ipr::Type_qualifiers cv_quals { };
+      explicit Pointer_indirector(ipr::Type_qualifiers cv) : cv_quals{cv} { }
       ipr::Type_qualifiers qualifiers() const final { return cv_quals; }
+   private:
+      ipr::Type_qualifiers cv_quals;
    };
 
    // -- implementation of ipr::cxx_form::Indirector::Reference
    struct Reference_indirector : impl::Indirector<cxx_form::Indirector::Reference> {
-      Reference_flavor how { };
+      explicit Reference_indirector(Reference_flavor f) : how{f} { }
       Reference_flavor flavor() const final { return how; }
+   private:
+      Reference_flavor how { };
    };
 
    // -- implementation of ipr::cxx_form::Indirector::Member
    struct Member_indirector : impl::Indirector<cxx_form::Indirector::Member> {
-      util::ref<const ipr::Expr> whole;
-      ipr::Type_qualifiers cv_quals { };
-      const ipr::Expr& scope() const final { return whole.get(); }
+      Member_indirector(const ipr::Expr& s, ipr::Type_qualifiers cv) : whole{s}, cv_quals{cv} { }
+      const ipr::Expr& scope() const final { return whole; }
       ipr::Type_qualifiers qualifiers() const final { return cv_quals; }
+   private:
+      const ipr::Expr& whole;
+      ipr::Type_qualifiers cv_quals;
    };
 
    // -- implementation of ipr::cxx_form::Morphism
@@ -819,12 +825,39 @@ namespace ipr::cxx_form::impl {
       void accept(Species_visitor& v) const final { v.visit(static_cast<const T&>(*this)); }
    };
 
-   // -- implementation of ipr::cxx_form::Species_declarator::Id
-   struct Id_species : impl::Species<cxx_form::Species_declarator::Id> {
-      util::ref<const ipr::Expr> expr;
+   // Provide implementation for common operations for the various classes implementing
+   // classes for instances of declarator-id.
+   template<typename T>
+   struct Id_species : impl::Species<T> {
       ipr::impl::ref_sequence<ipr::Attribute> attr_seq;
       const ipr::Sequence<ipr::Attribute>& attributes() const final { return attr_seq; }
-      const ipr::Expr& name() const final { return expr.get(); }
+   };
+
+   // Provide implementation for common operations for the various classes implementing
+   // unqualified-id instances of declarator-id.
+   template<typename T, typename S>
+   struct Name_species : impl::Id_species<T> {
+      Name_species() = default;
+      explicit Name_species(const S& s) : id{s} { }
+      Optional<S> name() const final { return id; }
+   private:
+      Optional<S> id{ };
+   };
+
+   // -- implementation of ipr::cxx_form::Species_declarator::Unqualified_id
+   using Unqualified_id_species = Name_species<cxx_form::Species_declarator::Unqualified_id, ipr::Name>;
+
+   // -- implementation of ipr::cxx_form::Species_declarator::Pack
+   using Pack_species = Name_species<cxx_form::Species_declarator::Pack, ipr::Identifier>;
+
+   // -- implementation of ipr::cxx_form::Species_declarator::Qualified_id
+   struct Qualified_id_species : impl::Id_species<cxx_form::Species_declarator::Qualified_id> {
+      Qualified_id_species(const ipr::Expr& s, const ipr::Name& n) : outer{s}, id{n} { }
+      const ipr::Expr& scope() const final { return outer; }
+      const ipr::Name& member() const final { return id; }
+   private:
+      const ipr::Expr& outer;
+      const ipr::Name& id;
    };
 
    // -- implementation of ipr::cxx_form::Species_declarator::Parenthesized
@@ -833,23 +866,60 @@ namespace ipr::cxx_form::impl {
       const Declarator::Term& term() const final { return declarator.get(); }
    };
 
+   // -- implementation of ipr::cxx_form::Declarator.
+   // Only the `accept()` operation is implemented here.  The other common operation, `species()`,
+   // is individually implemented by each of the derived classes.
+   template<typename T>
+   struct Declarator : T {
+      void accept(cxx_form::Declarator_visitor& v) const final { v.visit(static_cast<const T&>(*this)); }
+   };
+
+   // -- implementation of ipr::cxx_form::Declarator::Term
+   struct Term_declarator : impl::Declarator<cxx_form::Declarator::Term> {
+      ipr::impl::ref_sequence<cxx_form::Indirector> prefix;
+      util::ref<cxx_form::Species_declarator> tail;
+      const ipr::Sequence<cxx_form::Indirector>& indirectors() const final { return prefix; }
+      const Species_declarator& species() const final { return tail.get(); }
+   };
+
+   // -- implementation of ipr::cxx_form::Declarator::Targeted
+   struct Targeted_declarator : impl::Declarator<cxx_form::Declarator::Targeted> {
+      Targeted_declarator(const cxx_form::Species_declarator& s, const ipr::Type& t)
+         : domain{s}, range{t} { }
+      const cxx_form::Species_declarator& species() const final { return domain; }
+      const ipr::Type& target() const final { return range; }
+   private:
+      const cxx_form::Species_declarator& domain;
+      const ipr::Type& range;
+   };
+
    // -- Factory of C++ declarator forms.
    struct form_factory {
-      Pointer_indirector* make_pointer_indirector();
-      Reference_indirector* make_reference_indirector();
-      Member_indirector* make_member_indirector();
-      Id_species* make_id_species();
+      Pointer_indirector* make_pointer_indirector(ipr::Type_qualifiers);
+      Reference_indirector* make_reference_indirector(Reference_flavor);
+      Member_indirector* make_member_indirector(const ipr::Expr&, Type_qualifiers);
+      Unqualified_id_species* make_unqualified_id_species();
+      Unqualified_id_species* make_unqualified_id_species(const ipr::Name&);
+      Pack_species* make_pack_species();
+      Pack_species* make_pack_species(const ipr::Identifier&);
+      Qualified_id_species* make_qualified_id_species(const ipr::Expr&, const ipr::Name&);
       Parenthesized_species* make_parenthesized_species();
       Function_morphism* make_function_morphism(const ipr::Region& parent, Mapping_level level);
       Array_morphism* make_array_morphism();
+      Term_declarator* make_term_declarator();
+      Targeted_declarator* make_targeted_declarator(const cxx_form::Species_declarator&, const ipr::Type&);
    private:
       ipr::impl::stable_farm<Pointer_indirector> pointer_indirectors;
       ipr::impl::stable_farm<Reference_indirector> reference_indirectors;
       ipr::impl::stable_farm<Member_indirector> member_indirectors;
-      ipr::impl::stable_farm<Id_species> id_species;
+      ipr::impl::stable_farm<Unqualified_id_species> unqualified_id_species;
+      ipr::impl::stable_farm<Pack_species> pack_species;
+      ipr::impl::stable_farm<Qualified_id_species> qualified_id_species;
       ipr::impl::stable_farm<Parenthesized_species> paren_species;
       ipr::impl::stable_farm<Function_morphism> function_morphisms;
       ipr::impl::stable_farm<Array_morphism> array_morphisms;
+      ipr::impl::stable_farm<Term_declarator> term_declarators;
+      ipr::impl::stable_farm<Targeted_declarator> targeted_declarators;
    };
 }
 

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -197,24 +197,44 @@ namespace ipr::cxx_form::impl {
       : inputs{ parent, level }
    { }
 
-   Pointer_indirector* form_factory::make_pointer_indirector()
+   Pointer_indirector* form_factory::make_pointer_indirector(ipr::Type_qualifiers cv)
    {
-      return pointer_indirectors.make();
+      return pointer_indirectors.make(cv);
    }
 
-   Reference_indirector* form_factory::make_reference_indirector()
+   Reference_indirector* form_factory::make_reference_indirector(Reference_flavor f)
    {
-      return reference_indirectors.make();
+      return reference_indirectors.make(f);
    }
 
-   Member_indirector* form_factory::make_member_indirector()
+   Member_indirector* form_factory::make_member_indirector(const ipr::Expr& s, Type_qualifiers cv)
    {
-      return member_indirectors.make();
+      return member_indirectors.make(s, cv);
    }
 
-   Id_species* form_factory::make_id_species()
+   Unqualified_id_species* form_factory::make_unqualified_id_species()
    {
-      return id_species.make();
+      return unqualified_id_species.make();
+   }
+
+   Unqualified_id_species* form_factory::make_unqualified_id_species(const ipr::Name& id)
+   {
+      return unqualified_id_species.make(id);
+   }
+
+   Pack_species* form_factory::make_pack_species()
+   {
+      return pack_species.make();
+   }
+
+   Pack_species* form_factory::make_pack_species(const ipr::Identifier& id)
+   {
+      return pack_species.make(id);
+   }
+
+   Qualified_id_species* form_factory::make_qualified_id_species(const ipr::Expr& s, const ipr::Name& n)
+   {
+      return qualified_id_species.make(s, n);
    }
 
    Function_morphism* form_factory::make_function_morphism(const ipr::Region& parent, Mapping_level level)
@@ -230,6 +250,16 @@ namespace ipr::cxx_form::impl {
    Parenthesized_species* form_factory::make_parenthesized_species()
    {
       return paren_species.make();
+   }
+
+   Term_declarator* form_factory::make_term_declarator()
+   {
+      return term_declarators.make();
+   }
+
+   Targeted_declarator* form_factory::make_targeted_declarator(const cxx_form::Species_declarator& s, const ipr::Type& t)
+   {
+      return targeted_declarators.make(s, t);
    }
 }
 


### PR DESCRIPTION
This patch replaces the class `cxx_form::Declarator::Id` with three classes that better represent the various alternatives of the C++ grammar production for _declarator-id_.  This allows the resulting structures to be used in more natural representations of the grammar production _abstract-declarator_.