### PR TITLE
Expand on C++ forms for initialization

### DIFF
--- a/include/ipr/cxx-form
+++ b/include/ipr/cxx-form
@@ -251,10 +251,137 @@ namespace ipr::cxx_form {
         virtual void visit(const Species_declarator::Parenthesized&) = 0;
     };
 
+    // -- Proclamator.
+    // A proclamator is a complete declarator along with an initializer, or with a constraint.
+    // A proclamator represents an instance of the C++ grammar for init-declarator.  Furtermore,
+    // a proclamator holds the result of elaborating its declarator with a decl-specifier-seq that
+    // preceds it in a declaration.
+
+    // -- Initialization provision.
+    // -- An initialization provision is an initializer form that stipulates how an entity
+    // -- (the name of which is introduced by a declarator) shall be initialized. Choices range from
+    // -- classic provision introduced by the `=` sign, to recent innovations such as parenthesized
+    // -- expression list or brace enclosed initializer list for uniform initialization.
+
+    struct Provision_visitor;
+
+    // Base class of initialization provision classes.  They don't share much in common other than
+    // appearing in top-level init-declarators.
+    struct Initialization_provision {
+        virtual void accept(Provision_visitor&) const = 0;
+    };
+
+    // Base for navigating elemental initializers.
+    struct Initializer_visitor;
+
+    // Base class of initializer form (other than earmarked initializer) that can appear in a
+    // brace-enclosed initilizer form. 
+    struct Elemental_initializer {
+        virtual void accept(Initializer_visitor&) const = 0;
+    };
+
+    // Initialization provision of the form
+    //     `=` initializer-clause
+    struct Classic_provision : Initialization_provision {
+        virtual const Elemental_initializer& initializer() const = 0;
+    };
+
+    // Initialization provision of the form
+    //    `(` expression-list `)`;
+    struct Parenthesized_provision : Initialization_provision {
+        virtual const Expr& initializer() const = 0;
+    };
+
+    // Embedding of an expression in an elemental initializer hierarchy.
+    // Note that the expression here can be either
+    //      expression
+    // in general, or an
+    //     expression-list_opt
+    struct Expr_initializer : Elemental_initializer {
+        virtual const Expr& expression() const = 0;
+    };
+
+    // Initialization provision of the form
+    //    `{` initializer-list_opt `}`
+    struct Braced_provision : Initialization_provision, Elemental_initializer {
+        virtual const Sequence<Elemental_initializer>& elements() const = 0;
+    };
+
+    // An earmarked initializer is a form that specifies an initializer for a specific subobject
+    // of a structure or an array, in a designated-initializer-list.  Strictly speaking, ISO C++
+    // (unlike C99) currently supports only designated-initializer-list for structures, but not
+    // arrays.  But since the C99 designated-initialization for arrays is in practice accepted
+    // by major compilers as extensions, and that extension fits the general model here, the form
+    // data structures below make room for them.
+    struct Earmarked_initializer;
+
+    // An initializer provision of the form
+    //    `{` designated-initializer-list_opt `}`
+    struct Designated_list_provision : Initialization_provision, Elemental_initializer {
+        virtual const Sequence<Earmarked_initializer>& elements() const = 0;
+    };
+
+    // Base class for navigation of initialization provisions.
+    struct Provision_visitor {
+        virtual void visit(const Classic_provision&) = 0;
+        virtual void visit(const Parenthesized_provision&) = 0;
+        virtual void visit(const Braced_provision&) = 0;
+        virtual void visit(const Designated_list_provision&) = 0;
+    };
+
+    // -- Designator.
+    // A designator is a form that identifies an immediate subobject of a structure (by name),
+    // or an array (by slot index).  For example, in designated-initializer-list, the element
+    //     .galaxy { "Milky Way"}
+    // provides a braced-initializer for the field named `galaxy`.  Similarly the element
+    //     [4] = "Tau'ri"
+    // provides a classic-initializer for the fifth slot of the array being initialized.
+    struct Designator_visitor;
+
+    struct Subobject_designator {
+        virtual void accept(Designator_visitor&) const = 0;
+    };
+
+    // Designator of a field.
+    // Example:
+    //     . location
+    struct Field_designator : Subobject_designator {
+        virtual const Identifier& name() const = 0;
+    };
+
+    // Designator of an array slot.
+    // Example:
+    //    [ 13 ]
+    struct Slot_designator : Subobject_designator {
+        virtual const Expr& index() const = 0;
+    };
+
+    struct Designator_visitor {
+        virtual void visit(const Field_designator&) = 0;
+        virtual void visit(const Slot_designator&) = 0;
+    };
+
+    // An earmarked initializer is an element of a designated-initializer-list that provides
+    // an initialier for a direct subobject of a structure or an array.
+    // Example:
+    //    .galaxy { "Milky Way" }
+    //    [4] = "Tau'ri"
+    struct Earmarked_initializer {
+        virtual const Subobject_designator& subobject() const = 0;
+        virtual const Initialization_provision& initializer() const = 0;
+    };
+
+    // Base class for navigation of elemental initializers.
+    struct Initializer_visitor {
+        virtual void visit(const Expr_initializer&) = 0;
+        virtual void visit(const Braced_provision&) = 0;
+        virtual void visit(const Designated_list_provision&) = 0;
+    };
+
     struct Proclamator_visitor;
 
     struct Proclamator {
-        struct Initialized;
+        struct Initialized;                         // int ary[] { 1, 2, 3 };
         struct Constrained;
         virtual const Declarator& declarator() const = 0;
         virtual Decl& result() const = 0;
@@ -262,7 +389,7 @@ namespace ipr::cxx_form {
     };
 
     struct Proclamator::Initialized : Proclamator {
-        virtual Optional<Expr> initializer() const = 0;
+        virtual Optional<Initialization_provision> initializer() const = 0;
     };
 
     struct Proclamator::Constrained : Proclamator {

--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -759,6 +759,7 @@ namespace ipr::cxx_form::impl {
    // -- implementation of ipr::cxx_form::Indirector
    template<typename T>
    struct Indirector : T {
+      using Interface = T;
       ipr::impl::ref_sequence<ipr::Attribute> attr_seq;
       const ipr::Sequence<ipr::Attribute>& attributes() const final { return attr_seq; }
       void accept(Indirector_visitor& v) const final { v.visit(static_cast<const T&>(*this)); }
@@ -793,6 +794,7 @@ namespace ipr::cxx_form::impl {
    // -- implementation of ipr::cxx_form::Morphism
    template<typename T>
    struct Morphism : T {
+      using Interface = T;
       ipr::impl::ref_sequence<ipr::Attribute> attr_seq;
       const ipr::Sequence<ipr::Attribute>& attributes() const final { return attr_seq; }
       void accept(Morphism_visitor& v) const final { v.visit(static_cast<const T&>(*this)); }
@@ -820,6 +822,7 @@ namespace ipr::cxx_form::impl {
    // -- implementation of ipr::cxx_form::Species_declarator
    template<typename T>
    struct Species : T {
+      using Interface = T;
       ipr::impl::ref_sequence<cxx_form::Morphism> morphisms;
       const ipr::Sequence<cxx_form::Morphism>& suffix() const final { return morphisms; }
       void accept(Species_visitor& v) const final { v.visit(static_cast<const T&>(*this)); }
@@ -871,6 +874,7 @@ namespace ipr::cxx_form::impl {
    // is individually implemented by each of the derived classes.
    template<typename T>
    struct Declarator : T {
+      using Interface = T;
       void accept(cxx_form::Declarator_visitor& v) const final { v.visit(static_cast<const T&>(*this)); }
    };
 
@@ -893,6 +897,82 @@ namespace ipr::cxx_form::impl {
       const ipr::Type& range;
    };
 
+   // -- implementation of ipr::cxx_form::Initialization_provision
+   template<typename T>
+   struct Initialization_provision : T {
+      void accept(cxx_form::Provision_visitor& v) const final { v.visit(static_cast<const T&>(*this)); }
+   };
+
+   // -- implementation of ipr::cxx_form::Elemental_initializer
+   template<typename T>
+   struct Elemental_initializer : T {
+      using Interface = T;
+      void accept(cxx_form::Initializer_visitor& v) const final { v.visit(static_cast<const T&>(*this)); }
+   };
+
+   // -- implementation of ipr::cxx_form::Subobject_designator
+   template<typename T>
+   struct Subobject_designator : T {
+      using Interface = T;
+      void accept(cxx_form::Designator_visitor& v) const final { v.visit(static_cast<const T&>(*this)); }
+   };
+
+   // -- implementation of ipr::cxx_form::Field_designator
+   struct Field_designator : impl::Subobject_designator<cxx_form::Field_designator> {
+      explicit Field_designator(const ipr::Identifier& x) : id{x} { }
+      const ipr::Identifier& name() const final { return id; }
+   private:
+      const ipr::Identifier& id;
+   };
+
+   // -- implementation of ipr::cxx_form::Slot_designator
+   struct Slot_designator : impl::Subobject_designator<cxx_form::Slot_designator> {
+      explicit Slot_designator(const ipr::Expr& x) : idx{x} { }
+      const ipr::Expr& index() const final { return idx; }
+   private:
+      const ipr::Expr& idx;
+   };
+
+   // -- implementation of ipr::cxx_form::Earmarked_initializer
+   struct Earmarked_initializer : cxx_form::Earmarked_initializer {
+      using Interface = cxx_form::Earmarked_initializer;
+      Earmarked_initializer(const cxx_form::Subobject_designator& f, const cxx_form::Initialization_provision& x)
+         : sub{f}, init{x} { }
+      const cxx_form::Subobject_designator& subobject() const final { return sub; }
+      const cxx_form::Initialization_provision& initializer() const final { return init; }
+   private:
+      const cxx_form::Subobject_designator& sub;
+      const cxx_form::Initialization_provision& init;
+   };
+
+   // -- implementation of ipr::cxx_form::Classic_provision
+   struct Classic_provision : impl::Initialization_provision<ipr::cxx_form::Classic_provision> {
+      explicit Classic_provision(const ipr::cxx_form::Elemental_initializer& i) : init{i} { }
+      const ipr::cxx_form::Elemental_initializer& initializer() const final { return init; }
+   private:
+      const ipr::cxx_form::Elemental_initializer& init;
+   };
+
+   // -- implementation of ipr::cxx_form::Parenthesized_provision
+   struct Parenthesized_provision : impl::Initialization_provision<ipr::cxx_form::Parenthesized_provision> {
+      explicit Parenthesized_provision(const ipr::Expr& x) : expr{x} { }
+      const ipr::Expr& initializer() const final { return expr; }
+   private:
+      const ipr::Expr& expr;
+   };
+
+   // -- implementation of ipr::cxx_form::Braced_provision
+   struct Braced_provision : impl::Initialization_provision<impl::Elemental_initializer<ipr::cxx_form::Braced_provision>> {
+      ipr::impl::ref_sequence<cxx_form::Elemental_initializer> seq;
+      const ipr::Sequence<cxx_form::Elemental_initializer>& elements() const final { return seq; }
+   };
+
+   // -- implementation of ipr::cxx_form::Designated_list_provision
+   struct Designated_list_provision : impl::Initialization_provision<impl::Elemental_initializer<cxx_form::Designated_list_provision>> {
+      ipr::impl::obj_sequence<cxx_form::impl::Earmarked_initializer> seq;
+      const ipr::Sequence<cxx_form::Earmarked_initializer>& elements() const final { return seq; }
+   };   
+
    // -- Factory of C++ declarator forms.
    struct form_factory {
       Pointer_indirector* make_pointer_indirector(ipr::Type_qualifiers);
@@ -908,6 +988,13 @@ namespace ipr::cxx_form::impl {
       Array_morphism* make_array_morphism();
       Term_declarator* make_term_declarator();
       Targeted_declarator* make_targeted_declarator(const cxx_form::Species_declarator&, const ipr::Type&);
+      Classic_provision* make_classic_provision(const cxx_form::Elemental_initializer&);
+      Parenthesized_provision* make_parenthesized_provision(const ipr::Expr&);
+      Braced_provision* make_braced_provision();
+      Designated_list_provision* make_designated_provision();
+      Field_designator* make_field_designator(const ipr::Identifier&);
+      Slot_designator* make_slot_designator(const ipr::Expr&);
+
    private:
       ipr::impl::stable_farm<Pointer_indirector> pointer_indirectors;
       ipr::impl::stable_farm<Reference_indirector> reference_indirectors;
@@ -920,6 +1007,12 @@ namespace ipr::cxx_form::impl {
       ipr::impl::stable_farm<Array_morphism> array_morphisms;
       ipr::impl::stable_farm<Term_declarator> term_declarators;
       ipr::impl::stable_farm<Targeted_declarator> targeted_declarators;
+      ipr::impl::stable_farm<Classic_provision> classic_provisions;
+      ipr::impl::stable_farm<Parenthesized_provision> paren_provisions;
+      ipr::impl::stable_farm<Braced_provision> braced_provisions;
+      ipr::impl::stable_farm<Designated_list_provision> designated_provisions;
+      ipr::impl::stable_farm<Field_designator> field_designators;
+      ipr::impl::stable_farm<Slot_designator> slot_designators;
    };
 }
 

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -261,6 +261,36 @@ namespace ipr::cxx_form::impl {
    {
       return targeted_declarators.make(s, t);
    }
+
+   Classic_provision* form_factory::make_classic_provision(const cxx_form::Elemental_initializer& x)
+   {
+      return classic_provisions.make(x);
+   }
+
+   Parenthesized_provision* form_factory::make_parenthesized_provision(const ipr::Expr& x)
+   {
+      return paren_provisions.make(x);
+   }
+
+   Braced_provision* form_factory::make_braced_provision()
+   {
+      return braced_provisions.make();
+   }
+
+   Designated_list_provision* form_factory::make_designated_provision()
+   {
+      return designated_provisions.make();
+   }
+
+   Field_designator* form_factory::make_field_designator(const ipr::Identifier& x)
+   {
+      return field_designators.make(x);
+   }
+
+   Slot_designator* form_factory::make_slot_designator(const ipr::Expr& x)
+   {
+      return slot_designators.make(x);
+   }
 }
 
 namespace ipr::impl {


### PR DESCRIPTION
This patch expands on the various forms of initializers in a proclamator form for C++ source code.
As a small extension, these initializer forms are capable of also representing C99's designated initializers for arrays, which is not ISO C++ but common in practice.