### PR TITLE
Add support for constraints

### DIFF
--- a/include/ipr/cxx-form
+++ b/include/ipr/cxx-form
@@ -23,6 +23,104 @@
 // -- Note: There is no effort in this file to reify the parse trees of the ISO C++ grammar.
 
 namespace ipr::cxx_form {
+    // -- Syntactic constraints.
+    // -- C++ Concepts, as supported since C++20, focus primarily on the syntactic requirements
+    // -- on combinations of template arguments. The semantics counterpart is not yet supported by
+    // -- the base language.
+    // -- A constraint generally applies a concept to a compile-time argument list.  Hence the syntax
+    // -- uses the "template specialization" syntax for the application.  The result is a Boolean
+    // -- expression indicating whether the syntactic constraints contained in the body if the 
+    // -- concept are satisfied or not.  Given a monadic concept (a concept with exactly one parameter),
+    // -- the concept name, as a predicate, can be viewed as a type for a template-type parameter.  
+    // -- That is known as the "short-hand notation" . Similar notational convenience for non-type
+    // -- template parameter isn't as straightforward.
+    // -- Given a polyadic concept (a concept with more N parameters, N > 1), a constraint can be formed
+    // -- by applying the concept name to N-1 compile-time arguments (the "trailing arguments"). 
+
+    struct Constraint_visitor;
+
+    struct Constraint {
+        struct Monadic;                                         // -> C;
+        struct Polyadic;                                        // -> C<e1, e2>;
+        virtual void accept(Constraint_visitor&) const = 0;
+    };
+
+    // An object of this type corresponds to an instance of the first alternative of the ISO C++
+    // grammar production for type-constraint
+    //          nested-name-specifier_opt concept-name
+    struct Constraint::Monadic : Constraint {
+        virtual Optional<Expr> scope() const = 0;
+        virtual const Identifier& concept_name() const = 0;
+    };
+
+    // An object of this type corresponds to an instance of the second alternative of the ISO C++
+    // grammar production for type-constraint
+    //          nested-name-specifier_opt concept-name `< template-argument--list_opt `>`
+    struct Constraint::Polyadic : Constraint {
+        virtual Optional<Expr> scope() const = 0;
+        virtual const Identifier& concept_name() const = 0;
+        virtual const Sequence<Expr>& trailing_arguments() const = 0;
+    };
+
+    struct Constraint_visitor {
+        virtual void visit(const Constraint::Monadic&) = 0;
+        virtual void visit(const Constraint::Polyadic&) = 0;
+    };
+
+    // Base class for navigation of requirements.
+    struct Requirement_visitor;
+
+    // -- Typically, the definition of a concept is expressed in terms of syntactic requirements.
+    // -- Those requirements are formulated as proof obliggations for the validity of stylized
+    // -- expressions (usage patterns).
+    struct Requirement {
+        struct Simple;                                  // *p = t;
+        struct Type;                                    // typename C::iterator;
+        struct Compound;                                // { &*p } -> same_as<T*>;
+        struct Nested;                                  // requires Trivial<C::iterator>;
+        virtual void accept(Requirement_visitor&) const = 0;
+    };
+
+    // An object of this type corresponds to an instance of the ISO C++ grammar production
+    // for simple-requirement:
+    //          expression `;`
+    struct Requirement::Simple : Requirement {
+        virtual const Expr& expr() const = 0;
+    };
+
+    // An object of this type corresponds to an instance of the ISO C++ grammar production
+    // for type-requirement:
+    //      `typename` nested-name-specifier_opt type-namexpression `;`
+    struct Requirement::Type : Requirement {
+        virtual Optional<Expr> scope() const = 0;
+        virtual const Name& type_name() const = 0;
+    };
+
+    // An object of this type corresponds to an instance of the ISO C++ grammar production
+    // for compound-requirement:
+    //      `{` expression `}` `noexcept`_opt return-type-requirement_opt `;`
+    // where the grammar production for return-type-requirement is
+    //     `->` type-constraint
+    struct Requirement::Compound : Requirement {
+        virtual const Expr& expr() const = 0;
+        virtual Optional<Constraint> constraint() const = 0;
+        virtual bool nothrow() const = 0;
+    };
+
+    // An object of this type corresponds to an instance of the ISO C++ grammar production
+    // for nested-requirement:
+    //      `requires` constant-expression `;`
+    struct Requirement::Nested : Requirement {
+        virtual const Expr& condition() const = 0;
+    };
+
+    struct Requirement_visitor {
+        virtual void visit(const Requirement::Simple&) = 0;
+        virtual void visit(const Requirement::Type&) = 0;
+        virtual void visit(const Requirement::Compound&) = 0;
+        virtual void visit(const Requirement::Nested&) = 0;
+    };
+
     // -- Abstraction of ISO C++ Declarators:
     // -- The C and C++ languages have tortuous grammars for declarations, whereby
     // -- declarations are structured to mimic use (operator precedence).  A declaration

--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -756,6 +756,83 @@ namespace ipr::impl {
 }
 
 namespace ipr::cxx_form::impl {
+   // -- implementation of ipr::cxx_form::Constraint
+   template<typename T>
+   struct Constraint : T, ipr::util::immotile {
+      using Interface = T;
+      void accept(Constraint_visitor& v) const final { v.visit(static_cast<const T&>(*this)); }
+   };
+
+   // -- implementation of ipr::cxx_form::Constraint::Monadic
+   struct Monadic_constraint : impl::Constraint<cxx_form::Constraint::Monadic> {
+      explicit Monadic_constraint(const ipr::Identifier& n) : id{n} { }
+      Monadic_constraint(const ipr::Expr& s, const ipr::Identifier& n) : outer{s}, id{n} { }
+      Optional<ipr::Expr> scope() const final { return outer; }
+      const ipr::Identifier& concept_name() const final { return id; }
+   private:
+      Optional<ipr::Expr> outer { };
+      const ipr::Identifier& id;
+   };
+
+   // -- implementation of ipr::cxx_form::Constraint::Polyadic
+   struct Polyadic_constraint : impl::Constraint<cxx_form::Constraint::Polyadic> {
+      ipr::impl::ref_sequence<ipr::Expr> args;
+      explicit Polyadic_constraint(const ipr::Identifier& n) : id{n} { }
+      Polyadic_constraint(const ipr::Expr& s, const ipr::Identifier& n) : outer{s}, id{n} { }
+      Optional<ipr::Expr> scope() const final { return outer; }
+      const ipr::Identifier& concept_name() const final { return id; }
+      const ipr::Sequence<ipr::Expr>& trailing_arguments() const final { return args; }
+   private:
+      Optional<ipr::Expr> outer { };
+      const ipr::Identifier& id;
+   };
+
+   // -- implementation of ipr::cxx_form::Requirement
+   template<typename T>
+   struct Requirement : T, ipr::util::immotile {
+      using Interface = T;
+      void accept(Requirement_visitor& v) const final { v.visit(static_cast<const T&>(*this)); }
+   };
+
+   // -- implementation of ipr::cxx_form::Requirement::Simple
+   struct Simple_requirement : impl::Requirement<cxx_form::Requirement::Simple> {
+      explicit Simple_requirement(const ipr::Expr& x) : pattern{x} { }
+      const ipr::Expr& expr() const final { return pattern; }
+   private:
+      const ipr::Expr& pattern;
+   };
+
+   // -- implementation of ipr::cxx_form::Requirement::Type
+   struct Type_requirement : impl::Requirement<cxx_form::Requirement::Type> {
+      explicit Type_requirement(const ipr::Name& n) : name{n} { }
+      Type_requirement(const ipr::Expr& s, const ipr::Name& n) : outer{s}, name{n} { }
+      Optional<ipr::Expr> scope() const final { return outer; }
+      const ipr::Name& type_name() const final { return name; }
+   private:
+      Optional<ipr::Expr> outer { };
+      const ipr::Name& name;
+   };
+
+   // -- implementation of ipr::cxx_form::Requirement::Compound
+   struct Compound_requirement : impl::Requirement<cxx_form::Requirement::Compound> {
+      Optional<cxx_form::Constraint> type;
+      bool has_noexcept = false;
+      explicit Compound_requirement(const ipr::Expr& x) : pattern{x} { }
+      const ipr::Expr& expr() const final { return pattern; }
+      Optional<cxx_form::Constraint> constraint() const final { return type; }
+      bool nothrow() const final { return has_noexcept; }
+   private:
+      const ipr::Expr& pattern;
+   };
+
+   // -- implementation of ipr::cxx_form::Requirement::Compound
+   struct Nested_requirement : impl::Requirement<cxx_form::Requirement::Nested> {
+      explicit Nested_requirement(const ipr::Expr& x) : cond{x} { }
+      const ipr::Expr& condition() const final { return cond; }
+   private:
+      const ipr::Expr& cond;
+   };
+
    // -- implementation of ipr::cxx_form::Indirector
    template<typename T>
    struct Indirector : T {
@@ -975,6 +1052,16 @@ namespace ipr::cxx_form::impl {
 
    // -- Factory of C++ declarator forms.
    struct form_factory {
+      Monadic_constraint* make_monadic_constraint(const ipr::Identifier&);
+      Monadic_constraint* make_monadic_constraint(const ipr::Expr&, const ipr::Identifier&);
+      Polyadic_constraint* make_polyadic_constraint(const ipr::Identifier&);
+      Polyadic_constraint* make_polyadic_constraint(const ipr::Expr&, const ipr::Identifier&);
+      Simple_requirement* make_simple_requirement(const ipr::Expr&);
+      Type_requirement* make_type_requirement(const ipr::Name&);
+      Type_requirement* make_type_requirement(const ipr::Expr&, const ipr::Name&);
+      Compound_requirement* make_compound_requirement(const ipr::Expr&);
+      Nested_requirement* make_nested_requirement(const ipr::Expr&);
+
       Pointer_indirector* make_pointer_indirector(ipr::Type_qualifiers);
       Reference_indirector* make_reference_indirector(Reference_flavor);
       Member_indirector* make_member_indirector(const ipr::Expr&, Type_qualifiers);
@@ -996,6 +1083,12 @@ namespace ipr::cxx_form::impl {
       Slot_designator* make_slot_designator(const ipr::Expr&);
 
    private:
+      ipr::impl::stable_farm<Monadic_constraint> monadic_constraints;
+      ipr::impl::stable_farm<Polyadic_constraint> polyadic_constraints;
+      ipr::impl::stable_farm<Simple_requirement> simple_reqs;
+      ipr::impl::stable_farm<Type_requirement> type_reqs;
+      ipr::impl::stable_farm<Compound_requirement> compound_reqs;
+      ipr::impl::stable_farm<Nested_requirement> nested_reqs;
       ipr::impl::stable_farm<Pointer_indirector> pointer_indirectors;
       ipr::impl::stable_farm<Reference_indirector> reference_indirectors;
       ipr::impl::stable_farm<Member_indirector> member_indirectors;
@@ -1556,6 +1649,15 @@ namespace ipr::impl {
       const ipr::Sequence<ipr::Capture_specification>& captures() const final { return env_spec; }
    };
 
+   struct Requires : immotile_node<ipr::Requires> {
+      impl::Parameter_list formals;
+      impl::ref_sequence<cxx_form::Requirement> requirements;
+      Requires(const ipr::Region& r, Mapping_level l) : formals{r, l} { }
+      const ipr::Type& type() const final;
+      const ipr::Parameter_list& parameters() const final { return formals; }
+      const ipr::Sequence<cxx_form::Requirement>& body() const final { return requirements; }
+   };
+
    using Address = Classic_unary_expr<ipr::Address>;
    using Array_delete = Classic_unary_expr<ipr::Array_delete>;
    using Complement = Classic_unary_expr<ipr::Complement>;
@@ -1586,6 +1688,11 @@ namespace ipr::impl {
    using Args_cardinality = Unary_expr<ipr::Args_cardinality>;
    using Typeid = Unary_expr<ipr::Typeid>;
    using Label = Unary_expr<ipr::Label>;
+
+   struct Restriction : Unary_node<ipr::Restriction> {
+      explicit Restriction(const ipr::Expr& x) : Unary_node<ipr::Restriction>{x} { }
+      const ipr::Type& type() const final;
+   };
 
    struct Id_expr : Unary_expr<ipr::Id_expr> {
       Optional<ipr::Expr> decls { };
@@ -2399,6 +2506,7 @@ namespace ipr::impl {
       Sizeof* make_sizeof(const ipr::Expr&, Optional<ipr::Type> = { });
       Args_cardinality* make_args_cardinality(const ipr::Expr&, Optional<ipr::Type> = { });
       Typeid* make_typeid(const ipr::Expr&, Optional<ipr::Type> = { });
+      Restriction* make_restriction(const ipr::Expr&);
       impl::Id_expr* make_id_expr(const ipr::Name&, Optional<ipr::Type> = {});
       Id_expr* make_id_expr(const ipr::Decl&);
       Label* make_label(const ipr::Identifier&, Optional<ipr::Type> = {});
@@ -2478,6 +2586,7 @@ namespace ipr::impl {
                                     const ipr::Expr&, Optional<ipr::Type> = {});
       Mapping* make_mapping(const ipr::Region&, Mapping_level);
       Lambda* make_lambda(const ipr::Region&, Mapping_level);
+      Requires* make_requires(const ipr::Region&, Mapping_level);
 
       Elementary_substitution* make_elementary_substitution(const ipr::Parameter&, const ipr::Expr&);
       General_substitution* make_general_substitution();
@@ -2528,6 +2637,7 @@ namespace ipr::impl {
       stable_farm<impl::Construction> constructions;
       stable_farm<impl::Noexcept> noexcepts;
       stable_farm<impl::Args_cardinality> cardinalities;
+      stable_farm<impl::Restriction> restrictions;
 
       stable_farm<impl::Rewrite> rewrites;
       stable_farm<impl::Scope_ref> scope_refs;
@@ -2588,6 +2698,7 @@ namespace ipr::impl {
       stable_farm<impl::Conditional> conds;
       stable_farm<impl::Mapping> mappings;
       stable_farm<impl::Lambda> lambdas;
+      stable_farm<impl::Requires> reqs;
 
       stable_farm<impl::Elementary_substitution> elem_substs;
       stable_farm<impl::General_substitution> gen_substs;

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -873,6 +873,12 @@ namespace ipr {
                                 // -- Args_cardinality --
    struct Args_cardinality : Unary<Category<Category_code::Args_cardinality>> { };
 
+                                // -- Restriction --
+   // Representation of what ISO C++ calls "requires-clause", an expression of the form
+   //      `requires` constant-expression
+   // at the input source level.  Not to be confusion with "requires-expression".
+   struct Restriction : Unary<Category<Category_code::Restriction>> { };
+
                                 // -- Noexcept --
    struct Noexcept : Unary<Category<Category_code::Noexcept>> { };
 
@@ -1307,6 +1313,15 @@ namespace ipr {
       virtual const Substitution& substitution() const = 0;
       virtual Optional<Expr> instance() const  = 0;
       const Type& type() const final { return instance().get().type(); }
+   };
+
+                                // -- Requires --
+   // Representation of a requires-expression.  Despite the presence of `parameters()`, this expression
+   // is not a parameterization of expressions in the conventional sense.  In particular the type of
+   // a requires-expression is never a mapping in any sense.  It is always `bool`.
+   struct Requires : Category<Category_code::Requires> {
+      virtual const Parameter_list& parameters() const = 0;
+      virtual const Sequence<cxx_form::Requirement>& body() const = 0;
    };
 
                                 // -- New --
@@ -1916,6 +1931,7 @@ namespace ipr {
       virtual void visit(const Phantom&);
       virtual void visit(const Eclipsis&);
       virtual void visit(const Lambda&);
+      virtual void visit(const Requires&);
 
       virtual void visit(const Symbol&);
       virtual void visit(const Address&);
@@ -1929,6 +1945,7 @@ namespace ipr {
       virtual void visit(const Alignof&);
       virtual void visit(const Sizeof&);
       virtual void visit(const Args_cardinality&);
+      virtual void visit(const Restriction&);
       virtual void visit(const Expr_stmt&);
       virtual void visit(const Typeid&);
       virtual void visit(const Id_expr&);

--- a/include/ipr/node-category
+++ b/include/ipr/node-category
@@ -53,6 +53,7 @@ Guide_name,                         // ipr::Guide_name
 Phantom,                            // ipr::Phantom
 Eclipsis,                           // ipr::Eclipsis
 Lambda,                             // ipr::Lambda
+Requires,                           // ipr::Requires
 
 Symbol,                             // ipr::Symbol
 Address,                            // ipr::Address
@@ -83,6 +84,7 @@ Unary_plus,                         // ipr::Unary_plus
 Expansion,                          // ipr::Expansion
 Noexcept,                           // ipr::Noexcept
 Args_cardinality,                   // ipr::Args_cardinality
+Restriction,                        // ipr::Restriction
 
 Rewrite,                            // ipr::Rewrite
 Scope_ref,                          // ipr::Scope_ref

--- a/include/ipr/synopsis
+++ b/include/ipr/synopsis
@@ -73,6 +73,7 @@ namespace ipr {
                                  // rethrow, empty parts of a For, etc...
    struct Eclipsis;              // the `...' in a unary fold
    struct Lambda;                // Lambda expression, packing an environment and a code pointer
+   struct Requires;              // requires-expression -- requires(T t) { ++t; }
 
    // -------------------------------------------------------
    // -- results of unary expression constructor constants --
@@ -108,6 +109,7 @@ namespace ipr {
    struct Expansion;             // pack expansion                    t...
    struct Noexcept;              // noexcept expression        noexcept(e)
    struct Args_cardinality;      // arguments count in a parameter pack: sizeof...(args)
+   struct Restriction;           // requires-clause           requires same_as<S, T>
 
    // --------------------------------------------------------
    // -- results of binary expression constructor constants --

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -197,6 +197,51 @@ namespace ipr::cxx_form::impl {
       : inputs{ parent, level }
    { }
 
+   Monadic_constraint* form_factory::make_monadic_constraint(const ipr::Identifier& n)
+   {
+      return monadic_constraints.make(n);
+   }
+
+   Monadic_constraint* form_factory::make_monadic_constraint(const ipr::Expr& s, const ipr::Identifier& n)
+   {
+      return monadic_constraints.make(s, n);
+   }
+
+   Polyadic_constraint* form_factory::make_polyadic_constraint(const ipr::Identifier& n)
+   {
+      return polyadic_constraints.make(n);
+   }
+
+   Polyadic_constraint* form_factory::make_polyadic_constraint(const ipr::Expr& s, const ipr::Identifier& n)
+   {
+      return polyadic_constraints.make(s, n);
+   }
+
+   Simple_requirement* form_factory::make_simple_requirement(const ipr::Expr& x)
+   {
+      return simple_reqs.make(x);
+   }
+
+   Type_requirement* form_factory::make_type_requirement(const ipr::Name& n)
+   {
+      return type_reqs.make(n);
+   }
+
+   Type_requirement* form_factory::make_type_requirement(const ipr::Expr& s, const ipr::Name& n)
+   {
+      return type_reqs.make(s, n);
+   }
+
+   Compound_requirement* form_factory::make_compound_requirement(const ipr::Expr& x)
+   {
+      return compound_reqs.make(x);
+   }
+
+   Nested_requirement* form_factory::make_nested_requirement(const ipr::Expr& x)
+   {
+      return nested_reqs.make(x);
+   }
+
    Pointer_indirector* form_factory::make_pointer_indirector(ipr::Type_qualifiers cv)
    {
       return pointer_indirectors.make(cv);
@@ -1233,6 +1278,9 @@ namespace ipr::impl {
          return decls;
       }
 
+      // -- impl::Restriction --
+      const ipr::Type& Restriction::type() const { return impl::builtin(Fundamental::Bool); }
+
       // ---------------
       // -- Enclosure --
       // ---------------
@@ -1276,6 +1324,9 @@ namespace ipr::impl {
       {
          inputs.parms.owned_by = this;
       }
+
+      // -- impl::Requires
+      const ipr::Type& Requires::type() const { return impl::builtin(Fundamental::Bool); }
 
       // -------------------------------
       // -- impl::Scope --
@@ -1722,6 +1773,11 @@ namespace ipr::impl {
          return make(cardinalities, e).with_type(t);
       }
 
+      impl::Restriction* expr_factory::make_restriction(const ipr::Expr& e)
+      {
+         return restrictions.make(e);
+      }
+
       impl::Typeid*
       expr_factory::make_typeid(const ipr::Expr& e, Optional<ipr::Type> t)
       {
@@ -2112,6 +2168,11 @@ namespace ipr::impl {
       impl::Lambda* expr_factory::make_lambda(const ipr::Region& r, Mapping_level l)
       {
          return lambdas.make(r, l);
+      }
+
+      impl::Requires* expr_factory::make_requires(const ipr::Region& r, Mapping_level l)
+      {
+         return reqs.make(r, l);
       }
 
       impl::Elementary_substitution*

--- a/src/traversal.cxx
+++ b/src/traversal.cxx
@@ -300,6 +300,11 @@ void ipr::Visitor::visit(const Lambda& e)
    visit(as<Expr>(e));
 }
 
+void ipr::Visitor::visit(const Requires& e)
+{
+   visit(as<Expr>(e));
+}
+
 void
 ipr::Visitor::visit(const Symbol& e)
 {
@@ -366,6 +371,11 @@ ipr::Visitor::visit(const Sizeof& e)
 
 void
 ipr::Visitor::visit(const Args_cardinality& e)
+{
+   visit(as<Expr>(e));
+}
+
+void ipr::Visitor::visit(const Restriction& e)
 {
    visit(as<Expr>(e));
 }


### PR DESCRIPTION
This patch adds representations (C++ forms) for C++20 constraints which are syntactic requirements on combinations of template arguments lists.

Fixes #181