### PR TITLE
Denotation for decl-specifier

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,9 +77,12 @@ target_compile_options(${PROJECT_NAME}
 
 target_compile_definitions(${PROJECT_NAME}
    PRIVATE
-	  $<$<PLATFORM_ID:UNIX>:
-		 _FILE_OFFSET_BITS=64 # We want the ability to process large files.
-	  >
+      $<$<CXX_COMPILER_ID:MSVC>:
+         MSVC_WORKAROUND_VSO1822505    # Workaround a compile-time evaluation bug in MSVC
+      >
+	   $<$<PLATFORM_ID:UNIX>:
+		   _FILE_OFFSET_BITS=64 # We want the ability to process large files.
+	   >
 )
 
 install(

--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -550,7 +550,7 @@ namespace ipr::impl{
    // The chain of declarations in a scope.
    struct scope_datum : util::rb_tree::link<scope_datum> {
       // The specifiers for this declaration.  S
-      ipr::DeclSpecifiers spec = { };
+      ipr::Specifiers spec = { };
 
       // Back-pointer to this declaration.  It shall be set at
       // the declaration creation.
@@ -728,7 +728,7 @@ namespace ipr::impl {
    template<class Interface>
    struct unique_decl : immotile_stmt<Interface> {
       unique_decl() : seq{*this} { }
-      ipr::DeclSpecifiers specifiers() const override { return DeclSpecifiers::None; }
+      ipr::Specifiers specifiers() const override { return { }; }
       const ipr::Decl& master() const final { return *this; }
       const ipr::Linkage& linkage() const final { return impl::cxx_linkage(); }
       const ipr::Sequence<ipr::Decl>& decl_set() const final { return seq; }
@@ -1500,7 +1500,7 @@ namespace ipr::impl {
 
       // Set declaration specifiers for this decl.
       using D::specifiers;
-      void specifiers(ipr::DeclSpecifiers s) {
+      void specifiers(ipr::Specifiers s) {
          decl_data.spec = s;
       }
    };
@@ -1509,7 +1509,7 @@ namespace ipr::impl {
       const ipr::Type& base;
       const ipr::Region& where;
       const Decl_position scope_pos;
-      ipr::DeclSpecifiers spec;
+      ipr::Specifiers spec;
 
       Base_type(const ipr::Type&, const ipr::Region&, Decl_position);
       const ipr::Type& type() const final { return base; }
@@ -1521,7 +1521,7 @@ namespace ipr::impl {
       const ipr::Region& home_region() const final { return where; }
       Decl_position position() const final { return scope_pos; }
       Optional<ipr::Expr> initializer() const final;
-      DeclSpecifiers specifiers() const final { return spec; }
+      Specifiers specifiers() const final { return spec; }
    };
 
    struct Enumerator final : unique_decl<ipr::Enumerator> {
@@ -1555,7 +1555,7 @@ namespace ipr::impl {
          return this->decl_data.master_data->overload->name;
       }
 
-      ipr::DeclSpecifiers specifiers() const final
+      ipr::Specifiers specifiers() const final
       {
          return this->decl_data.spec;
       }
@@ -2282,22 +2282,22 @@ namespace ipr::impl {
    // -- Implementation of directives --
    struct Specifiers_spread : impl::Directive<ipr::Specifiers_spread, Phases::Elaboration> {
       impl::ref_sequence<cxx_form::Proclamator> proc_seq;
-      ipr::DeclSpecifiers specs { };
+      ipr::Specifiers specs { };
 
       const ipr::Sequence<cxx_form::Proclamator>& targets() const final { return proc_seq; }
-      ipr::DeclSpecifiers specifiers() const final { return specs; }
+      ipr::Specifiers specifiers() const final { return specs; }
    };
 
    struct Structured_binding : impl::Directive<ipr::Structured_binding, Phases::Elaboration> {
       impl::ref_sequence<ipr::Identifier> ids;           // names in this structured binding
       util::ref<const ipr::Expr> init;                   // initializer of this structured binding
       impl::ref_sequence<ipr::Decl> decl_seq;            // declarations resulting from this structured binding
-      ipr::DeclSpecifiers specs { };                     // the non-type part of decl-specifier-seq in
+      ipr::Specifiers specs { };                         // the non-type part of decl-specifier-seq in
                                                          // this structured binding.  Note: `type()` contains the
                                                          // the type part of the decl-specifier-seq
       ipr::Binding_mode binding_mode { };                // the binding mode of this structured binding
 
-      ipr::DeclSpecifiers specifiers() const final { return specs; }
+      ipr::Specifiers specifiers() const final { return specs; }
       ipr::Binding_mode mode() const final { return binding_mode; }
       const ipr::Sequence<ipr::Identifier>& names() const final { return ids; }
       const ipr::Expr& initializer() const final { return init.get(); }
@@ -2822,6 +2822,27 @@ namespace ipr::impl {
 
       const ipr::Linkage& cxx_linkage() const final;
       const ipr::Linkage& c_linkage() const final;
+
+      Specifiers export_specifier() const final;
+      Specifiers static_specifier() const final;
+      Specifiers extern_specifier() const final;
+      Specifiers mutable_specifier() const final;
+      Specifiers thread_local_specifier() const final;
+      Specifiers register_specifier() const final;
+      Specifiers inline_specifier() const final; 
+      Specifiers constexpr_specifier() const final;
+      Specifiers consteval_specifier() const final;
+      Specifiers virtual_specifier() const final;
+      Specifiers abstract_specifier() const final;
+      Specifiers explicit_specifier() const final;
+      Specifiers friend_specifier() const final;
+      Specifiers typedef_specifier() const final;
+      Specifiers public_specifier() const final;
+      Specifiers protected_specifier() const final;
+      Specifiers private_specifier() const final;
+      ipr::Specifiers specifiers(ipr::Basic_specifier) const final;
+      std::vector<ipr::Basic_specifier> decompose(ipr::Specifiers) const final;
+
 
       const ipr::Template_id& get_template_id(const ipr::Expr&,
                                                 const ipr::Expr_list&);

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -13,6 +13,7 @@
 #include <iterator>
 #include <stdexcept>
 #include <type_traits>
+#include <vector>
 #include <ipr/utility>
 #include <ipr/synopsis>
 #include <ipr/ancillary>

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -160,67 +160,71 @@ namespace ipr {
       bool operator!=(const Transfer&) const = default;
    };
 
-                                // -- DeclSpecifiers --
-   enum class DeclSpecifiers : std::uint32_t {
-      None       = 0,
-      Register   = 1 << 0,   // Banned from C++17.
-      Static     = 1 << 1,
-      Extern     = 1 << 2,
-      Mutable    = 1 << 3,
-      Thread     = 1 << 4,
-      StorageClass  = Register | Static | Extern | Mutable | Thread,
-
-      Inline     = 1 << 5,
-      Virtual    = 1 << 6,   // also used as storage class specifier
-                             // for virtual base subobjects
-      Explicit   = 1 << 7,
-      Pure       = 1 << 8, 
-      FunctionSpecifier = Inline | Virtual | Explicit | Pure,
-
-      Friend     = 1 << 9,
-      Typedef    = 1 << 10,
-
-      Public     = 1 << 11,
-      Protected  = 1 << 12,
-      Private    = 1 << 13,
-      AccessProtection = Public | Protected | Private,
-
-      Export     = 1 << 14,  // For exported declarations.
-      Constexpr  = 1 << 15,  // C++ 11
-      Consteval  = 1 << 16,  // C++20
+   // -- Basic_specifier --
+   // A symbolic semantic denotation of an instance of a the C++ grammar for decl-specifier 
+   // that is not a defining-type-specifier.  This type is intended to capture the result of
+   // semantic elaboration, not mirror of a syntactic construct.
+   // Note: This symbolic form allows for extensions of decl-specifier beyond those explicitly
+   // listed in the C++ standards.
+   struct Basic_specifier {
+      constexpr Basic_specifier(const Logogram& l) : spec{&l} { }
+      constexpr const Logogram& logogram() const { return *spec; }
+      constexpr bool operator==(const Basic_specifier&) const = default;
+   private:
+      const Logogram* spec;
    };
 
-   constexpr DeclSpecifiers operator|(DeclSpecifiers a, DeclSpecifiers b)
+   // -- Specifiers --
+   // An algebraic denotation of sets of basic specifiers.
+   // ISO C++ requires that decl-specifiers can appear in any order in the decl-specifier-seq
+   // of a declaration in the input source program.  Furthermore, any such decl-specifier
+   // can appear at most once. Taken together, those requirements mean that a decl-specifier-seq
+   // is in fact a set of basic specifiers. Therefore, the set of standard basic specifiers act
+   // as a basis of the space of decl-specifier-seqs, and the coordinates or a decl-specifier-seq
+   // are numbers drown from ZZ/2ZZ.  The space of those coordinates is represented by `Specifiers`.
+   // This space is kept abstract to allow extensions beyond the restricted set of speecifiers
+   // listed in the ISO C++ standards.  For example, from the IPR model perspective the ISO C++
+   // access control label `public`, `protected`, `private` are basic specifiers.
+   enum class Specifiers : std::uintptr_t { };
+
+   template<util::EnumType T>
+   constexpr T operator|(T a, T b)
    {
-      return DeclSpecifiers(std::uint32_t(a) | std::uint32_t(b));
+      return T{util::rep(a) | util::rep(b)};
    }
 
-   constexpr DeclSpecifiers& operator|=(DeclSpecifiers& a, DeclSpecifiers b)
+   template<util::EnumType T>
+   constexpr T& operator|=(T& a, T b)
    {
       return a = a | b;
    }
 
-   constexpr DeclSpecifiers operator&(DeclSpecifiers a, DeclSpecifiers b)
+   template<util::EnumType T>
+   constexpr T operator&(T a, T b)
    {
-      return DeclSpecifiers(std::uint32_t(a) & std::uint32_t(b));
+      return T{util::rep(a) & util::rep(b)};
    }
 
-   constexpr DeclSpecifiers& operator&=(DeclSpecifiers& a, DeclSpecifiers b)
+   template<util::EnumType T>
+   constexpr T& operator&=(T& a, T b)
    {
       return a = a & b;
    }
 
-   constexpr DeclSpecifiers operator^(DeclSpecifiers a, DeclSpecifiers b)
+   template<util::EnumType T>
+   constexpr T operator^(T a, T b)
    {
-      return DeclSpecifiers(std::uint32_t(a) ^ std::uint32_t(b));
+      return T{util::rep(a) ^ util::rep(b)};
    }
 
-   constexpr DeclSpecifiers& operator^=(DeclSpecifiers& a, DeclSpecifiers b)
+   template<util::EnumType T>
+   constexpr T& operator^=(T& a, T b)
    {
       return a = a ^ b;
    }
 
-   constexpr bool implies(DeclSpecifiers a, DeclSpecifiers b)
+   template<util::EnumType T>
+   constexpr bool implies(T a, T b)
    {
       return (a & b) == b;
    }
@@ -265,6 +269,8 @@ namespace ipr {
       using iterator = util::word_view::const_iterator;
       using Index = std::size_t;
       virtual util::word_view characters() const = 0;
+      bool operator==(const String& s) const { return this == &s; }
+      bool operator!=(const String&) const = default;
       Index size() const { return characters().size(); }
       iterator begin() const { return characters().begin(); }
       iterator end() const { return characters().end(); }
@@ -1453,7 +1459,7 @@ namespace ipr {
    // - The type component of the decl-specifier-seq is given by `type()`.
    // - The non-type component of the decl-specifier-seq is given by `specifiers()`.
    struct Specifiers_spread : Category<Category_code::Specifiers_spread, Directive> {
-      virtual DeclSpecifiers specifiers() const = 0;
+      virtual Specifiers specifiers() const = 0;
       virtual const Sequence<cxx_form::Proclamator>& targets() const = 0;
    };
 
@@ -1462,7 +1468,7 @@ namespace ipr {
    // (either an Alias or a Var) in the current binding environment by taking apart
    // the object value designated by the initializer.
    struct Structured_binding : Category<Category_code::Structured_binding, Directive> {
-      virtual DeclSpecifiers specifiers() const = 0;
+      virtual Specifiers specifiers() const = 0;
       virtual Binding_mode mode() const = 0;
       virtual const Sequence<Identifier>& names() const = 0;
       virtual const Expr& initializer() const = 0;
@@ -1725,7 +1731,7 @@ namespace ipr {
    //     (a) a primary template; or
    //     (b) a non-template declaration.
    struct Decl : Stmt {
-      virtual DeclSpecifiers specifiers() const = 0;
+      virtual Specifiers specifiers() const = 0;
       virtual const Linkage& linkage() const = 0;
 
       virtual const Name& name() const = 0;
@@ -1928,6 +1934,26 @@ namespace ipr {
 
       virtual const Linkage& cxx_linkage() const = 0;          // constant for 'extern "C++"'
       virtual const Linkage& c_linkage() const = 0;            // constant for 'extern "C"'
+
+      virtual Specifiers export_specifier() const = 0;         // `export` specifier.
+      virtual Specifiers static_specifier() const = 0;         // `static` standard specifier.
+      virtual Specifiers extern_specifier() const = 0;         // `extern` standard specifier.
+      virtual Specifiers mutable_specifier() const = 0;        // `mutable` standard specifier.
+      virtual Specifiers thread_local_specifier() const = 0;   // `thread_local` standard specifier.
+      virtual Specifiers register_specifier() const = 0;       // `register` standard specifier -- banned from C++17 and up.
+      virtual Specifiers inline_specifier() const = 0;         // `inline` standard specifier.
+      virtual Specifiers constexpr_specifier() const = 0;      // `constexpr` standard specifier.
+      virtual Specifiers consteval_specifier() const = 0;      // `consteval` standard specifier.
+      virtual Specifiers virtual_specifier() const = 0;        // `virtual` standard specifier.
+      virtual Specifiers abstract_specifier() const = 0;       // for " = 0" virtual functions.
+      virtual Specifiers explicit_specifier() const = 0;       // `explicit` standard specifier.
+      virtual Specifiers friend_specifier() const = 0;         // `friend` standard specifier.
+      virtual Specifiers typedef_specifier() const = 0;        // `typedef` standard specifier.
+      virtual Specifiers public_specifier() const = 0;         // `public` specifier.
+      virtual Specifiers protected_specifier() const = 0;      // `protected` specifier.
+      virtual Specifiers private_specifier() const = 0;        // `private` specifier.
+      virtual Specifiers specifiers(Basic_specifier) const = 0;   // convert a basic specifier to its `Specifiers` coordinates.
+      virtual std::vector<Basic_specifier> decompose(Specifiers) const = 0;   // return the constituents of Specifiers.
    };
 
                                 // -- Visitor --

--- a/include/ipr/io
+++ b/include/ipr/io
@@ -51,7 +51,7 @@ namespace ipr
          None, Before, After
       };
 
-      explicit Printer(std::ostream&);
+      Printer(const Lexicon&, std::ostream&);
 
       Padding padding() const { return pad; }
 
@@ -62,11 +62,8 @@ namespace ipr
       int indent() const { return pending_indentation; }
       std::ostream& channel() { return stream; }
 
-      // This series of declarations cannot be adequately be reduced
-      // into one template declaration, because it would tend to
-      // take over all other good candidates when an implicit conversion
-      // would be needed.
       Printer& operator<<(const char8_t*);
+      Printer& operator<<(Specifiers);
       template<typename T> requires util::std_insertable<T>
       Printer& operator<<(T t) { stream << t; return *this; }
 
@@ -77,6 +74,7 @@ namespace ipr
 
 
    private:
+      const Lexicon& lexicon;
       std::ostream& stream;
       Padding pad;
       bool emit_newline;
@@ -121,6 +119,7 @@ namespace ipr
    Printer& operator<<(Printer&, const Translation_unit&);
 
    Printer& operator<<(Printer&, const Identifier&);
+   Printer& operator<<(Printer&, const Logogram&);
    Printer& operator<<(Printer&, Mapping_level);
    Printer& operator<<(Printer&, Decl_position);
 }

--- a/include/ipr/utility
+++ b/include/ipr/utility
@@ -21,8 +21,12 @@
 #include <string>
 
 namespace ipr::util {
+   // Predicate to detect enumeration types.
+   template<typename T>
+   concept EnumType = std::is_enum_v<T>;
+   
    // Return the value representation of an enumeration value.
-   template<typename T> requires std::is_enum_v<T>
+   template<typename T> requires EnumType<T>
    constexpr auto rep(T t)
    {
       return static_cast<std::underlying_type_t<T>>(t);

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -4,8 +4,6 @@
 // See LICENSE for copright and license notices.
 //
 
-#include <ipr/impl>
-#include <ipr/traversal>
 #include <new>
 #include <stdexcept>
 #include <algorithm>
@@ -15,6 +13,11 @@
 #include <utility>
 #include <cstring>
 #include <array>
+#include <bit>
+#include <vector>
+#include <ipr/impl>
+#include <ipr/traversal>
+#include <ipr/io>
 
 namespace ipr {
    const String& String::empty_string()
@@ -56,9 +59,10 @@ namespace ipr::impl {
           impl::String str;
        };
 
-        // A table of statically known words used in the internal representation.
+        // A table of statically reserved words used in the internal representation.
         constexpr std_identifier known_words[] {
            u8"...",
+           u8"=0",
            u8"C",
            u8"C++",
            u8"auto",
@@ -68,22 +72,38 @@ namespace ipr::impl {
            u8"char32_t",
            u8"char8_t",
            u8"class",
+           u8"consteval",
+           u8"constexpr",
+           u8"constinit",
            u8"default",
            u8"delete",
            u8"double",
            u8"enum",
+           u8"explicit",
+           u8"export",
+           u8"extern",
            u8"false",
            u8"float",
+           u8"friend",
+           u8"inline",
            u8"int",
            u8"long",
            u8"long double",
            u8"long long",
+           u8"mutable",
            u8"namespace",
            u8"nullptr",
+           u8"private",
+           u8"protected",
+           u8"public",
+           u8"register",
            u8"short",
            u8"signed char",
+           u8"static",
            u8"this",
+           u8"thread_local",
            u8"true",
+           u8"typedef",
            u8"typename",
            u8"union",
            u8"unsigned char",
@@ -91,6 +111,7 @@ namespace ipr::impl {
            u8"unsigned long",
            u8"unsigned long long",
            u8"unsigned short",
+           u8"virtual",
            u8"void",
            u8"wchar_t",
         };
@@ -131,6 +152,45 @@ namespace ipr::impl {
     }
 
     const ipr::Linkage& c_linkage() { return impl::c_link; }
+}
+
+// -- Standard basic specifiers
+namespace ipr::impl {
+   namespace {
+      constexpr ipr::Basic_specifier std_specifiers[] {
+         known_word(u8"=0"),
+         known_word(u8"export"),
+         known_word(u8"public"),
+         known_word(u8"protected"),
+         known_word(u8"private"),
+         known_word(u8"consteval"),
+         known_word(u8"constexpr"),
+         known_word(u8"constinit"),
+         known_word(u8"explicit"),
+         known_word(u8"extern"),
+         known_word(u8"friend"),
+         known_word(u8"inline"),
+         known_word(u8"mutable"),
+         known_word(u8"register"),
+         known_word(u8"static"),
+         known_word(u8"thread_local"),
+         known_word(u8"typedef"),
+         known_word(u8"virtual"),
+      };
+
+      // Ensure all basic specifiers are representable with the precision declared for ipr::Specifiers.
+      static_assert(std::size(std_specifiers) < std::bit_width(~std::underlying_type_t<ipr::Specifiers>{}));
+
+      // Retrieve a pointer to a decl-specifier if standard.
+      const Basic_specifier* specifier_if_known(util::word_view w)
+      {
+         for (auto& s : std_specifiers) {
+            if (s.logogram().what().characters() == w)
+               return &s;
+         }
+         return nullptr;
+      }
+   }
 }
 
 // -- Natural transfer: C++ language linkage, and natural calling convention.
@@ -1602,6 +1662,8 @@ namespace ipr::impl {
       {
          if (s.size() == 0)
             return invisible_logo;
+         else if (auto logo = word_if_known(s.characters()))
+            return *logo;
          constexpr auto lt = [](auto& x, auto& y) { return compare(x.what(), y); };
          return *logos.insert(s, lt);
       }
@@ -2285,6 +2347,65 @@ namespace ipr::impl {
 
       const ipr::Linkage& Lexicon::c_linkage() const { return impl::c_link; }
       const ipr::Linkage& Lexicon::cxx_linkage() const { return impl::cxx_link; }
+
+      namespace {
+         struct UnknownSpecifierError { const char8_t* specifier; };
+      }
+      // Helper function used to precompose known values of standard specifiers.
+      consteval ipr::Specifiers specifiers(const char8_t* s)
+      {
+         auto pos = 0;
+         for (auto& x : impl::std_specifiers) {
+            if (x.logogram().operand().characters() == s)
+               return ipr::Specifiers{1u << pos};
+            ++pos;
+         }
+         throw UnknownSpecifierError{s};
+      }
+
+      ipr::Specifiers Lexicon::export_specifier() const { return impl::specifiers(u8"export"); }
+      ipr::Specifiers Lexicon::static_specifier() const { return impl::specifiers(u8"static"); }
+      ipr::Specifiers Lexicon::extern_specifier() const { return impl::specifiers(u8"extern"); }
+      ipr::Specifiers Lexicon::mutable_specifier() const { return impl::specifiers(u8"mutable"); }
+      ipr::Specifiers Lexicon::thread_local_specifier() const { return impl::specifiers(u8"thread_local"); }
+      ipr::Specifiers Lexicon::register_specifier() const { return impl::specifiers(u8"register"); }
+      ipr::Specifiers Lexicon::inline_specifier() const { return impl::specifiers(u8"inline"); }
+      ipr::Specifiers Lexicon::consteval_specifier() const { return impl::specifiers(u8"consteval"); }
+      ipr::Specifiers Lexicon::constexpr_specifier() const { return impl::specifiers(u8"constexpr"); }
+      ipr::Specifiers Lexicon::virtual_specifier() const { return impl::specifiers(u8"virtual"); }
+      ipr::Specifiers Lexicon::abstract_specifier() const { return impl::specifiers(u8"=0"); }
+      ipr::Specifiers Lexicon::explicit_specifier() const { return impl::specifiers(u8"explicit"); }
+      ipr::Specifiers Lexicon::friend_specifier() const { return impl::specifiers(u8"friend"); }
+      ipr::Specifiers Lexicon::typedef_specifier() const { return impl::specifiers(u8"typedef"); }
+      ipr::Specifiers Lexicon::public_specifier() const { return impl::specifiers(u8"public"); }
+      ipr::Specifiers Lexicon::protected_specifier() const { return impl::specifiers(u8"protected"); }
+      ipr::Specifiers Lexicon::private_specifier() const { return impl::specifiers(u8"private"); }
+
+      ipr::Specifiers Lexicon::specifiers(ipr::Basic_specifier s) const
+      {
+         auto pos = 0;
+         for (auto& x : impl::std_specifiers) {
+            if (x == s)
+               return ipr::Specifiers{1u << pos};
+            ++pos;
+         }
+         // FIXME: Throw an exception to signal unknown basic specifier?
+         return { };
+      }
+
+      // Return the decomposition of a specifier in terms of its basic specifiers.
+      std::vector<ipr::Basic_specifier> Lexicon::decompose(ipr::Specifiers specs) const
+      {
+         std::vector<ipr::Basic_specifier> result;
+         int pos = 0;
+         for (auto& s : impl::std_specifiers) {
+            if (ipr::implies(specs, ipr::Specifiers{1u << pos}))
+               result.push_back(s);
+            ++pos;
+         }
+         return result;
+      }
+
 
       Lexicon::Lexicon() { }
       Lexicon::~Lexicon() { }

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -180,16 +180,6 @@ namespace ipr::impl {
 
       // Ensure all basic specifiers are representable with the precision declared for ipr::Specifiers.
       static_assert(std::size(std_specifiers) < std::bit_width(~std::underlying_type_t<ipr::Specifiers>{}));
-
-      // Retrieve a pointer to a decl-specifier if standard.
-      const Basic_specifier* specifier_if_known(util::word_view w)
-      {
-         for (auto& s : std_specifiers) {
-            if (s.logogram().what().characters() == w)
-               return &s;
-         }
-         return nullptr;
-      }
    }
 }
 

--- a/src/io.cxx
+++ b/src/io.cxx
@@ -60,9 +60,13 @@ namespace ipr {
       Printer& pp;
    };
 
-   Printer::Printer(std::ostream& os)
-         : stream(os), pad(Padding::None), emit_newline(false),
-           pending_indentation(0) { }
+   Printer::Printer(const Lexicon& lex, std::ostream& os)
+      : lexicon{lex}, 
+        stream{os},
+        pad{Padding::None},
+        emit_newline{false},
+        pending_indentation{0}
+   { }
 
    Printer&
    Printer::operator<<(const char8_t* s)
@@ -229,6 +233,11 @@ namespace ipr {
    operator<<(Printer& pp, const Identifier& id)
    {
       return pp << xpr_identifier(id.string());
+   }
+
+   Printer& operator<<(Printer& pp, const Logogram& l)
+   {
+      return pp << xpr_identifier(l.what());
    }
 
    // ------------------------------
@@ -1746,35 +1755,12 @@ namespace ipr {
    }
 
 
-   Printer&
-   operator<<(Printer& printer, DeclSpecifiers spec)
+   Printer& Printer::operator<<(Specifiers spec)
    {
-      if (implies(spec, DeclSpecifiers::Export))
-         printer << xpr_identifier(u8"export");
-      if (implies(spec, DeclSpecifiers::Register))
-         printer << xpr_identifier(u8"register");
-      if (implies(spec, DeclSpecifiers::Static))
-         printer << xpr_identifier(u8"static");
-      if (implies(spec, DeclSpecifiers::Extern))
-         printer << xpr_identifier(u8"extern");
-      if (implies(spec, DeclSpecifiers::Mutable))
-         printer << xpr_identifier(u8"mutable");
-      if (implies(spec, DeclSpecifiers::Inline))
-         printer << xpr_identifier(u8"inline");
-      if (implies(spec, DeclSpecifiers::Virtual))
-         printer << xpr_identifier(u8"virtual");
-      if (implies(spec, DeclSpecifiers::Explicit))
-         printer << xpr_identifier(u8"explicit");
-      if (implies(spec, DeclSpecifiers::Friend))
-         printer << xpr_identifier(u8"friend");
-      if (implies(spec, DeclSpecifiers::Public))
-         printer << xpr_identifier(u8"public");
-      if (implies(spec, DeclSpecifiers::Protected))
-         printer << xpr_identifier(u8"protected");
-      if (implies(spec, DeclSpecifiers::Private))
-         printer << xpr_identifier(u8"private");
+      for (auto s : lexicon.decompose(spec))
+         *this << s.logogram();
 
-      return printer;
+      return *this;
    }
 
 

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(${TEST_BINARY}
    region-owner.cxx
    warehouse.cxx
    phased-eval.cxx
+   specifiers.cxx
 )
 
 target_link_libraries(${TEST_BINARY}

--- a/tests/unit-tests/phased-eval.cxx
+++ b/tests/unit-tests/phased-eval.cxx
@@ -2,10 +2,9 @@
 
 #include <ipr/impl>
 
-using namespace ipr;
-
 TEST_CASE("asm-declaration")
 {
+    using namespace ipr;
     impl::Lexicon lexicon { };
 
     auto& s = lexicon.get_string(u8"yo!");
@@ -15,6 +14,7 @@ TEST_CASE("asm-declaration")
 
 TEST_CASE("static_assert-declaration")
 {
+    using namespace ipr;
     impl::Lexicon lexicon { };
     auto cond = lexicon.make_not(lexicon.false_value(), lexicon.bool_type());
     auto assert = lexicon.make_static_assert(*cond, lexicon.get_string(u8"wait! what?"));

--- a/tests/unit-tests/simple.cxx
+++ b/tests/unit-tests/simple.cxx
@@ -19,7 +19,7 @@ TEST_CASE("global constant variable can be printed") {
   var->init = lexicon.make_literal(lexicon.int_type(), u8"1024");
 
   std::stringstream ss;
-  Printer pp{ss};
+  Printer pp{lexicon, ss};
   pp << unit;
   CHECK(!ss.str().empty());
 }
@@ -42,7 +42,7 @@ TEST_CASE("Can create and print line numbers")
   var->src_locus = loc;
 
   std::stringstream ss;
-  Printer pp{ss};
+  Printer pp{lexicon, ss};
   pp << unit;
   // By default location printing is off
   CHECK(ss.str().find("F1:1:2") == std::string::npos);

--- a/tests/unit-tests/specifiers.cxx
+++ b/tests/unit-tests/specifiers.cxx
@@ -1,0 +1,86 @@
+#include <doctest/doctest.h>
+
+#include <ctime>
+#include <string_view>
+#include <sstream>
+#include <vector>
+#include <algorithm>
+#include <ipr/impl>
+#include <ipr/io>
+#include <ipr/utility>
+
+const std::vector<std::u8string_view> specs {
+    u8"export",
+    
+    u8"public",
+    u8"protected",
+    u8"private",
+
+    u8"static",
+    u8"extern",
+    u8"mutable",
+    u8"thread_local",
+    u8"register",
+
+    u8"virtual",
+    u8"explicit",
+
+    u8"friend",
+    u8"inline",
+    u8"consteval",
+    u8"constexpr",
+    u8"constinit",
+
+    u8"typedef",
+};
+
+TEST_CASE("individual basic specifier") {
+    using namespace ipr;
+    impl::Lexicon lexicon { };
+    impl::Module m {lexicon};
+    impl::Interface_unit unit {lexicon, m};
+
+    for (auto w : specs) {
+        auto& logo = lexicon.get_logogram(lexicon.get_string(w));
+        CHECK(logo.what().characters() == w);
+        auto spec = lexicon.specifiers(ipr::Basic_specifier{logo});
+        CHECK(spec != ipr::Specifiers{});
+
+        auto vec = lexicon.decompose(spec);
+        CHECK(vec.size() == 1);
+        CHECK(vec[0].logogram().what().characters() == w);
+  }
+}
+
+TEST_CASE("random combination of basic specifiers") {
+    using namespace ipr;
+    impl::Lexicon lexicon { };
+
+    std::srand(std::time(nullptr));
+    const auto spec_count = specs.size();
+    const auto sample_size = 1 + std::rand() % spec_count;
+    std::vector<std::u8string_view> test;
+    ipr::Specifiers specifiers { };
+    for (int i = 0; i < sample_size; ++i) {
+        auto w = specs[std::rand() % sample_size];
+        // Only add new specifier.
+        if (std::find(test.begin(), test.end(), w) < test.end())
+            continue;
+        test.push_back(w);
+        auto& logo = lexicon.get_logogram(lexicon.get_string(w));
+        specifiers |= lexicon.specifiers(ipr::Basic_specifier{logo});
+    }
+    CHECK(test.size() == std::popcount(util::rep(specifiers)));
+
+    auto elements = lexicon.decompose(specifiers);
+    CHECK(elements.size() == test.size());
+
+    std::ranges::sort(test);
+    constexpr auto cmp = [](auto& x, auto& y) { 
+        return x.logogram().what().characters() < y.logogram().what().characters(); 
+    };
+    std::ranges::sort(elements, cmp);
+    for (auto i = 0u; i < test.size(); ++i) {
+        CHECK(test[i] == elements[i].logogram().what().characters());
+    }
+}


### PR DESCRIPTION
This patch rewrites the representation of ISO C++ _decl-specifier-seq_ grammar instances in form of symbolic and algebraic denotations.  This allows non-standard extensions while retaining efficient manipulations of them as bitmasks.