### PR TITLE
Symbolic denotation of type qualifiers

### DIFF
--- a/include/ipr/ancillary
+++ b/include/ipr/ancillary
@@ -36,52 +36,10 @@ namespace ipr {
       All                  = ~0x0,
    };
 
-                                // -- Type_qualifier --
-   // cv-qualifiers are actually type operators.  Much of these operators
-   // currently make sense only for classic type -- although it might
-   // be interesting to explore the notion of pointer to overload-set
-   // or reference to such an expression.
-   enum class Type_qualifiers : std::uint8_t {
-      None             = 0,
-      Const            = 1 << 0,
-      Volatile         = 1 << 1,
-      Restrict         = 1 << 2        // not standard C++
-   };
-
-   constexpr Type_qualifiers operator|(Type_qualifiers a, Type_qualifiers b)
-   {
-      return Type_qualifiers(uint8_t(a) | uint8_t(b));
-   }
-
-   constexpr Type_qualifiers& operator|=(Type_qualifiers& a, Type_qualifiers b)
-   {
-      return a = a | b;
-   }
-
-   constexpr Type_qualifiers operator&(Type_qualifiers a, Type_qualifiers b)
-   {
-      return Type_qualifiers(uint8_t(a) & uint8_t(b));
-   }
-
-   constexpr Type_qualifiers& operator&=(Type_qualifiers& a, Type_qualifiers b)
-   {
-      return a = a & b;
-   }
-
-   constexpr Type_qualifiers operator^(Type_qualifiers a, Type_qualifiers b)
-   {
-      return Type_qualifiers(uint8_t(a) ^ uint8_t(b));
-   }
-
-   constexpr Type_qualifiers& operator^=(Type_qualifiers& a, Type_qualifiers b)
-   {
-      return a = a ^ b;
-   }
-
-   constexpr bool implies(Type_qualifiers a, Type_qualifiers b)
-   {
-      return (a & b) == b;
-   }
+   // -- Qualifiers --
+   // Abstract data type capturing compositions of standard and extended type qualifiers.
+   // Composition of type qualifiers is commutative.
+   enum class Qualifiers : std::uintptr_t { };
 
                                 // -- Binding_mode --
    // Mode of binding of a object value to a name (parameter, variable, alias, etc).

--- a/include/ipr/cxx-form
+++ b/include/ipr/cxx-form
@@ -156,7 +156,7 @@ namespace ipr::cxx_form {
     // And object of this type corresponds to the instance of the ptr-operator C++ grammar:
     //      `*` attribute-specifier-seq_opt cv-qualifier-seq_opt
     struct Indirector::Pointer : Indirector {
-        virtual Type_qualifiers qualifiers() const = 0;
+        virtual Qualifiers qualifiers() const = 0;
     };
 
     // Syntactic indication of reference binding flavor.
@@ -180,7 +180,7 @@ namespace ipr::cxx_form {
     //     nested-named-specifier `*` attribute-specifier-seq_opt cv-qualifier-seq_opt
     struct Indirector::Member : Indirector {
         virtual const Expr& scope() const = 0;
-        virtual Type_qualifiers qualifiers() const = 0;
+        virtual Qualifiers qualifiers() const = 0;
     };
 
     // Traversal of Indirector objects is facilitated by visitor classes deriving
@@ -326,7 +326,7 @@ namespace ipr::cxx_form {
     //    noptr-declarator parameters-and-qualifiers
     struct Morphism::Function : Morphism {
         virtual const Parameter_list& parameters() const = 0;
-        virtual Type_qualifiers qualifiers() const = 0;
+        virtual Qualifiers qualifiers() const = 0;
         virtual Binding_mode binding_mode() const = 0;
         virtual Optional<Expr> throws() const = 0;
     };

--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -873,10 +873,10 @@ namespace ipr::cxx_form::impl {
 
    // -- implementation of ipr::cxx_form::Indirector::Pointer
    struct Pointer_indirector : impl::Indirector<cxx_form::Indirector::Pointer> {
-      explicit Pointer_indirector(ipr::Type_qualifiers cv) : cv_quals{cv} { }
-      ipr::Type_qualifiers qualifiers() const final { return cv_quals; }
+      explicit Pointer_indirector(ipr::Qualifiers q) : quals{q} { }
+      ipr::Qualifiers qualifiers() const final { return quals; }
    private:
-      ipr::Type_qualifiers cv_quals;
+      ipr::Qualifiers quals;
    };
 
    // -- implementation of ipr::cxx_form::Indirector::Reference
@@ -889,12 +889,12 @@ namespace ipr::cxx_form::impl {
 
    // -- implementation of ipr::cxx_form::Indirector::Member
    struct Member_indirector : impl::Indirector<cxx_form::Indirector::Member> {
-      Member_indirector(const ipr::Expr& s, ipr::Type_qualifiers cv) : whole{s}, cv_quals{cv} { }
+      Member_indirector(const ipr::Expr& s, ipr::Qualifiers q) : whole{s}, quals{q} { }
       const ipr::Expr& scope() const final { return whole; }
-      ipr::Type_qualifiers qualifiers() const final { return cv_quals; }
+      ipr::Qualifiers qualifiers() const final { return quals; }
    private:
       const ipr::Expr& whole;
-      ipr::Type_qualifiers cv_quals;
+      ipr::Qualifiers quals;
    };
 
    // -- implementation of ipr::cxx_form::Morphism
@@ -910,12 +910,12 @@ namespace ipr::cxx_form::impl {
    struct Function_morphism : impl::Morphism<cxx_form::Morphism::Function> {
       ipr::impl::Parameter_list inputs;
       Optional<ipr::Expr> eh_spec;
-      Type_qualifiers cv_quals { };
+      ipr::Qualifiers quals { };
       Binding_mode ref_qual { };
       Function_morphism(const ipr::Region&, Mapping_level);
       const ipr::Parameter_list& parameters() const final { return inputs; }
       Optional<ipr::Expr> throws() const final { return eh_spec; }
-      Type_qualifiers qualifiers() const final { return cv_quals; }
+      ipr::Qualifiers qualifiers() const final { return quals; }
       Binding_mode binding_mode() const final { return ref_qual; }
    };
 
@@ -1091,9 +1091,9 @@ namespace ipr::cxx_form::impl {
       Compound_requirement* make_compound_requirement(const ipr::Expr&);
       Nested_requirement* make_nested_requirement(const ipr::Expr&);
 
-      Pointer_indirector* make_pointer_indirector(ipr::Type_qualifiers);
+      Pointer_indirector* make_pointer_indirector(ipr::Qualifiers);
       Reference_indirector* make_reference_indirector(Reference_flavor);
-      Member_indirector* make_member_indirector(const ipr::Expr&, Type_qualifiers);
+      Member_indirector* make_member_indirector(const ipr::Expr&, ipr::Qualifiers);
       Unqualified_id_species* make_unqualified_id_species();
       Unqualified_id_species* make_unqualified_id_species(const ipr::Name&);
       Pack_species* make_pack_species();
@@ -2225,7 +2225,7 @@ namespace ipr::impl {
       const ipr::As_type& get_as_type(const ipr::Expr&, const ipr::Transfer&);
 
       const ipr::Array& get_array(const ipr::Type&, const ipr::Expr&);
-      const ipr::Qualified& get_qualified(ipr::Type_qualifiers, const ipr::Type&);
+      const ipr::Qualified& get_qualified(ipr::Qualifiers, const ipr::Type&);
       const ipr::Decltype& get_decltype(const ipr::Expr&);
       const ipr::Tor& get_tor(const ipr::Product&, const ipr::Sum&);
       const ipr::Function& get_function(const ipr::Product&, const ipr::Type&);
@@ -2623,9 +2623,8 @@ namespace ipr::impl {
       Plus* make_plus(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
       Plus_assign* make_plus_assign(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
       Pretend* make_pretend(const ipr::Expr&, const ipr::Type&, const ipr::Type&);
-      Qualification* make_qualification(const ipr::Expr&, ipr::Type_qualifiers, const ipr::Type&);
-      Reinterpret_cast* make_reinterpret_cast(const ipr::Type&,
-                                                const ipr::Expr&);
+      Qualification* make_qualification(const ipr::Expr&, ipr::Qualifiers, const ipr::Type&);
+      Reinterpret_cast* make_reinterpret_cast(const ipr::Type&, const ipr::Expr&);
       Scope_ref* make_scope_ref(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
       Rshift* make_rshift(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
       Rshift_assign* make_rshift_assign(const ipr::Expr&, const ipr::Expr&, Optional<ipr::Type> = {});
@@ -2823,26 +2822,31 @@ namespace ipr::impl {
       const ipr::Linkage& cxx_linkage() const final;
       const ipr::Linkage& c_linkage() const final;
 
-      Specifiers export_specifier() const final;
-      Specifiers static_specifier() const final;
-      Specifiers extern_specifier() const final;
-      Specifiers mutable_specifier() const final;
-      Specifiers thread_local_specifier() const final;
-      Specifiers register_specifier() const final;
-      Specifiers inline_specifier() const final; 
-      Specifiers constexpr_specifier() const final;
-      Specifiers consteval_specifier() const final;
-      Specifiers virtual_specifier() const final;
-      Specifiers abstract_specifier() const final;
-      Specifiers explicit_specifier() const final;
-      Specifiers friend_specifier() const final;
-      Specifiers typedef_specifier() const final;
-      Specifiers public_specifier() const final;
-      Specifiers protected_specifier() const final;
-      Specifiers private_specifier() const final;
+      ipr::Specifiers export_specifier() const final;
+      ipr::Specifiers static_specifier() const final;
+      ipr::Specifiers extern_specifier() const final;
+      ipr::Specifiers mutable_specifier() const final;
+      ipr::Specifiers thread_local_specifier() const final;
+      ipr::Specifiers register_specifier() const final;
+      ipr::Specifiers inline_specifier() const final; 
+      ipr::Specifiers constexpr_specifier() const final;
+      ipr::Specifiers consteval_specifier() const final;
+      ipr::Specifiers virtual_specifier() const final;
+      ipr::Specifiers abstract_specifier() const final;
+      ipr::Specifiers explicit_specifier() const final;
+      ipr::Specifiers friend_specifier() const final;
+      ipr::Specifiers typedef_specifier() const final;
+      ipr::Specifiers public_specifier() const final;
+      ipr::Specifiers protected_specifier() const final;
+      ipr::Specifiers private_specifier() const final;
       ipr::Specifiers specifiers(ipr::Basic_specifier) const final;
       std::vector<ipr::Basic_specifier> decompose(ipr::Specifiers) const final;
 
+      ipr::Qualifiers const_qualifier() const final;
+      ipr::Qualifiers volatile_qualifier() const final;
+      ipr::Qualifiers restrict_qualifier() const final;
+      ipr::Qualifiers qualifiers(ipr::Basic_qualifier) const final;
+      std::vector<ipr::Basic_qualifier> decompose(ipr::Qualifiers) const final;
 
       const ipr::Template_id& get_template_id(const ipr::Expr&,
                                                 const ipr::Expr_list&);

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -188,6 +188,20 @@ namespace ipr {
    // access control label `public`, `protected`, `private` are basic specifiers.
    enum class Specifiers : std::uintptr_t { };
 
+   // -- Basic_qualifier --
+   // Symbolic semantic denotation of a type qualifier.  Note that a type qualifier is a monadic
+   // type constructor.  The set of ISO C++ type qualifiers is { `const`, `volatile` }.  In practice,
+   // C++ implementations support more type qualifiers, including ISO C's `restrict`.  The name
+   // of the qualifier is indicated by the `logogram()` operation.
+   struct Basic_qualifier {
+      constexpr Basic_qualifier(const Logogram& l) : qual{&l} { }
+      constexpr const Logogram& logogram() const { return *qual; }
+      constexpr bool operator==(const Basic_qualifier&) const = default;
+   private:
+      const Logogram* qual;
+   };
+
+   // Algebraic operations on symbolic denotations expressed as bitwise operations (i.e. ZZ/2ZZ).
    template<util::EnumType T>
    constexpr T operator|(T a, T b)
    {
@@ -639,7 +653,7 @@ namespace ipr {
    // We also maintain the invariant that Qualified::qualifiers is never
    // Type::None, consequently it is an error to attempt to create such a node.
    struct Qualified : Binary<Category<Category_code::Qualified, Type>,
-                             ipr::Type_qualifiers, const Type&> {
+                             ipr::Qualifiers, const Type&> {
       Arg1_type qualifiers() const { return first(); }
       Arg2_type main_variant() const { return second(); }
    };
@@ -1290,7 +1304,7 @@ namespace ipr {
 
                                 // -- Qualification --
    // A conversion that add cv-qualifiers
-   struct Qualification : Binary<Category<Category_code::Qualification>, const Expr&, Type_qualifiers> {
+   struct Qualification : Binary<Category<Category_code::Qualification>, const Expr&, Qualifiers> {
       Arg1_type expr() const { return first(); }
       Arg2_type qualifiers() const { return second(); }
    };
@@ -1955,6 +1969,12 @@ namespace ipr {
       virtual Specifiers private_specifier() const = 0;        // `private` specifier.
       virtual Specifiers specifiers(Basic_specifier) const = 0;   // convert a basic specifier to its `Specifiers` coordinates.
       virtual std::vector<Basic_specifier> decompose(Specifiers) const = 0;   // return the constituents of Specifiers.
+
+      virtual Qualifiers const_qualifier() const = 0;             // `const` cv-qualifier.
+      virtual Qualifiers volatile_qualifier() const = 0;          // `volatile` cv-qualifier.
+      virtual Qualifiers restrict_qualifier() const = 0;          // `restrict` cv-qualifier.
+      virtual Qualifiers qualifiers(Basic_qualifier) const = 0;   // retrieve the algebraic coordinate of a named qualifier.
+      virtual std::vector<Basic_qualifier> decompose(Qualifiers) const = 0;   // retrieve the constituents of Qualifiers.
    };
 
                                 // -- Visitor --

--- a/include/ipr/io
+++ b/include/ipr/io
@@ -64,6 +64,7 @@ namespace ipr
 
       Printer& operator<<(const char8_t*);
       Printer& operator<<(Specifiers);
+      Printer& operator<<(Qualifiers);
       template<typename T> requires util::std_insertable<T>
       Printer& operator<<(T t) { stream << t; return *this; }
 

--- a/include/ipr/utility
+++ b/include/ipr/utility
@@ -24,12 +24,16 @@ namespace ipr::util {
    // Predicate to detect enumeration types.
    template<typename T>
    concept EnumType = std::is_enum_v<T>;
+
+   // The underlying type of an enumeration
+   template<EnumType T>
+   using raw = std::underlying_type_t<T>;
    
    // Return the value representation of an enumeration value.
    template<typename T> requires EnumType<T>
    constexpr auto rep(T t)
    {
-      return static_cast<std::underlying_type_t<T>>(t);
+      return static_cast<raw<T>>(t);
    }
 
    // A predicate for types with values that can be inserted into standard streams.

--- a/src/io.cxx
+++ b/src/io.cxx
@@ -1308,17 +1308,11 @@ namespace ipr {
       return pp;
    }
 
-   Printer&
-   operator<<(Printer& printer, Type_qualifiers cv)
+   Printer& Printer::operator<<(Qualifiers quals)
    {
-      if (implies(cv, Type_qualifiers::Const))
-         printer << xpr_identifier(u8"const");
-      if (implies(cv, Type_qualifiers::Volatile))
-         printer << xpr_identifier(u8"volatile");
-      if (implies(cv, Type_qualifiers::Restrict))
-         printer << xpr_identifier(u8"restrict");
-
-      return printer;
+      for (auto q : lexicon.decompose(quals))
+         *this << q.logogram();
+      return *this;
    }
 
    struct xpr_type_expr {

--- a/tests/unit-tests/conversions.cxx
+++ b/tests/unit-tests/conversions.cxx
@@ -25,7 +25,7 @@ TEST_CASE("C++ Standard Conversions") {
   INFO("int* const ptr = 0;");
   // Pointer Conversion            (Coercion)
   const auto& ptr_type = lexicon.get_qualified(
-    Type_qualifiers::Const, lexicon.get_pointer(lexicon.int_type()));
+    lexicon.const_qualifier(), lexicon.get_pointer(lexicon.int_type()));
   auto& ptr = *unit.global_region()->declare_var(lexicon.get_identifier(u8"ptr"), ptr_type);
   ptr.init = lexicon.make_coercion(
     *lexicon.make_literal(lexicon.int_type(), u8"0"),
@@ -110,19 +110,19 @@ TEST_CASE("CV Conversions") {
   INFO("(int) -> (volatile int)");
   lexicon.make_qualification(
     *lexicon.make_literal(lexicon.int_type(), u8"7"),
-    Type_qualifiers::Volatile,
+    lexicon.volatile_qualifier(),
     lexicon.int_type() // prvalue can be adjusted to remove qualifiers (see 7.2.2/2)
   );
 
   INFO("const int* ptr;");
   const auto& ptr_type = lexicon.get_qualified(
-    Type_qualifiers::Const, lexicon.get_pointer(lexicon.int_type()));
+    lexicon.const_qualifier(), lexicon.get_pointer(lexicon.int_type()));
   auto& ptr = *unit.global_region()->declare_var(lexicon.get_identifier(u8"ptr"), ptr_type);
 
   // Removal of const is a non-implicit conversion
   INFO("const_cast<int* const>(ptr);");
   lexicon.make_const_cast(
-    lexicon.get_qualified(Type_qualifiers::Const, lexicon.get_pointer(lexicon.int_type())),
+    lexicon.get_qualified(lexicon.const_qualifier(), lexicon.get_pointer(lexicon.int_type())),
     *lexicon.make_id_expr(ptr)
   );
 
@@ -135,18 +135,18 @@ TEST_CASE("CV Conversions") {
   lexicon.make_qualification(
     *lexicon.make_qualification(
       *lexicon.make_id_expr(ptr_ptr),
-      Type_qualifiers::Const,
-      lexicon.get_qualified(Type_qualifiers::Const, ptr_ptr.type())
+      lexicon.const_qualifier(),
+      lexicon.get_qualified(lexicon.const_qualifier(), ptr_ptr.type())
     ),
-    Type_qualifiers::Const,
-    lexicon.get_pointer(lexicon.get_qualified(Type_qualifiers::Const,
+    lexicon.const_qualifier(),
+    lexicon.get_pointer(lexicon.get_qualified(lexicon.const_qualifier(),
       lexicon.get_pointer(lexicon.int_type())))
       // prvalue can be adjusted to remove qualifier on top-level (see 7.2.2/2)
   );
 
   INFO("const int var = 0;");
   auto& var = *unit.global_region()->declare_var(lexicon.get_identifier(u8"var"), 
-    lexicon.get_qualified(Type_qualifiers::Const, lexicon.int_type()));
+    lexicon.get_qualified(lexicon.const_qualifier(), lexicon.int_type()));
 
   // Pretend can be used to explicitly reperesent automatic type adjustment as detailed
   // in (7.2.2/2). Compilers are likely to just apply this adjustment on constraints without
@@ -156,7 +156,7 @@ TEST_CASE("CV Conversions") {
   lexicon.make_pretend(
     *lexicon.make_address(
       *lexicon.make_id_expr(var),
-      &lexicon.get_qualified(Type_qualifiers::Const, lexicon.int_type())
+      &lexicon.get_qualified(lexicon.const_qualifier(), lexicon.int_type())
     ),
     lexicon.int_type(),
     lexicon.int_type()

--- a/tests/unit-tests/simple.cxx
+++ b/tests/unit-tests/simple.cxx
@@ -14,7 +14,7 @@ TEST_CASE("global constant variable can be printed") {
   impl::Scope* global_scope = unit.global_scope();
 
   auto& name = lexicon.get_identifier(u8"bufsz");
-  auto& type = lexicon.get_qualified(Type_qualifiers::Const, lexicon.int_type());
+  auto& type = lexicon.get_qualified(lexicon.const_qualifier(), lexicon.int_type());
   impl::Var* var = global_scope->make_var(name, type);
   var->init = lexicon.make_literal(lexicon.int_type(), u8"1024");
 
@@ -34,7 +34,7 @@ TEST_CASE("Can create and print line numbers")
   impl::Scope* global_scope = unit.global_scope();
 
   auto& name = lexicon.get_identifier(u8"bufsz");
-  auto& type = lexicon.get_qualified(Type_qualifiers::Const, lexicon.int_type());
+  auto& type = lexicon.get_qualified(lexicon.const_qualifier(), lexicon.int_type());
   impl::Var* var = global_scope->make_var(name, type);
   var->init = lexicon.make_literal(lexicon.int_type(), u8"1024");
 


### PR DESCRIPTION
Just like the case of _decl-specifier-seq_ , this patch rewrites the representation of type qualifiers in both symbolic and algebraic form, offering both extensions (for vendor-specific type qualifiers) and efficiency (operations remain bitmask operations).

This patch introduces source-level breaking changes.