### PR TITLE
Add `ipr::input::SourceFile`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(
-   VERSION 3.24
+   VERSION 3.28
 )
 include(CheckIPOSupported)
 
@@ -30,6 +30,7 @@ add_library(${PROJECT_NAME}
    src/impl.cxx
    src/io.cxx
    src/traversal.cxx
+   src/input.cxx
    src/utility.cxx
 )
 
@@ -52,6 +53,7 @@ target_sources(${PROJECT_NAME}
         ${PROJECT_SOURCE_DIR}/include/ipr/synopsis
         ${PROJECT_SOURCE_DIR}/include/ipr/traversal
         ${PROJECT_SOURCE_DIR}/include/ipr/utility
+        ${PROJECT_SOURCE_DIR}/include/ipr/input
         ${PROJECT_SOURCE_DIR}/3rdparty/doctest/doctest.h
 )
 

--- a/include/ipr/input
+++ b/include/ipr/input
@@ -1,0 +1,51 @@
+// -*- C++ -*-
+//
+// This file is part of The Pivot framework.
+// Written by Gabriel Dos Reis.
+// See LICENSE for copyright and license notices.
+//
+
+#include <cstddef>
+#include <span>
+#include <filesystem>
+
+namespace ipr::input {
+    // Type for the error code values used by the host OS.
+#ifdef _WIN32
+    using ErrorCode = DWORD;
+#else
+    using ErrorCode = int;
+#endif
+
+    // String type preferred by the host OS to specify pathnames.
+    using SystemPath = std::filesystem::path::string_type;
+
+    // Exception type used to signal inability of the host OS to access a file.
+    struct AccessError {
+        SystemPath path;
+        ErrorCode error_code;
+    };
+
+    // Exception type used to signal the file designated by th `path` is not a regular file.
+    struct RegularFileError {
+        SystemPath path;
+    };
+
+    // Exception type used to signal inability of the host OS to memory-map a file.
+    struct FileMappingError {
+        SystemPath path;
+        ErrorCode error_code;
+    };
+
+    // Input source file mapped to memory as sequence of raw bytes.
+    struct SourceFile {
+        using View = std::span<const std::byte>;
+        
+        explicit SourceFile(const SystemPath&);
+        SourceFile(SourceFile&&);
+        ~SourceFile();
+        View bytes() const { return view; }
+    private:
+        View view;
+    };
+}

--- a/src/input.cxx
+++ b/src/input.cxx
@@ -1,0 +1,95 @@
+//
+// This file is part of The Pivot framework.
+// Written by Gabriel Dos Reis.
+// See LICENSE for copright and license notices.
+//
+
+#ifdef _WIN32
+#  include <windows.h>
+#else
+#  include <sys/stat.h>
+#  include <sys/mman.h>
+#  include <fcntl.h>
+#  include <unistd.h>
+#endif
+
+#include <ipr/input>
+
+namespace ipr::input {
+#ifdef _WIN32
+    // Helper type for automatically closing a handle on scope exit.
+    struct SystemHandle {
+        SystemHandle(HANDLE h) : handle{h} { }
+        bool valid() const { return handle != INVALID_HANDLE_VALUE; }
+        auto get_handle() const { return handle; }
+        ~SystemHandle()
+        {
+            if (valid())
+                CloseHandle(handle);
+        }
+    private:
+        HANDLE handle;
+    };
+#endif
+
+    SourceFile::SourceFile(const SystemPath& path)
+    {
+#ifdef _WIN32
+        // FIXME: Handle the situation of large files in a 32-bit program.
+        static_assert(sizeof(LARGE_INTEGER) == sizeof(std::size_t));
+
+        SystemHandle file = CreateFileW(path.c_str(), GENERIC_READ, 0, nullptr,
+                                        OPEN_EXISTING,
+                                        FILE_ATTRIBUTE_NORMAL, nullptr);
+        if (not file.valid())
+            throw AccessError{ path, GetLastError() };
+        LARGE_INTEGER s { };
+        if (not GetFileSizeEx(file.get_handle(), &s))
+            throw AccessError{ path, GetLastError() };
+        if (s.QuadPart)
+            return;
+        SystemHandle mapping = CreateFileMapping(file.get_handle(), nullptr, PAGE_READONLY, 0, 0, nullptr);
+        if (mapping.get_handle() == nullptr)
+            throw FileMappingError{ path, GetLastError() };
+        auto start = MapViewOfFile(mapping.get_handle(), FILE_MAP_READ, 0, 0, 0);
+        view = { reinterpret_cast<const std::byte*>(start), static_cast<View::size_type>(s.QuadPart) };
+#else
+        struct stat s { };
+        errno = 0;
+        if (stat(path.c_str(), &s) < 0)
+            throw AccessError{ path, errno };
+        else if (not S_ISREG(s.st_mode))
+            throw RegularFileError{ path };
+
+        // Don't labor too hard with empty files.
+        if (s.st_size == 0)
+            return;
+        
+        auto fd = open(path.c_str(), O_RDONLY);
+        if (fd < 0)
+            throw AccessError{ path, errno };
+        auto start = mmap(nullptr, s.st_size, PROT_READ, MAP_PRIVATE, fd, 0);
+        close(fd);
+        if (start == MAP_FAILED)
+            throw FileMappingError{ path };
+        view = { reinterpret_cast<std::byte*>(start), static_cast<View::size_type>(s.st_size) };
+#endif
+    }
+
+    SourceFile::SourceFile(SourceFile&& src) : view{src.view}
+    {
+        src.view = { };
+    }
+
+    SourceFile::~SourceFile()
+    {
+        if (not view.empty())
+        {
+#ifdef _WIN32
+            UnmapViewOfFile(view.data());
+#else
+            munmap(const_cast<std::byte*>(view.data()), view.size());
+#endif
+        }
+    }
+}

--- a/tests/unit-tests/specifiers.cxx
+++ b/tests/unit-tests/specifiers.cxx
@@ -5,6 +5,7 @@
 #include <sstream>
 #include <vector>
 #include <algorithm>
+#include <ranges>
 #include <ipr/impl>
 #include <ipr/io>
 #include <ipr/utility>
@@ -61,7 +62,7 @@ TEST_CASE("random combination of basic specifiers") {
     const auto sample_size = 1 + std::rand() % spec_count;
     std::vector<std::u8string_view> test;
     ipr::Specifiers specifiers { };
-    for (int i = 0; i < sample_size; ++i) {
+    for (auto i[[maybe_unused]] : std::views::iota(0u, sample_size)) {
         auto w = specs[std::rand() % sample_size];
         // Only add new specifier.
         if (std::find(test.begin(), test.end(), w) < test.end())


### PR DESCRIPTION
The data type `ipr::input::SourceFile` abstracts away the ceremonies of memory mapping an input source file into memory as a sequence of raw bytes.