### PR TITLE
Resolve SA alert 4447

### DIFF
--- a/include/ipr/input
+++ b/include/ipr/input
@@ -42,7 +42,7 @@ namespace ipr::input {
         using View = std::span<const std::byte>;
         
         explicit SourceFile(const SystemPath&);
-        SourceFile(SourceFile&&);
+        SourceFile(SourceFile&&) noexcept;
         ~SourceFile();
         View bytes() const { return view; }
     private:

--- a/src/input.cxx
+++ b/src/input.cxx
@@ -76,7 +76,7 @@ namespace ipr::input {
 #endif
     }
 
-    SourceFile::SourceFile(SourceFile&& src) : view{src.view}
+    SourceFile::SourceFile(SourceFile&& src) noexcept : view{src.view}
     {
         src.view = { };
     }


### PR DESCRIPTION
Mark `ipr::input::SourceFile` move constructor as noexcept.