### PR TITLE
Rename `ipr::Linkgage` to `ipr::Language_linkage`

### DIFF
--- a/include/ipr/impl
+++ b/include/ipr/impl
@@ -160,21 +160,21 @@ namespace ipr::impl {
    using Transfer = impl::Basic_binary<ipr::Transfer>;
 
    // -- Specialized implementation of ipr::Transfer
-   // An object of this class pairs a specified linkage with the natural
+   // An object of this class pairs a specified language linkage with the natural
    // C++ calling convention.
    struct Transfer_from_linkage : ipr::Transfer {
-      constexpr explicit Transfer_from_linkage(const ipr::Linkage& l) : link{l} { }
-      const ipr::Linkage& first() const final { return link; }
+      constexpr explicit Transfer_from_linkage(const ipr::Language_linkage& l) : link{l} { }
+      const ipr::Language_linkage& first() const final { return link; }
       const ipr::Calling_convention& second() const final;
    private:
-      const ipr::Linkage& link;
+      const ipr::Language_linkage& link;
    };
 
    // -- Specialized implementation of ipr::Transfer
    // An object of this class pairs the C++ language linkage with a specified calling convention.
    struct Transfer_from_cc : ipr::Transfer {
       constexpr explicit Transfer_from_cc(const ipr::Calling_convention& cc) : conv{cc} { }
-      const ipr::Linkage& first() const final;
+      const ipr::Language_linkage& first() const final;
       const ipr::Calling_convention& second() const final { return conv; }
    private:
       const ipr::Calling_convention& conv;
@@ -441,8 +441,8 @@ namespace ipr::impl {
    const ipr::Transfer& cxx_transfer();
 
    // The two language linkages required of all C++ implementations.
-   const ipr::Linkage& c_linkage();
-   inline const ipr::Linkage& cxx_linkage() { return cxx_transfer().linkage(); }
+   const ipr::Language_linkage& c_linkage();
+   inline const ipr::Language_linkage& cxx_linkage() { return cxx_transfer().language_linkage(); }
 
    // The type of types, including itselt.
    // Yes, we have a ``Type: Type'' problem.
@@ -730,7 +730,7 @@ namespace ipr::impl {
       unique_decl() : seq{*this} { }
       ipr::Specifiers specifiers() const override { return { }; }
       const ipr::Decl& master() const final { return *this; }
-      const ipr::Linkage& linkage() const final { return impl::cxx_linkage(); }
+      const ipr::Language_linkage& language_linkage() const final { return impl::cxx_linkage(); }
       const ipr::Sequence<ipr::Decl>& decl_set() const final { return seq; }
    private:
       singleton_ref<ipr::Decl> seq;
@@ -1327,7 +1327,7 @@ namespace ipr::impl {
       return compare(lhs.what(), rhs.what());
    }
 
-   inline int compare(const ipr::Linkage& lhs, const ipr::Linkage& rhs)
+   inline int compare(const ipr::Language_linkage& lhs, const ipr::Language_linkage& rhs)
    {
       return compare(lhs.language(), rhs.language());
    }
@@ -1389,7 +1389,7 @@ namespace ipr::impl {
    struct master_decl_data : basic_decl_data<Interface>, overload_entry {
       // The declaration that is considered to be the definition.
       Optional<Interface> def { };
-      util::ref<const ipr::Linkage> langlinkage { };
+      util::ref<const ipr::Language_linkage> lang_linkage { };
 
       // The overload set that contains this master declaration.  It
       // shall be set at the time the node for the master declaration
@@ -1410,7 +1410,7 @@ namespace ipr::impl {
       using Base = basic_decl_data<ipr::Template>;
       // The declaration that is considered to be the definition.
       Optional<ipr::Template> def { };
-      util::ref<const ipr::Linkage> langlinkage { };
+      util::ref<const ipr::Language_linkage> lang_linkage { };
       const ipr::Template* primary;
       const ipr::Region* home;
 
@@ -1489,9 +1489,9 @@ namespace ipr::impl {
 
       Decl() : decl_data{ nullptr } { }
 
-      const ipr::Linkage& linkage() const final
+      const ipr::Language_linkage& language_linkage() const final
       {
-         return util::check(decl_data.master_data)->langlinkage.get();
+         return util::check(decl_data.master_data)->lang_linkage.get();
       }
 
       const ipr::Region& home_region() const final {
@@ -2225,9 +2225,9 @@ namespace ipr::impl {
    // as setting their types (as expressions) and their names.
 
    struct type_factory {
-      const ipr::Transfer& get_transfer_from_linkage(const ipr::Linkage&);
+      const ipr::Transfer& get_transfer_from_linkage(const ipr::Language_linkage&);
       const ipr::Transfer& get_transfer_from_convention(const ipr::Calling_convention&);
-      const ipr::Transfer& get_transfer(const ipr::Linkage&, const ipr::Calling_convention&);
+      const ipr::Transfer& get_transfer(const ipr::Language_linkage&, const ipr::Calling_convention&);
 
       // Build an IPR node for an expression that denotes a type.
       // The transfer protocol, if not specified, is assumed to be C++.
@@ -2536,8 +2536,8 @@ namespace ipr::impl {
 
    struct expr_factory : name_factory {
       // Returns an IPR node a language linkage.
-      const ipr::Linkage& get_linkage(util::word_view);
-      const ipr::Linkage& get_linkage(const ipr::String&);
+      const ipr::Language_linkage& get_linkage(util::word_view);
+      const ipr::Language_linkage& get_linkage(const ipr::String&);
 
       // Rerturn an IPR for a calling convention.
       const ipr::Calling_convention& get_calling_convention(util::word_view);
@@ -2662,7 +2662,7 @@ namespace ipr::impl {
       impl::Static_assert* make_static_assert_expr(const ipr::Expr&, Optional<ipr::String> = { });
 
    private:
-      util::rb_tree::container<ipr::Linkage> linkages;
+      util::rb_tree::container<ipr::Language_linkage> linkages;
       util::rb_tree::container<ipr::Calling_convention> conventions;
 
       util::rb_tree::container<impl::Literal> lits;
@@ -2830,8 +2830,8 @@ namespace ipr::impl {
       Lexicon();
       ~Lexicon();
 
-      const ipr::Linkage& cxx_linkage() const final;
-      const ipr::Linkage& c_linkage() const final;
+      const ipr::Language_linkage& cxx_linkage() const final;
+      const ipr::Language_linkage& c_linkage() const final;
 
       ipr::Specifiers export_specifier() const final;
       ipr::Specifiers static_specifier() const final;

--- a/include/ipr/interface
+++ b/include/ipr/interface
@@ -156,7 +156,7 @@ namespace ipr {
       const Logogram& conv;
    };
 
-                                // -- Linkage --
+                                // -- Language_linkage --
    // An object of this type represents language linkage, e.g., "C" in `extern "C"'.
    // The ISO standard mandates at least two language linkages: "C" and
    // "C++".  If those were the only language linkages used in practice,
@@ -166,11 +166,11 @@ namespace ipr {
    // is adopted in the form of a logogram.  From ISO C++ point of view, language 
    // linkage applies only to function names, variable names, and function types.  
    // Furthermore, a language linkage applied to a function type is a calling convention.
-   struct Linkage {
-      explicit constexpr Linkage(const Logogram& l) : lang{l} { }
+   struct Language_linkage {
+      explicit constexpr Language_linkage(const Logogram& l) : lang{l} { }
       const Logogram& language() const { return lang; }
-      bool operator==(const Linkage& x) const { return lang == x.lang; }
-      bool operator!=(const Linkage&) const = default;
+      bool operator==(const Language_linkage& x) const { return lang == x.lang; }
+      bool operator!=(const Language_linkage&) const = default;
    private:
       const Logogram& lang;
    };
@@ -179,12 +179,12 @@ namespace ipr {
    // A summary of characteristics of data or control tranfer.  Both language linkage and 
    // calling convention affect how data are transferred to subroutines in function calls.
    // Furthermore, language linkage also affects linking across translation units.
-   struct Transfer : Basic_binary<const Linkage&, const Calling_convention&> {
-      const Linkage& linkage() const { return first(); }
+   struct Transfer : Basic_binary<const Language_linkage&, const Calling_convention&> {
+      const Language_linkage& language_linkage() const { return first(); }
       const Calling_convention& convention() const { return second(); }
       bool operator==(const Transfer& t) const
       {
-         return linkage() == t.linkage() and convention() == t.convention();
+         return language_linkage() == t.language_linkage() and convention() == t.convention();
       }
       bool operator!=(const Transfer&) const = default;
    };
@@ -568,7 +568,6 @@ namespace ipr {
    struct Type : Expr {
       virtual const Name& name() const = 0;
       virtual const Transfer& transfer() const = 0;
-      const Linkage& linkage() const { return transfer().linkage(); }
    protected:
       constexpr Type(Category_code c) : Expr{ c } { }
    };
@@ -1776,7 +1775,7 @@ namespace ipr {
    //     (b) a non-template declaration.
    struct Decl : Stmt {
       virtual Specifiers specifiers() const = 0;
-      virtual const Linkage& linkage() const = 0;
+      virtual const Language_linkage& language_linkage() const = 0;
 
       virtual const Name& name() const = 0;
 
@@ -1994,8 +1993,8 @@ namespace ipr {
                                                                //             and as default value for case in labeled statements.
       virtual const Symbol& delete_value() const = 0;          // "delete" - as initializer in deleted function definitions.
 
-      virtual const Linkage& cxx_linkage() const = 0;          // constant for 'extern "C++"'
-      virtual const Linkage& c_linkage() const = 0;            // constant for 'extern "C"'
+      virtual const Language_linkage& cxx_linkage() const = 0;          // constant for 'extern "C++"'
+      virtual const Language_linkage& c_linkage() const = 0;            // constant for 'extern "C"'
 
       virtual Specifiers export_specifier() const = 0;         // `export` specifier.
       virtual Specifiers static_specifier() const = 0;         // `static` standard specifier.

--- a/src/impl.cxx
+++ b/src/impl.cxx
@@ -151,11 +151,11 @@ namespace ipr::impl {
         constexpr auto& internal_string(const char8_t* p) { return known_word(p).operand(); }
 
         // Known language linkages to all C++ implementations.
-        constexpr Linkage c_link { known_word(u8"C") };
-        constexpr Linkage cxx_link { known_word(u8"C++") };
+        constexpr Language_linkage c_link { known_word(u8"C") };
+        constexpr Language_linkage cxx_link { known_word(u8"C++") };
     }
 
-    const ipr::Linkage& c_linkage() { return impl::c_link; }
+    const ipr::Language_linkage& c_linkage() { return impl::c_link; }
 }
 
 // -- Standard basic specifiers and qualifiers
@@ -200,7 +200,7 @@ namespace ipr::impl {
 namespace ipr::impl {
    namespace {
       struct Natural_transfer : ipr::Transfer {
-         const ipr::Linkage& first() const final { return impl::cxx_link; }
+         const ipr::Language_linkage& first() const final { return impl::cxx_link; }
          const ipr::Calling_convention& second() const final { return impl::natural_cc; }
       };
 
@@ -214,7 +214,7 @@ namespace ipr::impl {
 namespace ipr::impl {
    const ipr::Calling_convention& Transfer_from_linkage::second() const { return impl::natural_cc; }
 
-   const ipr::Linkage& Transfer_from_cc::first() const { return impl::cxx_link; }
+   const ipr::Language_linkage& Transfer_from_cc::first() const { return impl::cxx_link; }
 }
 
 namespace ipr::impl {
@@ -1009,7 +1009,7 @@ namespace ipr::impl {
 
       inline int compare(const ipr::Transfer& x, const ipr::Transfer& y)
       {
-         if (auto cmp = impl::compare(x.linkage(), y.linkage()))
+         if (auto cmp = impl::compare(x.language_linkage(), y.language_linkage()))
             return cmp;
          return impl::compare(x.convention(), y.convention());
       }
@@ -1137,9 +1137,9 @@ namespace ipr::impl {
       };
       // <<<< Yuriy Solodkyy: 2008/07/10
 
-      const ipr::Transfer& type_factory::get_transfer_from_linkage(const ipr::Linkage& l)
+      const ipr::Transfer& type_factory::get_transfer_from_linkage(const ipr::Language_linkage& l)
       {
-         constexpr auto cmp = [](auto& x, auto& y) { return impl::compare(x.linkage(), y); };
+         constexpr auto cmp = [](auto& x, auto& y) { return impl::compare(x.language_linkage(), y); };
          return *xfer_links.insert(l, cmp);
       }
 
@@ -1149,7 +1149,7 @@ namespace ipr::impl {
          return *xfer_ccs.insert(c, cmp);
       }
 
-      const ipr::Transfer& type_factory::get_transfer(const ipr::Linkage& l, const ipr::Calling_convention& c)
+      const ipr::Transfer& type_factory::get_transfer(const ipr::Language_linkage& l, const ipr::Calling_convention& c)
       {
          if (l == impl::cxx_link)
             return get_transfer_from_convention(c);
@@ -1726,7 +1726,7 @@ namespace ipr::impl {
       // ------------------------
 
       // -- Language linkage
-      const ipr::Linkage& expr_factory::get_linkage(util::word_view w)
+      const ipr::Language_linkage& expr_factory::get_linkage(util::word_view w)
       {
          if (w == u8"C")
             return impl::c_link;
@@ -1735,7 +1735,7 @@ namespace ipr::impl {
          return get_linkage(get_string(w));
       }
 
-      const ipr::Linkage& expr_factory::get_linkage(const ipr::String& lang)
+      const ipr::Language_linkage& expr_factory::get_linkage(const ipr::String& lang)
       {
          if (physically_same(lang, internal_string(u8"C")))
             return impl::c_link;
@@ -2348,8 +2348,8 @@ namespace ipr::impl {
 
       // -- impl::Lexicon --
 
-      const ipr::Linkage& Lexicon::c_linkage() const { return impl::c_link; }
-      const ipr::Linkage& Lexicon::cxx_linkage() const { return impl::cxx_link; }
+      const ipr::Language_linkage& Lexicon::c_linkage() const { return impl::c_link; }
+      const ipr::Language_linkage& Lexicon::cxx_linkage() const { return impl::cxx_link; }
 
       namespace {
          struct UnknownLogogramError { 


### PR DESCRIPTION
With modules in C++20, "name linkage" is picking up more steam in conversations and we need to make the terms a bit more explicit.