### PR TITLE
Add line range to `input::SourceFile`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,8 @@ target_compile_definitions(${PROJECT_NAME}
 	   >
 )
 
+set_property(SOURCE ${PROJECT_SOURCE_DIR}/src/input.cxx APPEND PROPERTY COMPILE_DEFINITIONS NDEBUG)
+
 install(
    TARGETS ipr
    LIBRARY DESTINATION lib

--- a/include/ipr/input
+++ b/include/ipr/input
@@ -37,15 +37,72 @@ namespace ipr::input {
         ErrorCode error_code;
     };
 
+    // A morsel is a pierce of source text designated by an offset from
+    // from the start of the source and its extent in bytes. 
+    struct Morsel {
+        std::uint64_t offset : 48;      // offset from the beginning of containing text
+        std::uint64_t length : 16;      // number of bytes from the start
+    };
+
     // Input source file mapped to memory as sequence of raw bytes.
+    // UTF-8 is assumed as the encoding of the text.
     struct SourceFile {
-        using View = std::span<const std::byte>;
+        using View = std::span<const char8_t>;
+        struct LineRange;
         
         explicit SourceFile(const SystemPath&);
         SourceFile(SourceFile&&) noexcept;
         ~SourceFile();
-        View bytes() const { return view; }
+        LineRange lines() const noexcept;
+        View contents() const noexcept { return view; }
+        View contents(Morsel m) const noexcept;
     private:
         View view;
     };
+
+    // A source file line range is an input_range of morsels, each representing a physical 
+    // line in the input source file.
+    struct SourceFile::LineRange {
+        using difference_type = std::ptrdiff_t;
+        struct iterator;
+        explicit LineRange(const SourceFile&);
+        iterator begin() noexcept;
+        iterator end() noexcept;
+    private:
+        const SourceFile* src;
+        const char8_t* ptr;
+        Morsel cache { };
+        void next_line() noexcept;
+    };
+
+    // An iterator for input source file line range.
+    struct SourceFile::LineRange::iterator {
+        using difference_type = std::ptrdiff_t;
+        using value_type = Morsel;
+        using iterator_category = std::input_iterator_tag;
+
+        explicit iterator(LineRange* r) noexcept : range{r} { }
+        Morsel operator*() const noexcept;
+        iterator& operator++() noexcept;
+        void operator++(int) noexcept { ++(*this); }
+        bool operator==(const iterator& that) const noexcept { return range == that.range; }
+        bool operator!=(const iterator& that) const noexcept = default;
+    private:
+        LineRange* range;
+    };
+
+    inline SourceFile::LineRange SourceFile::lines() const noexcept
+    {
+        return LineRange{*this};
+    }
+
+    inline SourceFile::LineRange::iterator SourceFile::LineRange::begin() noexcept
+    {
+        return iterator{this};
+    }
+
+    inline SourceFile::LineRange::iterator SourceFile::LineRange::end() noexcept
+    {
+        return iterator{nullptr};
+    }
 }

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(${TEST_BINARY}
    warehouse.cxx
    phased-eval.cxx
    specifiers.cxx
+   lines.cxx
 )
 
 target_link_libraries(${TEST_BINARY}

--- a/tests/unit-tests/lines.cxx
+++ b/tests/unit-tests/lines.cxx
@@ -1,0 +1,26 @@
+#include "doctest/doctest.h"
+#ifdef _WIN32
+#  include <windows.h>
+#  define WIDEN_(S) L ## S
+#  define WIDEN(S) WIDEN_(S)
+#else
+#  define WIDEN(S) S
+#endif
+
+#include <iostream>
+#include "ipr/input"
+
+TEST_CASE("echo input file") {
+    ipr::input::SystemPath path = WIDEN(__FILE__);
+    ipr::input::SourceFile file{path};
+    auto n = 1;
+    std::cout << "file.size: " << file.contents().size() << std::endl;
+    for (auto line : file.lines())
+    {
+        std::cout << '[' << n << ']'
+                << " -> {offset: " << line.offset
+                << ", length: " << line.length << "}\n";
+        ++n;
+    }
+    CHECK(n == 27); // Adjust this number based on the actual number of lines in the file
+}


### PR DESCRIPTION
To iterate (one-pass) over physical lines from an input source file, assumed to have UTF-8 encoded contents.