### PR TITLE
`SourceFile::lines` shall be numbered

### DIFF
--- a/include/ipr/input
+++ b/include/ipr/input
@@ -44,6 +44,12 @@ namespace ipr::input {
         std::uint64_t length : 16;      // number of bytes from the start
     };
 
+    // Descriptor for a physical line from an input source file.
+    struct PhysicalLine {
+        Morsel morsel { };
+        std::uint32_t number { };
+    };
+
     // Input source file mapped to memory as sequence of raw bytes.
     // UTF-8 is assumed as the encoding of the text.
     struct SourceFile {
@@ -71,7 +77,7 @@ namespace ipr::input {
     private:
         const SourceFile* src;
         const char8_t* ptr;
-        Morsel cache { };
+        PhysicalLine cache { };
         void next_line() noexcept;
     };
 
@@ -82,7 +88,7 @@ namespace ipr::input {
         using iterator_category = std::input_iterator_tag;
 
         explicit iterator(LineRange* r) noexcept : range{r} { }
-        Morsel operator*() const noexcept;
+        PhysicalLine operator*() const noexcept;
         iterator& operator++() noexcept;
         void operator++(int) noexcept { ++(*this); }
         bool operator==(const iterator& that) const noexcept { return range == that.range; }

--- a/src/input.cxx
+++ b/src/input.cxx
@@ -118,8 +118,9 @@ namespace ipr::input {
         while (idx < limit and ptr[idx] != carriage_return and ptr[idx] != line_feed)
             ++idx;
         assert(idx < max_extent);
-        cache.offset = offset;
-        cache.length = idx;
+        cache.morsel.offset = offset;
+        cache.morsel.length = idx;
+        ++cache.number;
 
         // Skip the new line marker.
         if (idx < limit)
@@ -139,7 +140,7 @@ namespace ipr::input {
         next_line();
     }
 
-    Morsel SourceFile::LineRange::iterator::operator*() const noexcept
+    PhysicalLine SourceFile::LineRange::iterator::operator*() const noexcept
     {
         assert(range != nullptr);
         return range->cache;

--- a/tests/unit-tests/lines.cxx
+++ b/tests/unit-tests/lines.cxx
@@ -13,14 +13,14 @@
 TEST_CASE("echo input file") {
     ipr::input::SystemPath path = WIDEN(__FILE__);
     ipr::input::SourceFile file{path};
-    auto n = 1;
     std::cout << "file.size: " << file.contents().size() << std::endl;
+    std::uint32_t last_line_number = 0;
     for (auto line : file.lines())
     {
-        std::cout << '[' << n << ']'
-                << " -> {offset: " << line.offset
-                << ", length: " << line.length << "}\n";
-        ++n;
+        std::cout << '[' << line.number << ']'
+                << " -> {offset: " << line.morsel.offset
+                << ", length: " << line.morsel.length << "}\n";
+        last_line_number = line.number;
     }
-    CHECK(n == 27); // Adjust this number based on the actual number of lines in the file
+    CHECK(last_line_number == 26); // Adjust this number based on the actual number of lines in the file
 }


### PR DESCRIPTION
The member function `ipr::input::SourcFile::lines()` should return physical line numbers in addition to the morsel descriptors.